### PR TITLE
Improve message dialog, session inspector, and diff viewer usability

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -691,6 +691,13 @@ function TerminalPaneLayout({
     const previousUserSelect = document.body.style.userSelect;
     document.body.style.cursor = horizontal ? "col-resize" : "row-resize";
     document.body.style.userSelect = "none";
+    // Capture the pointer so pointerup still reaches the window (and restores
+    // cursor/user-select) even when released outside the browser window.
+    try {
+      e.currentTarget.setPointerCapture(e.pointerId);
+    } catch {
+      // Pointer capture is best-effort; window listeners still apply.
+    }
 
     const finish = (event: PointerEvent) => {
       window.removeEventListener("pointerup", finish, true);

--- a/web/src/components/AgentHistoryDrawer.tsx
+++ b/web/src/components/AgentHistoryDrawer.tsx
@@ -289,6 +289,13 @@ export function AgentHistoryDrawer({
     setPreviewError("");
   }, []);
 
+  // Stable identity so the message dialog's focus effect only re-runs when the
+  // message itself changes, not on every drawer re-render.
+  const closeExpandedMessage = useCallback(
+    () => setExpandedMessage(null),
+    [],
+  );
+
   const usage = tokenUsage(session);
   const messages = history?.messages ?? [];
   const visibleMessages = visibleSessionMessages(
@@ -558,7 +565,7 @@ export function AgentHistoryDrawer({
       </aside>
       <AgentMessageDialog
         message={expandedMessage}
-        onClose={() => setExpandedMessage(null)}
+        onClose={closeExpandedMessage}
       />
       <AgentSessionPreviewDialog
         pane={previewPane}

--- a/web/src/components/AgentMessageDialog.tsx
+++ b/web/src/components/AgentMessageDialog.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Copy, X } from "lucide-react";
 import { focusDialogElement } from "./dialogFocus";
+import { MarkdownPreview } from "./markdown";
 
 type AgentMessage = {
   role: "user" | "assistant";
@@ -25,6 +26,16 @@ export function AgentMessageDialog({
   onClose: () => void;
 }) {
   const dialogRef = useRef<HTMLDivElement>(null);
+  const [viewMode, setViewMode] = useState<"rendered" | "raw">("rendered");
+  const [viewModeMessage, setViewModeMessage] = useState(message);
+
+  if (message !== viewModeMessage) {
+    // Reset the view for each newly opened message during render so the stale
+    // mode never flashes. Assistant messages are usually markdown; user
+    // messages are usually prose.
+    setViewModeMessage(message);
+    setViewMode(message?.role === "assistant" ? "rendered" : "raw");
+  }
 
   useEffect(() => {
     if (!message) return;
@@ -64,6 +75,21 @@ export function AgentMessageDialog({
           <div className="agent-message-modal-actions">
             <button
               type="button"
+              className="agent-message-mode-toggle"
+              onClick={() =>
+                setViewMode((mode) => (mode === "rendered" ? "raw" : "rendered"))
+              }
+              aria-label={
+                viewMode === "rendered"
+                  ? "Show raw markdown"
+                  : "Show rendered markdown"
+              }
+              title={viewMode === "rendered" ? "Show raw" : "Show rendered"}
+            >
+              {viewMode === "rendered" ? "Raw" : "Rendered"}
+            </button>
+            <button
+              type="button"
               className="agent-history-icon"
               onClick={() => void navigator.clipboard?.writeText(message.text)}
               aria-label="Copy message"
@@ -82,7 +108,17 @@ export function AgentMessageDialog({
             </button>
           </div>
         </div>
-        <pre className="agent-message-modal-content">{message.text}</pre>
+        {viewMode === "rendered" ? (
+          <div className="agent-message-modal-content is-rendered">
+            <MarkdownPreview
+              text={message.text}
+              className="agent-message-markdown"
+              breaks
+            />
+          </div>
+        ) : (
+          <pre className="agent-message-modal-content">{message.text}</pre>
+        )}
       </div>
     </div>
   );

--- a/web/src/components/AgentSessionPreviewDialog.tsx
+++ b/web/src/components/AgentSessionPreviewDialog.tsx
@@ -1,5 +1,14 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { Copy, Download, X } from "lucide-react";
+import { useEffect, useMemo, useRef, useState, memo } from "react";
+import {
+  Brain,
+  ChevronRight,
+  Copy,
+  Download,
+  FileText,
+  Info,
+  Wrench,
+  X,
+} from "lucide-react";
 import { useStore } from "../store";
 import type { Pane } from "../types";
 import { shortId } from "../utils";
@@ -11,11 +20,13 @@ import {
   type AgentSessionSummary,
   downloadSession,
   downloadSessionAtif,
+  firstLinePreview,
   formatBytes,
   formatCount,
   formatOptionalCompact,
   formatTokenTotal,
   groupTrajectoryTurns,
+  toolArgumentsPreview,
 } from "./agentSession";
 import { focusDialogElement } from "./dialogFocus";
 
@@ -326,27 +337,24 @@ function SessionTimeline({ turns }: { turns: AgentSessionTurn[] }) {
   );
 }
 
-function SessionTurn({ turn }: { turn: AgentSessionTurn }) {
-  const userMessages = turn.steps.filter(
-    (step) => step.source === "user" && meaningfulMessage(step),
-  );
-  const agentMessages = turn.steps.filter(
-    (step) => step.source === "agent" && meaningfulMessage(step),
-  );
-  const systemMessages = turn.steps.filter(
-    (step) => step.source === "system" && meaningfulMessage(step),
-  );
-  const reasoning = turn.steps.filter(
-    (step) =>
-      step.reasoning_content &&
-      step.reasoning_content !== meaningfulMessage(step),
-  );
-  const toolCalls = turn.steps.flatMap((step) => step.tool_calls ?? []);
-  const observations = turn.steps.flatMap(
-    (step) => step.observation?.results ?? [],
-  );
+// The timeline subscribes to the global store higher up, so it re-renders on
+// every unrelated app update. Turn objects are stable (memoized on the
+// trajectory steps), making each turn cheap to skip.
+const SessionTurn = memo(function SessionTurn({
+  turn,
+}: {
+  turn: AgentSessionTurn;
+}) {
   const metrics = stepMetricText(turn.steps);
   const firstTimestamp = turn.steps.find((step) => step.timestamp)?.timestamp;
+  // Match tool results back to their calls so output rows can carry the tool
+  // name regardless of which step reported the call.
+  const toolNameById = new Map<string, string>();
+  for (const step of turn.steps) {
+    for (const tool of step.tool_calls ?? []) {
+      toolNameById.set(tool.tool_call_id, tool.function_name);
+    }
+  }
 
   return (
     <article className="agent-session-turn">
@@ -362,61 +370,114 @@ function SessionTurn({ turn }: { turn: AgentSessionTurn }) {
         </span>
       </header>
       <div className="agent-session-turn-body">
-        {userMessages.map((step) => (
-          <section className="agent-session-exchange is-user" key={step.step_id}>
-            <span>Prompt</span>
-            <pre>{step.message}</pre>
-          </section>
+        {turn.steps.map((step) => (
+          <SessionStepRows
+            step={step}
+            toolNameById={toolNameById}
+            key={step.step_id}
+          />
         ))}
-        {agentMessages.map((step) => (
-          <section className="agent-session-exchange is-agent" key={step.step_id}>
-            <span>Response</span>
-            <pre>{step.message}</pre>
-          </section>
-        ))}
-        {systemMessages.length > 0 ? (
-          <details className="agent-session-turn-details">
-            <summary>System context ({systemMessages.length})</summary>
-            {systemMessages.map((step) => (
-              <pre key={step.step_id}>{step.message}</pre>
-            ))}
-          </details>
-        ) : null}
-        {reasoning.length > 0 ? (
-          <details className="agent-session-turn-details">
-            <summary>Reasoning ({reasoning.length})</summary>
-            {reasoning.map((step) => (
-              <pre key={step.step_id}>{step.reasoning_content}</pre>
-            ))}
-          </details>
-        ) : null}
-        {toolCalls.length > 0 ? (
-          <details className="agent-session-turn-details">
-            <summary>Tool calls ({toolCalls.length})</summary>
-            <div className="agent-session-tool-list">
-              {toolCalls.map((tool) => (
-                <code key={tool.tool_call_id}>
-                  <strong>{tool.function_name}</strong>
-                  {JSON.stringify(tool.arguments, null, 2)}
-                </code>
-              ))}
-            </div>
-          </details>
-        ) : null}
-        {observations.length > 0 ? (
-          <details className="agent-session-turn-details">
-            <summary>Tool output ({observations.length})</summary>
-            <div className="agent-session-observation-list">
-              {observations.map((result, index) => (
-                <pre key={`${result.source_call_id ?? "result"}:${index}`}>
-                  {result.content}
-                </pre>
-              ))}
-            </div>
-          </details>
-        ) : null}
         {metrics ? <footer>{metrics}</footer> : null}
       </div>
     </article>
+  );
+});
+
+// Render one trajectory step in place so the timeline follows the actual
+// execution order: reasoning, messages, tool calls and their results appear
+// exactly where they happened instead of being regrouped by type.
+function SessionStepRows({
+  step,
+  toolNameById,
+}: {
+  step: AgentSessionTrajectoryStep;
+  toolNameById: Map<string, string>;
+}) {
+  const message = meaningfulMessage(step);
+  const reasoning =
+    step.reasoning_content && step.reasoning_content !== message
+      ? step.reasoning_content
+      : "";
+  const observations = step.observation?.results ?? [];
+  return (
+    <>
+      {reasoning ? (
+        <details className="agent-session-turn-details">
+          <summary>
+            <ChevronRight size={12} className="agent-session-details-icon" />
+            <Brain size={12} />
+            <span>Reasoning</span>
+            <small>{firstLinePreview(reasoning)}</small>
+          </summary>
+          <pre>{reasoning}</pre>
+        </details>
+      ) : null}
+      {step.source === "user" && message ? (
+        <section className="agent-session-exchange is-user">
+          <span>Prompt</span>
+          <pre>{message}</pre>
+        </section>
+      ) : null}
+      {step.source === "agent" && message ? (
+        <section className="agent-session-exchange is-agent">
+          <span>Response</span>
+          <pre>{message}</pre>
+        </section>
+      ) : null}
+      {(step.tool_calls ?? []).map((tool) => (
+        <details className="agent-session-turn-details" key={tool.tool_call_id}>
+          <summary>
+            <ChevronRight size={12} className="agent-session-details-icon" />
+            <Wrench size={12} />
+            <span>{tool.function_name}</span>
+            <small>
+              {toolArgumentsPreview(
+                tool.arguments,
+                typeof tool.extra?.description === "string"
+                  ? tool.extra.description
+                  : undefined,
+              )}
+            </small>
+          </summary>
+          <div className="agent-session-tool-list">
+            <code>
+              <strong>{tool.function_name}</strong>
+              {JSON.stringify(tool.arguments, null, 2)}
+            </code>
+          </div>
+        </details>
+      ))}
+      {observations.map((result, index) => (
+        <details
+          className="agent-session-turn-details"
+          key={`${result.source_call_id ?? "result"}:${index}`}
+        >
+          <summary>
+            <ChevronRight size={12} className="agent-session-details-icon" />
+            <FileText size={12} />
+            <span>
+              {(result.source_call_id &&
+                toolNameById.get(result.source_call_id)) ||
+                "Tool output"}
+            </span>
+            <small>{firstLinePreview(result.content ?? "")}</small>
+          </summary>
+          <div className="agent-session-observation-list">
+            <pre>{result.content}</pre>
+          </div>
+        </details>
+      ))}
+      {step.source === "system" && message && observations.length === 0 ? (
+        <details className="agent-session-turn-details">
+          <summary>
+            <ChevronRight size={12} className="agent-session-details-icon" />
+            <Info size={12} />
+            <span>System</span>
+            <small>{firstLinePreview(message)}</small>
+          </summary>
+          <pre>{message}</pre>
+        </details>
+      ) : null}
+    </>
   );
 }

--- a/web/src/components/CommandCombobox.test.ts
+++ b/web/src/components/CommandCombobox.test.ts
@@ -40,22 +40,32 @@ describe("command combobox search helpers", () => {
     expect(commandPathQuery("README")).toBe("");
   });
 
-  test("maps Command-number-row shortcuts across keyboard layouts", () => {
+  test("maps modifier-number-row shortcuts across keyboard layouts", () => {
     const event = {
-      altKey: false,
+      altKey: true,
       code: "Digit4",
       ctrlKey: false,
       key: "4",
-      metaKey: true,
+      metaKey: false,
       shiftKey: false,
     };
     expect(commandNumberShortcutIndex(event)).toBe(3);
+    // Option+digit types alternate characters on macOS, so the physical key
+    // code wins over the produced character.
     expect(
-      commandNumberShortcutIndex({ ...event, code: "Digit1", key: "&" }),
+      commandNumberShortcutIndex({ ...event, code: "Digit1", key: "¡" }),
     ).toBe(0);
-    expect(commandNumberShortcutIndex({ ...event, metaKey: false })).toBeNull();
-    expect(commandNumberShortcutIndex({ ...event, ctrlKey: true })).toBeNull();
-    expect(commandNumberShortcutIndex({ ...event, altKey: true })).toBeNull();
+    // Ctrl (macOS) and Meta (embedded webviews) work as aliases.
+    expect(
+      commandNumberShortcutIndex({ ...event, altKey: false, ctrlKey: true }),
+    ).toBe(3);
+    expect(
+      commandNumberShortcutIndex({ ...event, altKey: false, metaKey: true }),
+    ).toBe(3);
+    expect(commandNumberShortcutIndex({ ...event, altKey: false })).toBeNull();
+    expect(
+      commandNumberShortcutIndex({ ...event, ctrlKey: true, shiftKey: false }),
+    ).toBeNull();
     expect(commandNumberShortcutIndex({ ...event, shiftKey: true })).toBeNull();
     expect(
       commandNumberShortcutIndex({ ...event, code: "Digit0", key: "0" }),

--- a/web/src/components/CommandCombobox.tsx
+++ b/web/src/components/CommandCombobox.tsx
@@ -167,10 +167,17 @@ type CommandNumberShortcutEvent = CommandNumberShortcutModifiers &
 export function commandNumberShortcutIndex(
   event: CommandNumberShortcutModifiers,
 ) {
-  if (!event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
-    return null;
-  }
+  // Desktop browsers reserve bare Cmd/Win+1-9 (tab switching on macOS, taskbar
+  // shortcuts on Windows) and never deliver them to pages, so Alt+1-9 is the
+  // displayed shortcut: it is the only modifier combo that reliably reaches
+  // the page across macOS, Windows and Linux. Ctrl (delivered on macOS) and
+  // Meta (delivered by embedded webviews) are accepted as aliases.
+  const modifiers =
+    Number(event.altKey) + Number(event.ctrlKey) + Number(event.metaKey);
+  if (modifiers !== 1 || event.shiftKey) return null;
   if (/^[1-9]$/.test(event.key)) return Number(event.key) - 1;
+  // Option+digit types alternate characters on macOS (e.g. ¡ for 1), so fall
+  // back to the physical key code for layout-independent matching.
   const match = /^Digit([1-9])$/.exec(event.code);
   return match ? Number(match[1]) - 1 : null;
 }
@@ -1073,7 +1080,7 @@ function ActionItem({
   onSelect: () => void;
 }) {
   const numberShortcut =
-    numberShortcutIndex === undefined ? null : `⌘${numberShortcutIndex + 1}`;
+    numberShortcutIndex === undefined ? null : `⌥${numberShortcutIndex + 1}`;
   return (
     <CommandItem
       value={value}
@@ -1083,7 +1090,7 @@ function ActionItem({
       aria-keyshortcuts={
         numberShortcutIndex === undefined
           ? undefined
-          : `Meta+${numberShortcutIndex + 1}`
+          : `Alt+${numberShortcutIndex + 1}`
       }
     >
       <span className="command-item-icon">{icon}</span>

--- a/web/src/components/DiffContentView.tsx
+++ b/web/src/components/DiffContentView.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronUp, FolderOpen, Search, X } from "lucide-react";
+import { ChevronDown, ChevronRight, ChevronUp, FolderOpen, Search, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { html as diffToHtml } from "diff2html";
 import "diff2html/bundles/css/diff2html.min.css";
@@ -215,6 +215,9 @@ export function DiffContentView({
     Record<string, ImagePreviewState>
   >({});
   const requestedImagePreviewsRef = useRef<Set<string>>(new Set());
+  const [collapsedKeys, setCollapsedKeys] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
   const effectiveViewMode: DiffViewMode = mobile ? "unified" : viewMode;
   const wrapEnabled = mobile ? mobileWrap : desktopWrap;
   const activeSearchQuery = searchQuery;
@@ -412,6 +415,15 @@ export function DiffContentView({
     [searchMatchCount],
   );
 
+  const toggleSectionCollapsed = useCallback((key: string) => {
+    setCollapsedKeys((current) => {
+      const next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
@@ -453,6 +465,16 @@ export function DiffContentView({
           </strong>
           {entry ? <span>{entry.path}</span> : null}
         </div>
+        {mobile ? (
+          <button
+            type="button"
+            className={`diff-wrap-toggle ${mobileWrap ? "is-active" : ""}`}
+            onClick={() => setMobileWrap((value) => !value)}
+            aria-pressed={mobileWrap}
+          >
+            {mobileWrap ? "Wrap" : "No wrap"}
+          </button>
+        ) : null}
         <div className="diff-content-actions">
           <label className="diff-search">
             <Search size={13} />
@@ -546,17 +568,6 @@ export function DiffContentView({
         </div>
       </div>
 
-      {mobile ? (
-        <button
-          type="button"
-          className={`diff-wrap-toggle ${mobileWrap ? "is-active" : ""}`}
-          onClick={() => setMobileWrap((value) => !value)}
-          aria-pressed={mobileWrap}
-        >
-          {mobileWrap ? "Wrap" : "No wrap"}
-        </button>
-      ) : null}
-
       {error && !visibleEntries.length ? (
         <div className="diff-content-state is-error">{error}</div>
       ) : null}
@@ -582,6 +593,7 @@ export function DiffContentView({
             const sectionLoading =
               loading && activeEntryKey === section.key && !section.file;
             const loadingFile = !section.file && !section.error;
+            const collapsed = collapsedKeys.has(section.key);
             return (
               <article
                 className="diff-file-section"
@@ -589,6 +601,20 @@ export function DiffContentView({
                 data-diff-entry-key={section.key}
               >
                 <header className="diff-file-section-head">
+                  <button
+                    type="button"
+                    className="diff-file-collapse"
+                    onClick={() => toggleSectionCollapsed(section.key)}
+                    aria-expanded={!collapsed}
+                    aria-label={`${collapsed ? "Expand" : "Collapse"} ${section.entry.path}`}
+                    title={collapsed ? "Expand" : "Collapse"}
+                  >
+                    {collapsed ? (
+                      <ChevronRight size={14} />
+                    ) : (
+                      <ChevronDown size={14} />
+                    )}
+                  </button>
                   <div className="diff-file-section-title">
                     <strong>{section.entry.path}</strong>
                     <span>
@@ -606,37 +632,41 @@ export function DiffContentView({
                     <span>Open in Files</span>
                   </button>
                 </header>
-                {section.error ? (
-                  <div className="diff-content-state is-error">
-                    {section.error}
-                  </div>
-                ) : null}
-                {loadingFile ? (
-                  <div className="diff-content-state">
-                    {sectionLoading ? <span className="file-loading-spinner" /> : null}
-                    Loading diff
-                  </div>
-                ) : null}
-                {section.file && !section.file.diff && !section.imagePreview ? (
-                  <div className="diff-content-state">
-                    No textual diff available.
-                  </div>
-                ) : null}
-                {section.imagePreview && section.file ? (
-                  <DiffImagePreview
-                    state={imagePreviews[imagePreviewKey(section.file)]}
-                    path={section.entry.path}
-                  />
-                ) : null}
-                {section.file?.truncated ? (
-                  <div className="diff-truncated">Diff truncated at 512 KB.</div>
-                ) : null}
-                {section.html ? (
-                  <div
-                    className="diff-file-html"
-                    dangerouslySetInnerHTML={{ __html: section.html }}
-                  />
-                ) : null}
+                {collapsed ? null : (
+                  <>
+                    {section.error ? (
+                      <div className="diff-content-state is-error">
+                        {section.error}
+                      </div>
+                    ) : null}
+                    {loadingFile ? (
+                      <div className="diff-content-state">
+                        {sectionLoading ? <span className="file-loading-spinner" /> : null}
+                        Loading diff
+                      </div>
+                    ) : null}
+                    {section.file && !section.file.diff && !section.imagePreview ? (
+                      <div className="diff-content-state">
+                        No textual diff available.
+                      </div>
+                    ) : null}
+                    {section.imagePreview && section.file ? (
+                      <DiffImagePreview
+                        state={imagePreviews[imagePreviewKey(section.file)]}
+                        path={section.entry.path}
+                      />
+                    ) : null}
+                    {section.file?.truncated ? (
+                      <div className="diff-truncated">Diff truncated at 512 KB.</div>
+                    ) : null}
+                    {section.html ? (
+                      <div
+                        className="diff-file-html"
+                        dangerouslySetInnerHTML={{ __html: section.html }}
+                      />
+                    ) : null}
+                  </>
+                )}
               </article>
             );
           })}

--- a/web/src/components/FilePreviewContent.tsx
+++ b/web/src/components/FilePreviewContent.tsx
@@ -1,14 +1,13 @@
 import {
   useEffect,
-  useMemo,
   useRef,
   useState,
   type MutableRefObject,
 } from "react";
-import { marked } from "marked";
 import type { Extension } from "@codemirror/state";
 import type { EditorView as CodeMirrorEditorView } from "@codemirror/view";
 import type { FileExplorerEntry, FilePreview } from "../types";
+import { MarkdownPreview } from "./markdown";
 
 export type ActiveFilePreviewSelection = {
   entry: FileExplorerEntry | null;
@@ -167,53 +166,6 @@ function openPreviewSearch(view: CodeMirrorEditorView | null) {
   void loadCodeMirrorPreviewDeps().then((deps) => deps.openSearchPanel(view));
 }
 
-const MARKDOWN_ALLOWED_TAGS = new Set([
-  "a",
-  "blockquote",
-  "br",
-  "code",
-  "del",
-  "em",
-  "h1",
-  "h2",
-  "h3",
-  "h4",
-  "h5",
-  "h6",
-  "hr",
-  "input",
-  "img",
-  "li",
-  "ol",
-  "p",
-  "pre",
-  "strong",
-  "table",
-  "tbody",
-  "td",
-  "th",
-  "thead",
-  "tr",
-  "ul",
-]);
-const MARKDOWN_ALLOWED_ATTRS = new Set([
-  "alt",
-  "checked",
-  "colspan",
-  "disabled",
-  "href",
-  "rowspan",
-  "src",
-  "title",
-  "type",
-]);
-const MARKDOWN_DROP_CONTENT_TAGS = new Set([
-  "iframe",
-  "object",
-  "script",
-  "style",
-]);
-
 function isMarkdownPath(path: string) {
   const lower = path.toLowerCase();
   return (
@@ -222,74 +174,6 @@ function isMarkdownPath(path: string) {
     lower.endsWith(".mdown") ||
     lower.endsWith(".mkdn")
   );
-}
-
-function isSafeMarkdownUrl(value: string) {
-  const trimmed = value.trim().toLowerCase();
-  if (!trimmed || trimmed.startsWith("//")) return false;
-  if (trimmed.startsWith("#") || trimmed.startsWith("/")) return true;
-  const protocolMatch = trimmed.match(/^([a-z][a-z0-9+.-]*):/);
-  if (!protocolMatch) return true;
-  return ["http:", "https:", "mailto:"].includes(protocolMatch[0]);
-}
-
-function sanitizeMarkdownHtml(html: string) {
-  const doc = new DOMParser().parseFromString(html, "text/html");
-  const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_ELEMENT);
-  const elements: Element[] = [];
-  while (walker.nextNode()) elements.push(walker.currentNode as Element);
-
-  for (const element of elements) {
-    const tag = element.tagName.toLowerCase();
-    if (MARKDOWN_DROP_CONTENT_TAGS.has(tag)) {
-      element.remove();
-      continue;
-    }
-    if (!MARKDOWN_ALLOWED_TAGS.has(tag)) {
-      element.replaceWith(...Array.from(element.childNodes));
-      continue;
-    }
-
-    if (tag === "input") {
-      const isCheckbox = element.getAttribute("type") === "checkbox";
-      if (!isCheckbox) {
-        element.remove();
-        continue;
-      }
-      element.setAttribute("disabled", "");
-    }
-
-    for (const attr of Array.from(element.attributes)) {
-      const name = attr.name.toLowerCase();
-      if (
-        name.startsWith("on") ||
-        name === "style" ||
-        !MARKDOWN_ALLOWED_ATTRS.has(name)
-      ) {
-        element.removeAttribute(attr.name);
-        continue;
-      }
-      if ((name === "href" || name === "src") && !isSafeMarkdownUrl(attr.value)) {
-        element.removeAttribute(attr.name);
-      }
-    }
-
-    if (tag === "a" && element.hasAttribute("href")) {
-      element.setAttribute("target", "_blank");
-      element.setAttribute("rel", "noreferrer noopener");
-    }
-  }
-
-  return doc.body.innerHTML;
-}
-
-function renderMarkdown(text: string) {
-  const html = marked.parse(text, {
-    async: false,
-    breaks: false,
-    gfm: true,
-  });
-  return sanitizeMarkdownHtml(String(html));
 }
 
 function currentDocumentTheme(): AppTheme {
@@ -437,15 +321,6 @@ export function FilePreviewContent({
   );
 }
 
-function MarkdownPreview({ text }: { text: string }) {
-  const html = useMemo(() => renderMarkdown(text), [text]);
-  return (
-    <article
-      className="file-preview-markdown"
-      dangerouslySetInnerHTML={{ __html: html }}
-    />
-  );
-}
 
 function CodeMirrorPreview({
   text,

--- a/web/src/components/agentSession.test.ts
+++ b/web/src/components/agentSession.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
+  firstLinePreview,
   groupTrajectoryTurns,
   type AgentSessionTrajectoryStep,
+  toolArgumentsPreview,
   visibleSessionMessages,
 } from "./agentSession";
 
@@ -61,5 +63,27 @@ describe("agent session presentation", () => {
       { sequence: 1, message: { text: "first" } },
       { sequence: 3, message: { text: "second" } },
     ]);
+  });
+
+  test("previews tool call arguments by priority key", () => {
+    expect(
+      toolArgumentsPreview({ command: "ls\napps/roadie", cwd: "/repo" }),
+    ).toBe("ls apps/roadie");
+    expect(toolArgumentsPreview({ file_path: "src/index.ts" })).toBe(
+      "src/index.ts",
+    );
+    expect(toolArgumentsPreview({}, "List files in apps/roadie")).toBe(
+      "List files in apps/roadie",
+    );
+    expect(toolArgumentsPreview({ a: 1 })).toBe('{"a":1}');
+    expect(toolArgumentsPreview({ command: "x".repeat(120) }, undefined, 10)).toBe(
+      `${"x".repeat(10)}…`,
+    );
+  });
+
+  test("previews the first non-empty line with truncation", () => {
+    expect(firstLinePreview("\n  first line  \nsecond")).toBe("first line");
+    expect(firstLinePreview("")).toBe("");
+    expect(firstLinePreview("x".repeat(120), 10)).toBe(`${"x".repeat(10)}…`);
   });
 });

--- a/web/src/components/agentSession.ts
+++ b/web/src/components/agentSession.ts
@@ -20,6 +20,7 @@ export type AgentSessionTrajectoryStep = {
     tool_call_id: string;
     function_name: string;
     arguments: Record<string, unknown>;
+    extra?: Record<string, unknown>;
   }[];
   observation?: {
     results: {
@@ -129,6 +130,50 @@ export function visibleSessionMessages<
       ? [{ message, sequence: index + 1 }]
       : [],
   );
+}
+
+// Build a compact one-line preview for a tool call, preferring the most
+// descriptive argument (command, path, pattern, ...) before falling back to
+// the agent-provided description or the raw JSON.
+const TOOL_ARGUMENT_PREVIEW_KEYS = [
+  "command",
+  "file_path",
+  "path",
+  "pattern",
+  "query",
+  "url",
+  "description",
+  "prompt",
+];
+
+export function toolArgumentsPreview(
+  args: Record<string, unknown>,
+  description?: string,
+  max = 72,
+) {
+  const truncate = (value: string) => {
+    const text = value.replace(/\s+/g, " ").trim();
+    return text.length > max ? `${text.slice(0, max)}…` : text;
+  };
+  for (const key of TOOL_ARGUMENT_PREVIEW_KEYS) {
+    const value = args[key];
+    if (typeof value === "string" && value.trim()) return truncate(value);
+  }
+  if (description?.trim()) return truncate(description);
+  try {
+    return truncate(JSON.stringify(args) ?? "");
+  } catch {
+    return "";
+  }
+}
+
+export function firstLinePreview(text: string, max = 96) {
+  const line =
+    text
+      .split("\n")
+      .map((value) => value.trim())
+      .find(Boolean) ?? "";
+  return line.length > max ? `${line.slice(0, max)}…` : line;
 }
 
 export function formatCount(value: number) {

--- a/web/src/components/markdown.tsx
+++ b/web/src/components/markdown.tsx
@@ -1,0 +1,138 @@
+import { useMemo } from "react";
+import { marked } from "marked";
+
+const MARKDOWN_ALLOWED_TAGS = new Set([
+  "a",
+  "blockquote",
+  "br",
+  "code",
+  "del",
+  "em",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "hr",
+  "input",
+  "img",
+  "li",
+  "ol",
+  "p",
+  "pre",
+  "strong",
+  "table",
+  "tbody",
+  "td",
+  "th",
+  "thead",
+  "tr",
+  "ul",
+]);
+const MARKDOWN_ALLOWED_ATTRS = new Set([
+  "alt",
+  "checked",
+  "colspan",
+  "disabled",
+  "href",
+  "rowspan",
+  "src",
+  "title",
+  "type",
+]);
+const MARKDOWN_DROP_CONTENT_TAGS = new Set([
+  "iframe",
+  "object",
+  "script",
+  "style",
+]);
+
+export function isSafeMarkdownUrl(value: string) {
+  const trimmed = value.trim().toLowerCase();
+  if (!trimmed || trimmed.startsWith("//")) return false;
+  if (trimmed.startsWith("#") || trimmed.startsWith("/")) return true;
+  const protocolMatch = trimmed.match(/^([a-z][a-z0-9+.-]*):/);
+  if (!protocolMatch) return true;
+  return ["http:", "https:", "mailto:"].includes(protocolMatch[0]);
+}
+
+export function sanitizeMarkdownHtml(html: string) {
+  const doc = new DOMParser().parseFromString(html, "text/html");
+  const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_ELEMENT);
+  const elements: Element[] = [];
+  while (walker.nextNode()) elements.push(walker.currentNode as Element);
+
+  for (const element of elements) {
+    const tag = element.tagName.toLowerCase();
+    if (MARKDOWN_DROP_CONTENT_TAGS.has(tag)) {
+      element.remove();
+      continue;
+    }
+    if (!MARKDOWN_ALLOWED_TAGS.has(tag)) {
+      element.replaceWith(...Array.from(element.childNodes));
+      continue;
+    }
+
+    if (tag === "input") {
+      const isCheckbox = element.getAttribute("type") === "checkbox";
+      if (!isCheckbox) {
+        element.remove();
+        continue;
+      }
+      element.setAttribute("disabled", "");
+    }
+
+    for (const attr of Array.from(element.attributes)) {
+      const name = attr.name.toLowerCase();
+      if (
+        name.startsWith("on") ||
+        name === "style" ||
+        !MARKDOWN_ALLOWED_ATTRS.has(name)
+      ) {
+        element.removeAttribute(attr.name);
+        continue;
+      }
+      if ((name === "href" || name === "src") && !isSafeMarkdownUrl(attr.value)) {
+        element.removeAttribute(attr.name);
+      }
+    }
+
+    if (tag === "a" && element.hasAttribute("href")) {
+      element.setAttribute("target", "_blank");
+      element.setAttribute("rel", "noreferrer noopener");
+    }
+  }
+
+  return doc.body.innerHTML;
+}
+
+export function renderMarkdown(text: string, options: { breaks?: boolean } = {}) {
+  const html = marked.parse(text, {
+    async: false,
+    // Chat messages are not authored as strict markdown documents, so callers
+    // rendering conversation text should opt into breaks to keep intentional
+    // single newlines instead of collapsing them into one paragraph.
+    breaks: options.breaks ?? false,
+    gfm: true,
+  });
+  return sanitizeMarkdownHtml(String(html));
+}
+
+export function MarkdownPreview({
+  text,
+  className = "",
+  breaks = false,
+}: {
+  text: string;
+  className?: string;
+  breaks?: boolean;
+}) {
+  const html = useMemo(() => renderMarkdown(text, { breaks }), [text, breaks]);
+  return (
+    <article
+      className={`file-preview-markdown ${className}`.trim()}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4117,9 +4117,27 @@ textarea:focus {
   );
 }
 .diff-file-section-title {
+  flex: 1 1 auto;
   min-width: 0;
   display: grid;
   gap: 2px;
+}
+.diff-file-collapse {
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted);
+}
+.diff-file-collapse:hover {
+  background: var(--accent-soft);
+  color: var(--text-strong);
 }
 .diff-file-section-title strong,
 .diff-file-section-title span {
@@ -4159,6 +4177,10 @@ textarea:focus {
 }
 .diff-file-html {
   min-width: 0;
+  /* Scope horizontal scrolling to the code area so the file header and state
+     banners stay put in no-wrap mode (previously the whole wrapper scrolled
+     and carried the header off screen). */
+  overflow-x: auto;
 }
 .diff-image-preview {
   display: grid;
@@ -4190,7 +4212,11 @@ textarea:focus {
 .diff2html-wrapper {
   flex: 1 1 auto;
   min-height: 0;
-  overflow: auto;
+  /* Only scroll vertically here. Horizontal scrolling is scoped to each
+     .diff-file-html code area; nothing else may carry the file headers off
+     screen, so clamp this axis instead of letting it scroll again. */
+  overflow-x: hidden;
+  overflow-y: auto;
   background: var(--diff-bg);
 }
 .diff2html-wrapper .d2h-wrapper {
@@ -6508,7 +6534,7 @@ textarea:focus {
     flex-wrap: wrap;
   }
   .diff-content-title {
-    flex: 1 1 100%;
+    flex: 1 1 auto;
   }
   .diff-content-actions {
     flex: 1 1 100%;
@@ -6523,27 +6549,12 @@ textarea:focus {
   }
   .diff-file-section-head {
     align-items: flex-start;
-    padding-right: calc(72px + env(safe-area-inset-right, 0px));
   }
   .diff-file-open span {
     display: none;
   }
   .diff-view-toggle {
     display: none;
-  }
-  .diff-wrap-toggle {
-    position: absolute;
-    top: 50px;
-    right: calc(8px + env(safe-area-inset-right, 0px));
-    z-index: 3;
-    padding: 4px 8px;
-    border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--panel) 76%, transparent);
-    box-shadow: var(--shadow-lg);
-    color: var(--text-strong);
-    -webkit-backdrop-filter: blur(14px);
-    backdrop-filter: blur(14px);
   }
   .diff2html-wrapper {
     box-sizing: border-box;
@@ -6569,6 +6580,13 @@ textarea:focus {
     min-width: max-content;
     width: max-content;
     white-space: nowrap;
+  }
+  /* Unified rows carry two line-number cells; 7.5em each would consume half
+     of a phone screen before any code is visible. */
+  .diff2html-wrapper .d2h-code-linenumber {
+    width: 3.4em;
+    min-width: 3.4em;
+    padding: 0 0.25em;
   }
   .diff2html-wrapper .d2h-code-line-ctn {
     flex: 0 0 auto;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5922,6 +5922,21 @@ textarea:focus {
   align-items: center;
   gap: 4px;
 }
+.agent-message-mode-toggle {
+  flex: 0 0 auto;
+  height: 24px;
+  margin-right: 4px;
+  padding: 0 9px;
+  border-radius: 7px;
+  background: var(--viewer-panel-bg);
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 700;
+}
+.agent-message-mode-toggle:hover {
+  color: var(--text-strong);
+  border-color: var(--accent);
+}
 .agent-message-modal-content {
   min-height: 0;
   max-height: min(660px, calc(100dvh - 122px));
@@ -5937,6 +5952,19 @@ textarea:focus {
   background: var(--input-bg);
   border: 1px solid var(--border);
   border-radius: 8px;
+  user-select: text;
+  -webkit-user-select: text;
+}
+.agent-message-modal-content.is-rendered {
+  color: var(--text);
+  font-family: inherit;
+  white-space: normal;
+  overflow-wrap: break-word;
+}
+.agent-message-markdown {
+  padding: 0;
+  font-size: 13px;
+  line-height: 1.6;
 }
 .terminal-loading {
   position: absolute;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3136,16 +3136,46 @@ textarea:focus {
   line-height: 1.45;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
+  user-select: text;
+  -webkit-user-select: text;
 }
 .agent-session-turn-details {
   color: var(--muted);
   font-size: 11px;
 }
 .agent-session-turn-details > summary {
-  width: fit-content;
+  max-width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 6px;
   padding: 4px 0;
   color: var(--muted);
   cursor: pointer;
+  list-style: none;
+}
+.agent-session-turn-details > summary::-webkit-details-marker {
+  display: none;
+}
+.agent-session-turn-details > summary svg {
+  flex: 0 0 auto;
+}
+.agent-session-details-icon {
+  transition: transform 120ms ease;
+}
+.agent-session-turn-details[open] > summary .agent-session-details-icon {
+  transform: rotate(90deg);
+}
+.agent-session-turn-details > summary > span {
+  flex: 0 0 auto;
+}
+.agent-session-turn-details > summary > small {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 11px;
+  font-weight: 400;
+  opacity: 0.75;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .agent-session-turn-details[open] > summary {
   color: var(--text-strong);
@@ -3173,6 +3203,8 @@ textarea:focus {
   line-height: 1.45;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
+  user-select: text;
+  -webkit-user-select: text;
   background: var(--code-bg);
   border-left: 2px solid var(--border-soft);
 }


### PR DESCRIPTION
## Summary

A set of usability improvements across the agent viewers, command menu, and diff viewer:

- **Full-message dialog**: messages can be viewed as rendered markdown with a Rendered/Raw toggle (assistant defaults to rendered, user to raw). Rendering is shared with the file preview through a new `markdown.tsx` helper (marked + DOMPurify), so sanitization stays in one place.
- **Text selection**: fixed `user-select: none` getting stuck on `body` after dragging pane dividers when the pointer was released outside the window (pointer capture on the resizer), and made the dialog, session inspector, and tool-output blocks explicitly selectable.
- **Session inspector**: trajectory steps now render chronologically (reasoning → response → tool call → tool output) as individual collapsible rows with one-line previews, instead of grouping by type. Tool outputs no longer appear once under "System context" and again under "Tool output".
- **Command menu**: numbered actions are now triggered with Alt/⌥+digit instead of ⌘+digit, which browsers reserve for tab switching and never deliver to the page (Ctrl/Cmd are still accepted where the OS does deliver them).
- **Diff viewer (mobile)**: the wrap toggle moved from an overlapping floating position into the header title row, the search row keeps its prev/next buttons clear, and line-number columns no longer consume half the screen. In no-wrap mode, horizontal scrolling now happens inside each file's code area instead of carrying the file header off screen; the wrapper is pinned with an `overflow-x: hidden` guard so headers can never scroll away again (same fix covers desktop unified no-wrap).
- **Diff viewer**: file sections can be collapsed from their headers (chevron, `aria-expanded`); collapsed sections unmount their diff DOM, and search still matches their header paths.

Tests were added for the session-step grouping/previews and the Alt+number shortcut mapping.

## Verification

- `bun run lint`
- `bun run typecheck` (web + server)
- `bun run test` — 351 pass, 0 fail
- `bun run build`
- Manual checks in headless Chrome at 390px (mobile) and 800–1280px (desktop) viewports covering: markdown dialog toggle, inspector step expansion, Alt+number triggering, diff search, wrap modes, per-section horizontal scroll with long lines, and section collapse.
