### PR TITLE
Release 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.3.4 - 2026-08-17
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "herdr-gui",
   "private": true,
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A web GUI client for Herdr (local socket bridge + React dashboard).",
   "license": "MIT",
   "author": "Arthur",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "herdr-gui-server",
   "private": true,
-  "version": "0.3.3",
+  "version": "0.3.4",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "herdr-gui-web",
   "private": true,
-  "version": "0.3.3",
+  "version": "0.3.4",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump the root, web, and server package versions to `0.3.4`.
- Finalize the `0.3.4` changelog with command-menu shortcuts and iOS terminal input/paste compatibility.

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun test --timeout 10000` — 349 passed
- Built and inspected release packages for:
  - `linux-x64`
  - `linux-arm64`
  - `darwin-x64`
  - `darwin-arm64`
- Verified archive contents, `VERSION` metadata, SHA-256 checksums, update manifests, executable formats, and the native Darwin arm64 version output.
