### PR TITLE
Improve iOS terminal IME and paste compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 - Run the first nine visible command-menu actions with `Cmd+1` through `Cmd+9`,
   with matching shortcut hints beside each action.
 
+### Fixed
+
+- Recover iOS terminal input committed by third-party IMEs during keyup or input
+  events when xterm does not forward the helper-textarea mutation.
+- Route complete native iOS paste mutations through the terminal paste API when
+  the ClipboardEvent text is missing or truncated.
+
 ## 0.3.3 - 2026-08-13
 
 ### Added

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -40,7 +40,11 @@ import {
   type TerminalFileLinkCandidate,
   TerminalFileResolutionCache,
 } from "../terminalFileLinks";
-import { terminalPasteRequest } from "../terminalPaste";
+import {
+	terminalPasteInputText,
+	terminalPasteRequest,
+	type TerminalPasteTextareaSnapshot,
+} from "../terminalPaste";
 import {
   createTerminalClipboardProvider,
   decodeTerminalClipboard,
@@ -53,6 +57,7 @@ import {
   terminalImeEventTime,
   terminalImeFallbackText,
   TerminalImeFallbackTracker,
+	TerminalImeTextareaFallbackTracker,
 } from "../terminalIme";
 import { terminalPageScroll, terminalWheelScroll } from "../terminalScroll";
 import {
@@ -519,7 +524,9 @@ export function TerminalView({
     }
     try {
       fit.fit();
-    } catch {}
+		} catch {
+			// A hidden or detaching terminal can reject a transient fit.
+		}
     return { cols: term.cols, rows: term.rows };
   }, [container]);
   const relayViewportFor = useCallback(
@@ -751,7 +758,9 @@ export function TerminalView({
     }
     try {
       fit.fit();
-    } catch {}
+		} catch {
+			// ResizeObserver will retry after the terminal becomes measurable.
+		}
     termRef.current = term;
     fitRef.current = fit;
     const linkProvider = registerTerminalLinkProvider(
@@ -761,11 +770,32 @@ export function TerminalView({
     );
 
     const imeFallback = new TerminalImeFallbackTracker();
+		const imeTextareaFallback = new TerminalImeTextareaFallbackTracker();
+		const readTerminalTextareaSnapshot = (): TerminalPasteTextareaSnapshot => {
+			const textarea = term.textarea;
+			const value = textarea?.value ?? "";
+			const selectionStart = textarea?.selectionStart ?? value.length;
+			return {
+				value,
+				selectionStart,
+				selectionEnd: textarea?.selectionEnd ?? selectionStart,
+			};
+		};
+		let imeTextareaTimer: number | null = null;
+		let terminalCompositionActive = false;
+		let compositionSettleTimer: number | null = null;
+		let nativePasteFallbackTimer: number | null = null;
+		let pasteTextareaClearTimer: number | null = null;
+		let pasteTextareaBeforeInput: TerminalPasteTextareaSnapshot | null = null;
+		let pastePaneIdBeforeInput: string | null = null;
+		let lastTerminalTextareaSnapshot = readTerminalTextareaSnapshot();
     term.onData((data) => {
+			const unsuppressedData = imeTextareaFallback.recordXtermData(data);
+			if (!unsuppressedData) return;
       const dataAt = performance.now();
-      const shouldSend = imeFallback.recordXtermData(data, dataAt);
+			const shouldSend = imeFallback.recordXtermData(unsuppressedData, dataAt);
       if (!shouldSend) return;
-      const bytes = new TextEncoder().encode(data);
+			const bytes = new TextEncoder().encode(unsuppressedData);
       sendBytes(bytes, desiredTerminalRef.current).catch(() => {});
     });
 
@@ -828,11 +858,13 @@ export function TerminalView({
       const bytes = new TextEncoder().encode(text);
       sendBytes(bytes, desiredTerminalRef.current).catch(() => {});
     };
-    const pasteText = async (text: string) => {
+		const pasteText = async (
+			text: string,
+			destinationPaneId: string | null = paneIdRef.current ?? null,
+		) => {
       if (!text) return;
-      const activePaneId = paneIdRef.current;
-      if (activePaneId) {
-        const request = terminalPasteRequest(activePaneId, text);
+			if (destinationPaneId) {
+				const request = terminalPasteRequest(destinationPaneId, text);
         await bridge.call(request.method, request.params);
         return;
       }
@@ -843,7 +875,7 @@ export function TerminalView({
       }
       sendText(text);
     };
-    const sendMissingImePunctuation = (
+		const sendMissingImeText = (
       text: string,
       eventTime: number,
       observedAt: number,
@@ -851,7 +883,40 @@ export function TerminalView({
       const shouldSend = imeFallback.recordInput(text, eventTime, observedAt);
       if (shouldSend) sendText(text);
     };
-    const pasteImage = async (blob: Blob) => {
+		const cancelImeTextareaFallback = () => {
+			if (imeTextareaTimer !== null) {
+				window.clearTimeout(imeTextareaTimer);
+				imeTextareaTimer = null;
+			}
+			imeTextareaFallback.cancel();
+		};
+		const cancelCompositionSettle = () => {
+			if (compositionSettleTimer === null) return;
+			window.clearTimeout(compositionSettleTimer);
+			compositionSettleTimer = null;
+		};
+		const cancelNativePasteFallback = () => {
+			if (nativePasteFallbackTimer === null) return;
+			window.clearTimeout(nativePasteFallbackTimer);
+			nativePasteFallbackTimer = null;
+		};
+		const cancelPasteTextareaClear = () => {
+			if (pasteTextareaClearTimer === null) return;
+			window.clearTimeout(pasteTextareaClearTimer);
+			pasteTextareaClearTimer = null;
+		};
+		let pasteOperationCount = 0;
+		const runPasteOperation = async <T,>(operation: () => Promise<T>) => {
+			pasteOperationCount += 1;
+			setPasteLoading(true);
+			try {
+				return await operation();
+			} finally {
+				pasteOperationCount -= 1;
+				if (pasteOperationCount === 0) setPasteLoading(false);
+			}
+		};
+		const pasteImage = async (blob: Blob, destinationPaneId: string | null) => {
       const file =
         blob instanceof File
           ? blob
@@ -859,14 +924,15 @@ export function TerminalView({
               type: blob.type || "image/png",
             });
       const path = await uploadImage(file);
-      sendText(path);
+			await pasteText(path, destinationPaneId);
     };
     let clipboardPasteInFlight = false;
     const pasteFromBrowserClipboard = async () => {
       if (clipboardPasteInFlight) return;
       clipboardPasteInFlight = true;
-      setPasteLoading(true);
+			const destinationPaneId = paneIdRef.current ?? null;
       try {
+				await runPasteOperation(async () => {
         if (!navigator.clipboard) {
           throw new Error("browser clipboard API is unavailable");
         }
@@ -886,7 +952,7 @@ export function TerminalView({
                 CLIPBOARD_READ_TIMEOUT_MS,
                 "读取剪贴板图片超时",
               );
-              await pasteImage(blob);
+								await pasteImage(blob, destinationPaneId);
               return;
             }
           }
@@ -902,7 +968,7 @@ export function TerminalView({
                 CLIPBOARD_READ_TIMEOUT_MS,
                 "读取剪贴板文本超时",
               );
-              await pasteText(text);
+								await pasteText(text, destinationPaneId);
               return;
             }
           }
@@ -913,16 +979,20 @@ export function TerminalView({
           CLIPBOARD_READ_TIMEOUT_MS,
           "读取剪贴板文本超时",
         );
-        await pasteText(text);
+					await pasteText(text, destinationPaneId);
+				});
       } finally {
         clipboardPasteInFlight = false;
-        setPasteLoading(false);
       }
     };
     const applePlatform = isApplePlatform();
+		const appleTouchPlatform = applePlatform && navigator.maxTouchPoints > 0;
     const shouldHandleCtrlVPaste = !applePlatform;
 
     term.attachCustomKeyEventHandler((e) => {
+			if (e.type === "keydown" && e.keyCode !== 229) {
+				imeTextareaFallback.cancelPending();
+			}
       const modifiedEnter = modifiedEnterSequence(e);
       if (modifiedEnter) {
         e.preventDefault();
@@ -985,8 +1055,91 @@ export function TerminalView({
       return true;
     });
 
+    const flushTextareaImeFallback = (
+      event: Event,
+      final = false,
+    ): "pending" | "unhandled" | "handled" => {
+      const result = imeTextareaFallback.flush(
+        term.textarea?.value ?? "",
+        final,
+      );
+      if (result.status === "handled" && result.text) {
+        const observedAt = performance.now();
+        const eventAt = terminalImeEventTime(event, observedAt);
+        sendMissingImeText(result.text, eventAt, observedAt);
+      }
+      return result.status;
+    };
+    const scheduleImeTextareaFinal = (event: Event) => {
+      if (imeTextareaTimer !== null) window.clearTimeout(imeTextareaTimer);
+      imeTextareaTimer = window.setTimeout(() => {
+        imeTextareaTimer = null;
+        flushTextareaImeFallback(event, true);
+        imeTextareaFallback.complete();
+      }, 0);
+    };
+    const onTerminalKeyDown = (event: KeyboardEvent) => {
+      lastTerminalTextareaSnapshot = readTerminalTextareaSnapshot();
+      if (
+        !applePlatform ||
+        event.keyCode !== 229 ||
+        terminalCompositionActive
+      ) {
+        return;
+      }
+      // Do not trust event.isComposing here. Third-party iOS keyboards can set
+      // it without dispatching a real composition lifecycle.
+      imeTextareaFallback.begin(lastTerminalTextareaSnapshot.value);
+    };
+    const onTerminalKeyUp = (event: KeyboardEvent) => {
+      if (!applePlatform || event.keyCode !== 229) return;
+
+      // Read synchronously: some third-party iOS keyboards expose the committed
+      // textarea value only during keyup. If it is not visible yet, keep the
+      // cycle pending for one final task, matching xterm's upstream fallback.
+      flushTextareaImeFallback(event);
+      scheduleImeTextareaFinal(event);
+    };
+    const onTerminalCompositionStart = () => {
+      cancelCompositionSettle();
+      terminalCompositionActive = true;
+      cancelNativePasteFallback();
+      cancelPasteTextareaClear();
+      pasteTextareaBeforeInput = null;
+      pastePaneIdBeforeInput = null;
+      lastTerminalTextareaSnapshot = readTerminalTextareaSnapshot();
+      cancelImeTextareaFallback();
+    };
+    const onTerminalCompositionEnd = () => {
+      lastTerminalTextareaSnapshot = readTerminalTextareaSnapshot();
+      cancelImeTextareaFallback();
+      cancelCompositionSettle();
+      // This listener runs after xterm's compositionend listener. Keep fallback
+      // disabled until xterm's queued composition finalization has completed.
+      compositionSettleTimer = window.setTimeout(() => {
+        compositionSettleTimer = null;
+        terminalCompositionActive = false;
+      }, 0);
+    };
+    const onTerminalBlur = () => {
+      cancelCompositionSettle();
+      terminalCompositionActive = false;
+      cancelNativePasteFallback();
+      cancelPasteTextareaClear();
+      pasteTextareaBeforeInput = null;
+      pastePaneIdBeforeInput = null;
+      lastTerminalTextareaSnapshot = readTerminalTextareaSnapshot();
+      cancelImeTextareaFallback();
+    };
     const onTerminalBeforeInput = (e: Event) => {
       const input = e as InputEvent;
+      if (input.inputType === "insertFromPaste" && !input.isComposing) {
+        if (!pasteTextareaBeforeInput) {
+          pasteTextareaBeforeInput = readTerminalTextareaSnapshot();
+          pastePaneIdBeforeInput = paneIdRef.current ?? null;
+        }
+        return;
+      }
       const fallbackText = terminalImeFallbackText(input);
       if (!fallbackText || !input.cancelable) return;
       const observedAt = performance.now();
@@ -997,16 +1150,108 @@ export function TerminalView({
       // relying on the bridge round trip before the next key is processed.
       input.preventDefault();
       input.stopPropagation();
-      sendMissingImePunctuation(fallbackText, eventAt, observedAt);
+      sendMissingImeText(fallbackText, eventAt, observedAt);
     };
     const onTerminalTextInput = (e: Event) => {
       const input = e as InputEvent;
+      const textareaSnapshot = readTerminalTextareaSnapshot();
+      const hadPasteSnapshot = pasteTextareaBeforeInput !== null;
+      const beforePaste =
+        pasteTextareaBeforeInput ?? lastTerminalTextareaSnapshot;
+      const destinationPaneId = hadPasteSnapshot
+        ? pastePaneIdBeforeInput
+        : (paneIdRef.current ?? null);
+      const pastedText = terminalPasteInputText(
+        input,
+        beforePaste,
+        textareaSnapshot.value,
+      );
+      if (pastedText !== null) {
+        cancelNativePasteFallback();
+        cancelPasteTextareaClear();
+        cancelImeTextareaFallback();
+        pasteTextareaBeforeInput = null;
+        pastePaneIdBeforeInput = null;
+        const textarea = term.textarea;
+        if (textarea) {
+          // Restore xterm's keydown baseline until its queued 229 timer runs.
+          // Clearing immediately makes xterm emit a spurious DEL.
+          textarea.value = beforePaste.value;
+          textarea.setSelectionRange(
+            beforePaste.selectionStart,
+            beforePaste.selectionEnd,
+          );
+          lastTerminalTextareaSnapshot = beforePaste;
+          pasteTextareaClearTimer = window.setTimeout(() => {
+            pasteTextareaClearTimer = null;
+            if (
+              term.textarea === textarea &&
+              textarea.value === beforePaste.value
+            ) {
+              textarea.value = "";
+              lastTerminalTextareaSnapshot = {
+                value: "",
+                selectionStart: 0,
+                selectionEnd: 0,
+              };
+            }
+          }, 0);
+        }
+        input.stopPropagation();
+        void runPasteOperation(() =>
+          pasteText(pastedText, destinationPaneId),
+        ).catch((error) => {
+          setUploadError(`文本粘贴失败：${(error as Error).message}`);
+        });
+        return;
+      }
+
+      lastTerminalTextareaSnapshot = textareaSnapshot;
+      if (input.inputType === "insertFromPaste") {
+        input.stopPropagation();
+        if (nativePasteFallbackTimer === null) {
+          pasteTextareaBeforeInput = null;
+          pastePaneIdBeforeInput = null;
+        }
+        return;
+      }
+      cancelNativePasteFallback();
+      cancelPasteTextareaClear();
+      pasteTextareaBeforeInput = null;
+      pastePaneIdBeforeInput = null;
+
+      if (
+        applePlatform &&
+        !terminalCompositionActive &&
+        input.inputType === "insertText" &&
+        imeTextareaFallback.hasPending()
+      ) {
+        const flushStatus = flushTextareaImeFallback(input);
+        scheduleImeTextareaFinal(input);
+        if (flushStatus === "handled") return;
+      }
+
       const fallbackText = terminalImeFallbackText(input);
       if (!fallbackText) return;
       const observedAt = performance.now();
       const eventAt = terminalImeEventTime(input, observedAt);
-      sendMissingImePunctuation(fallbackText, eventAt, observedAt);
+      sendMissingImeText(fallbackText, eventAt, observedAt);
     };
+    term.textarea?.addEventListener("keydown", onTerminalKeyDown, {
+      capture: true,
+    });
+    term.textarea?.addEventListener("keyup", onTerminalKeyUp, {
+      capture: true,
+    });
+    term.textarea?.addEventListener(
+      "compositionstart",
+      onTerminalCompositionStart,
+      { capture: true },
+    );
+    term.textarea?.addEventListener("compositionend", onTerminalCompositionEnd);
+    term.textarea?.addEventListener("blur", onTerminalBlur, {
+      capture: true,
+    });
     term.textarea?.addEventListener("beforeinput", onTerminalBeforeInput, {
       capture: true,
     });
@@ -1021,7 +1266,6 @@ export function TerminalView({
         .find((it) => it.type.startsWith("image/"))
         ?.getAsFile();
       const text = img ? "" : (e.clipboardData?.getData("text/plain") ?? "");
-      if (!img && !text) return;
       const active = document.activeElement;
       const target = e.target;
       const isTerminalPaste =
@@ -1029,18 +1273,53 @@ export function TerminalView({
         container.contains(target as Node | null) ||
         (active ? container.contains(active) : false);
       if (!isTerminalPaste && isEditableElement(target)) return;
+      const destinationPaneId = paneIdRef.current ?? null;
+      if (!img && appleTouchPlatform && isTerminalPaste) {
+        cancelImeTextareaFallback();
+        cancelNativePasteFallback();
+        cancelPasteTextareaClear();
+        const beforePaste = readTerminalTextareaSnapshot();
+        pasteTextareaBeforeInput = beforePaste;
+        pastePaneIdBeforeInput = destinationPaneId;
+        lastTerminalTextareaSnapshot = beforePaste;
+
+        // Keep WebKit's native insertion so insertFromPaste can expose the full
+        // text, but stop xterm's target listener from consuming truncated
+        // ClipboardEvent data and clearing the textarea first.
+        e.stopPropagation();
+        if (text) {
+          nativePasteFallbackTimer = window.setTimeout(() => {
+            nativePasteFallbackTimer = null;
+            if (pasteTextareaBeforeInput !== beforePaste) return;
+            pasteTextareaBeforeInput = null;
+            pastePaneIdBeforeInput = null;
+            void runPasteOperation(() =>
+              pasteText(text, destinationPaneId),
+            ).catch((error) => {
+              setUploadError(`文本粘贴失败：${(error as Error).message}`);
+            });
+          }, 0);
+        }
+        return;
+      }
+      if (!img && !text) return;
+      cancelImeTextareaFallback();
+      cancelNativePasteFallback();
+      cancelPasteTextareaClear();
+      pasteTextareaBeforeInput = null;
+      pastePaneIdBeforeInput = null;
       e.preventDefault();
       e.stopPropagation();
-      setPasteLoading(true);
       try {
-        if (img) await pasteImage(img);
-        else await pasteText(text);
+        await runPasteOperation(() =>
+          img
+            ? pasteImage(img, destinationPaneId)
+            : pasteText(text, destinationPaneId),
+        );
       } catch (err) {
         setUploadError(
           `${img ? "图片上传" : "文本粘贴"}失败：${(err as Error).message}`,
         );
-      } finally {
-        setPasteLoading(false);
       }
     };
     container.addEventListener("paste", onPaste);
@@ -1159,6 +1438,28 @@ export function TerminalView({
       resizeSync.dispose();
       resizeSyncRef.current = null;
       attachWatchdogRef.current?.cancel();
+			cancelImeTextareaFallback();
+			cancelCompositionSettle();
+			cancelNativePasteFallback();
+			cancelPasteTextareaClear();
+			term.textarea?.removeEventListener("keydown", onTerminalKeyDown, {
+				capture: true,
+			});
+			term.textarea?.removeEventListener("keyup", onTerminalKeyUp, {
+				capture: true,
+			});
+			term.textarea?.removeEventListener(
+				"compositionstart",
+				onTerminalCompositionStart,
+				{ capture: true },
+			);
+			term.textarea?.removeEventListener(
+				"compositionend",
+				onTerminalCompositionEnd,
+			);
+			term.textarea?.removeEventListener("blur", onTerminalBlur, {
+				capture: true,
+			});
       term.textarea?.removeEventListener("input", onTerminalTextInput, {
         capture: true,
       });

--- a/web/src/terminalIme.test.ts
+++ b/web/src/terminalIme.test.ts
@@ -3,6 +3,8 @@ import {
   terminalImeEventTime,
   terminalImeFallbackText,
   TerminalImeFallbackTracker,
+	TerminalImeTextareaFallbackTracker,
+	terminalImeTextareaDelta,
 } from "./terminalIme";
 
 function inputEvent(
@@ -57,6 +59,125 @@ describe("terminal IME punctuation detection", () => {
   });
 });
 
+describe("terminal IME textarea fallback", () => {
+	test("extracts append-only ASCII, Chinese, and emoji text", () => {
+		expect(terminalImeTextareaDelta("", "hello")).toBe("hello");
+		expect(terminalImeTextareaDelta("已有", "已有中文")).toBe("中文");
+		expect(terminalImeTextareaDelta("a", "a😀")).toBe("😀");
+	});
+
+	test("leaves replacement and deletion changes to xterm", () => {
+		expect(terminalImeTextareaDelta("same", "same")).toBeNull();
+		expect(terminalImeTextareaDelta("abc", "axc")).toBeNull();
+		expect(terminalImeTextareaDelta("abc", "ab")).toBeNull();
+	});
+
+	test("flushes a short-lived mutation synchronously", () => {
+		const tracker = new TerminalImeTextareaFallbackTracker();
+		tracker.begin("");
+		expect(tracker.flush("中文输入")).toEqual({
+			status: "handled",
+			text: "中文输入",
+		});
+		expect(tracker.hasPending()).toBe(false);
+	});
+
+	test("keeps an unchanged keyup pending for the timer fallback", () => {
+		const tracker = new TerminalImeTextareaFallbackTracker();
+		tracker.begin("");
+		expect(tracker.flush("")).toEqual({ status: "pending" });
+		expect(tracker.hasPending()).toBe(true);
+		expect(tracker.flush("稍后写入", true)).toEqual({
+			status: "handled",
+			text: "稍后写入",
+		});
+	});
+
+	test("distinguishes xterm-handled input from an unhandled cycle", () => {
+		const tracker = new TerminalImeTextareaFallbackTracker();
+		tracker.begin("hello");
+		expect(tracker.recordXtermData(" world")).toBe(" world");
+		expect(tracker.flush("hello world")).toEqual({
+			status: "handled",
+			text: null,
+		});
+		expect(tracker.flush("hello world", true)).toEqual({
+			status: "unhandled",
+		});
+	});
+
+	test("subtracts text xterm already emitted", () => {
+		const tracker = new TerminalImeTextareaFallbackTracker();
+		tracker.begin("hello");
+		expect(tracker.recordXtermData(" ")).toBe(" ");
+		expect(tracker.flush("hello world")).toEqual({
+			status: "handled",
+			text: "world",
+		});
+
+		tracker.complete();
+		tracker.begin("a");
+		expect(tracker.recordXtermData("😀b")).toBe("😀b");
+		expect(tracker.flush("a😀b")).toEqual({
+			status: "handled",
+			text: null,
+		});
+	});
+
+	test("suppresses partial or delayed xterm output after a synchronous flush", () => {
+		const tracker = new TerminalImeTextareaFallbackTracker();
+		tracker.begin("");
+		expect(tracker.flush("中文")).toEqual({
+			status: "handled",
+			text: "中文",
+		});
+		expect(tracker.recordXtermData("中")).toBeNull();
+		expect(tracker.recordXtermData("文")).toBeNull();
+
+		tracker.complete();
+		tracker.begin("");
+		expect(tracker.flush("abc")).toEqual({
+			status: "handled",
+			text: "abc",
+		});
+		expect(tracker.recordXtermData("abc-extra")).toBe("-extra");
+		tracker.complete();
+		expect(tracker.recordXtermData("abc")).toBe("abc");
+	});
+
+	test("cancels an abandoned cycle without clearing duplicate suppression", () => {
+		const tracker = new TerminalImeTextareaFallbackTracker();
+		tracker.begin("");
+		tracker.cancelPending();
+		expect(tracker.recordXtermData("a")).toBe("a");
+		expect(tracker.flush("abc", true)).toEqual({ status: "unhandled" });
+
+		tracker.begin("");
+		expect(tracker.flush("中文")).toEqual({
+			status: "handled",
+			text: "中文",
+		});
+		tracker.cancelPending();
+		expect(tracker.recordXtermData("中")).toBeNull();
+	});
+
+	test("keeps the earliest repeated baseline and supports cancel", () => {
+		const tracker = new TerminalImeTextareaFallbackTracker();
+		tracker.begin("");
+		tracker.begin("中");
+		expect(tracker.flush("中文")).toEqual({
+			status: "handled",
+			text: "中文",
+		});
+
+		tracker.begin("中文");
+		tracker.cancel();
+		expect(tracker.flush("中文输入", true)).toEqual({
+			status: "unhandled",
+		});
+	});
+});
+
 describe("terminal IME punctuation fallback tracking", () => {
   test("consumes xterm output emitted immediately before the input listener", () => {
     const tracker = new TerminalImeFallbackTracker();
@@ -101,7 +222,11 @@ describe("terminal IME punctuation fallback tracking", () => {
   test("preserves order when xterm drops or delays part of a rapid sequence", () => {
     const tracker = new TerminalImeFallbackTracker();
     const sent: string[] = [];
-    const input = (text: string, eventAt: number, mode: "before" | "after" | "missing") => {
+		const input = (
+			text: string,
+			eventAt: number,
+			mode: "before" | "after" | "missing",
+		) => {
       if (mode === "before" && tracker.recordXtermData(text, eventAt + 1)) {
         sent.push(text);
       }

--- a/web/src/terminalIme.ts
+++ b/web/src/terminalIme.ts
@@ -44,6 +44,99 @@ export function terminalImeFallbackText(input: ImeInputEvent): string | null {
 }
 
 /**
+ * Returns append-only text committed to xterm's helper textarea. Replacement
+ * and deletion remain under xterm's control because replaying them here could
+ * race its own keyCode 229 fallback and duplicate destructive input.
+ */
+export function terminalImeTextareaDelta(
+	before: string,
+	after: string,
+): string | null {
+	if (after === before || !after.startsWith(before)) return null;
+	return after.slice(before.length) || null;
+}
+
+/**
+ * Tracks one iOS keyCode 229 cycle and subtracts any prefix xterm already
+ * emitted. A synchronous flush catches short-lived keyup/input mutations; an
+ * unchanged cycle stays pending for one final timer fallback.
+ */
+export type TerminalImeTextareaFlushResult =
+	| { status: "pending" }
+	| { status: "unhandled" }
+	| { status: "handled"; text: string | null };
+
+export class TerminalImeTextareaFallbackTracker {
+	private pending: { textareaValue: string; xtermData: string } | null = null;
+	private suppressXtermData = "";
+
+	begin(textareaValue: string): void {
+		this.pending ??= { textareaValue, xtermData: "" };
+	}
+
+	recordXtermData(text: string): string | null {
+		if (this.pending) this.pending.xtermData += text;
+		if (!this.suppressXtermData) return text;
+
+		if (this.suppressXtermData.startsWith(text)) {
+			this.suppressXtermData = this.suppressXtermData.slice(text.length);
+			return null;
+		}
+		if (text.startsWith(this.suppressXtermData)) {
+			const unsuppressedText = text.slice(this.suppressXtermData.length);
+			this.suppressXtermData = "";
+			return unsuppressedText || null;
+		}
+
+		this.suppressXtermData = "";
+		return text;
+	}
+
+	flush(textareaValue: string, final = false): TerminalImeTextareaFlushResult {
+		const pending = this.pending;
+		if (!pending) return { status: "unhandled" };
+		const committedText = terminalImeTextareaDelta(
+			pending.textareaValue,
+			textareaValue,
+		);
+		if (!committedText) {
+			if (final || textareaValue !== pending.textareaValue) {
+				this.pending = null;
+				return { status: "unhandled" };
+			}
+			return { status: "pending" };
+		}
+
+		this.pending = null;
+		if (!committedText.startsWith(pending.xtermData)) {
+			return { status: "unhandled" };
+		}
+		this.suppressXtermData = committedText;
+		return {
+			status: "handled",
+			text: committedText.slice(pending.xtermData.length) || null,
+		};
+	}
+
+	hasPending(): boolean {
+		return this.pending !== null;
+	}
+
+	cancelPending(): void {
+		this.pending = null;
+	}
+
+	complete(): void {
+		this.pending = null;
+		this.suppressXtermData = "";
+	}
+
+	cancel(): void {
+		this.complete();
+	}
+}
+
+/**
  * DOM event timestamps share performance.now()'s clock in modern browsers.
  * Fall back to observation time for older Safari timestamps that used epoch
  * milliseconds, as those cannot be compared with xterm's performance time.

--- a/web/src/terminalPaste.test.ts
+++ b/web/src/terminalPaste.test.ts
@@ -1,10 +1,81 @@
 import { describe, expect, test } from "bun:test";
 import {
   prepareTerminalPasteText,
+	terminalPasteInputText,
   terminalPasteRequest,
+	type TerminalPasteTextareaSnapshot,
 } from "./terminalPaste";
 
+function snapshot(
+	value: string,
+	selectionStart = value.length,
+	selectionEnd = selectionStart,
+): TerminalPasteTextareaSnapshot {
+	return { value, selectionStart, selectionEnd };
+}
+
 describe("terminal paste", () => {
+	test("recovers full native paste text from xterm's helper textarea", () => {
+		const text = `${"中英文😀".repeat(300)}\nsecond line`;
+		expect(
+			terminalPasteInputText(
+				{ inputType: "insertFromPaste", isComposing: false },
+				snapshot(""),
+				text,
+			),
+		).toBe(text);
+		expect(terminalPasteRequest("p7", text).params.text).toBe(
+			text.replace("\n", "\r"),
+		);
+		expect(
+			terminalPasteInputText(
+				{ inputType: "insertFromPaste", isComposing: false },
+				snapshot("previous"),
+				"previouspasted",
+			),
+		).toBe("pasted");
+	});
+
+	test("extracts selection replacement without replaying surviving text", () => {
+		const paste = { inputType: "insertFromPaste", isComposing: false };
+		expect(terminalPasteInputText(paste, snapshot("abc", 1, 2), "aXc")).toBe(
+			"X",
+		);
+		expect(terminalPasteInputText(paste, snapshot("abc", 0, 3), "XYZ")).toBe(
+			"XYZ",
+		);
+		expect(terminalPasteInputText(paste, snapshot("abc", 1, 2), "abc")).toBe(
+			"b",
+		);
+		expect(
+			terminalPasteInputText(paste, snapshot("abc", 1, 1), "axc"),
+		).toBeNull();
+	});
+
+	test("ignores composing, unchanged collapsed, and non-paste input", () => {
+		expect(
+			terminalPasteInputText(
+				{ inputType: "insertFromPaste", isComposing: true },
+				snapshot(""),
+				"text",
+			),
+		).toBeNull();
+		expect(
+			terminalPasteInputText(
+				{ inputType: "insertFromPaste", isComposing: false },
+				snapshot(""),
+				"",
+			),
+		).toBeNull();
+		expect(
+			terminalPasteInputText(
+				{ inputType: "insertText", isComposing: false },
+				snapshot(""),
+				"text",
+			),
+		).toBeNull();
+	});
+
   test("normalizes browser line endings like xterm", () => {
     expect(prepareTerminalPasteText("one\ntwo\r\nthree\rfour")).toBe(
       "one\rtwo\rthree\rfour",

--- a/web/src/terminalPaste.ts
+++ b/web/src/terminalPaste.ts
@@ -1,3 +1,46 @@
+type TerminalPasteInputEvent = Pick<InputEvent, "inputType" | "isComposing">;
+
+export type TerminalPasteTextareaSnapshot = {
+	value: string;
+	selectionStart: number;
+	selectionEnd: number;
+};
+
+/**
+ * Recovers text inserted by WebKit's native paste path from xterm's helper
+ * textarea. Selection-aware prefix/suffix matching avoids replaying text that
+ * merely survived a replacement paste.
+ */
+export function terminalPasteInputText(
+	input: TerminalPasteInputEvent,
+	before: TerminalPasteTextareaSnapshot,
+	textareaValue: string,
+): string | null {
+	if (input.isComposing || input.inputType !== "insertFromPaste") return null;
+	if (
+		before.selectionStart < 0 ||
+		before.selectionEnd < before.selectionStart ||
+		before.selectionEnd > before.value.length
+	) {
+		return null;
+	}
+	if (
+		before.selectionStart === before.selectionEnd &&
+		textareaValue === before.value
+	) {
+		return null;
+	}
+
+	const prefix = before.value.slice(0, before.selectionStart);
+	const suffix = before.value.slice(before.selectionEnd);
+	if (!textareaValue.startsWith(prefix) || !textareaValue.endsWith(suffix)) {
+		return null;
+	}
+	const insertedEnd = textareaValue.length - suffix.length;
+	if (insertedEnd < prefix.length) return null;
+	return textareaValue.slice(prefix.length, insertedEnd) || null;
+}
+
 export function prepareTerminalPasteText(text: string) {
   // Match xterm's paste normalization while letting Herdr apply bracketed
   // paste from the authoritative PTY mode instead of the browser's stale copy.


### PR DESCRIPTION
## Summary

- Recover terminal text committed by iOS keyboards when xterm does not forward helper-textarea mutations during `input` or `keyup`.
- Suppress delayed or partial duplicate output while preserving normal system, third-party, and hardware keyboard handling.
- Recover complete native iOS paste text through `insertFromPaste`, including selection replacement and multiline content.
- Route recovered text and uploaded image paths through the mode-aware pane input API and bind asynchronous paste operations to their originating pane.
- Keep the compatibility handling limited to touch-capable Apple devices.

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun test --timeout 10000` — 349 passed
- `bun run build:darwin-arm64`
- Verified text entry with multiple iOS keyboards in an installed PWA.
- Verified long native text paste without truncation or duplicate input.
