### PR TITLE
Handle browser WebSocket backpressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Keep browser WebSocket connections open when Bun queues outbound data under
+  backpressure, while retaining the 8 MiB slow-client protection.
+
 ## 0.3.4 - 2026-08-17
 
 ### Added

--- a/server/src/bridge/websocket-send.test.ts
+++ b/server/src/bridge/websocket-send.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+import {
+  sendWebSocketMessage,
+  WS_BACKPRESSURE_LIMIT_BYTES,
+} from "./websocket-send";
+
+function createWebSocket({
+  bufferedAmount = 0,
+  bufferedAmounts,
+  sendResult = 1,
+  sendError,
+}: {
+  bufferedAmount?: number;
+  bufferedAmounts?: number[];
+  sendResult?: number;
+  sendError?: Error;
+} = {}) {
+  const sent: string[] = [];
+  const closes: Array<[number | undefined, string | undefined]> = [];
+  const queuedAmounts = [...(bufferedAmounts ?? [bufferedAmount])];
+  let lastBufferedAmount = bufferedAmount;
+  return {
+    closes,
+    sent,
+    ws: {
+      close(code?: number, reason?: string) {
+        closes.push([code, reason]);
+      },
+      getBufferedAmount() {
+        lastBufferedAmount = queuedAmounts.shift() ?? lastBufferedAmount;
+        return lastBufferedAmount;
+      },
+      send(payload: string) {
+        sent.push(payload);
+        if (sendError) throw sendError;
+        return sendResult;
+      },
+    },
+  };
+}
+
+function sendWithObservability(
+  ws: ReturnType<typeof createWebSocket>["ws"],
+  context = "terminal frame",
+) {
+  let cleanupCount = 0;
+  const warnings: string[] = [];
+  const result = sendWebSocketMessage(ws, "payload", {
+    cleanup: () => {
+      cleanupCount += 1;
+    },
+    context,
+    warn: (message) => warnings.push(message),
+  });
+  return { cleanupCount, result, warnings };
+}
+
+describe("browser WebSocket sending", () => {
+  test("keeps the connection open when Bun queues a message under backpressure", () => {
+    for (const sendResult of [-1, 7]) {
+      const { closes, sent, ws } = createWebSocket({ sendResult });
+      const outcome = sendWithObservability(ws);
+
+      expect(outcome).toEqual({ cleanupCount: 0, result: true, warnings: [] });
+      expect(sent).toEqual(["payload"]);
+      expect(closes).toEqual([]);
+    }
+  });
+
+  test("closes a slow connection when a queued send crosses the buffer limit", () => {
+    const bufferedAmount = WS_BACKPRESSURE_LIMIT_BYTES + 1;
+    const { closes, sent, ws } = createWebSocket({
+      bufferedAmounts: [0, bufferedAmount],
+      sendResult: -1,
+    });
+    const outcome = sendWithObservability(ws);
+
+    expect(outcome).toEqual({
+      cleanupCount: 1,
+      result: false,
+      warnings: [
+        `[bridge] closing slow websocket during terminal frame: ${bufferedAmount}B buffered`,
+      ],
+    });
+    expect(sent).toEqual(["payload"]);
+    expect(closes).toEqual([[1013, "client too slow"]]);
+  });
+
+  test("cleans up when Bun drops a message because of a connection issue", () => {
+    const { closes, sent, ws } = createWebSocket({ sendResult: 0 });
+    const outcome = sendWithObservability(ws, "workspace event");
+
+    expect(outcome).toEqual({
+      cleanupCount: 1,
+      result: false,
+      warnings: [
+        "[bridge] websocket send dropped during workspace event",
+      ],
+    });
+    expect(sent).toEqual(["payload"]);
+    expect(closes).toEqual([[undefined, undefined]]);
+  });
+
+  test("uses Bun's buffered amount API to close a persistently slow client", () => {
+    const bufferedAmount = WS_BACKPRESSURE_LIMIT_BYTES + 1;
+    const { closes, sent, ws } = createWebSocket({ bufferedAmount });
+    const outcome = sendWithObservability(ws);
+
+    expect(outcome).toEqual({
+      cleanupCount: 1,
+      result: false,
+      warnings: [
+        `[bridge] closing slow websocket during terminal frame: ${bufferedAmount}B buffered`,
+      ],
+    });
+    expect(sent).toEqual([]);
+    expect(closes).toEqual([[1013, "client too slow"]]);
+  });
+
+  test("logs and cleans up when sending throws", () => {
+    const { closes, sent, ws } = createWebSocket({
+      sendError: new Error("socket closed"),
+    });
+    const outcome = sendWithObservability(ws);
+
+    expect(outcome).toEqual({
+      cleanupCount: 1,
+      result: false,
+      warnings: [
+        "[bridge] websocket send failed during terminal frame: socket closed",
+      ],
+    });
+    expect(sent).toEqual(["payload"]);
+    expect(closes).toEqual([[undefined, undefined]]);
+  });
+});

--- a/server/src/bridge/websocket-send.ts
+++ b/server/src/bridge/websocket-send.ts
@@ -1,0 +1,87 @@
+export const WS_BACKPRESSURE_LIMIT_BYTES = 8 * 1024 * 1024;
+
+interface WebSocketSendTarget {
+  close(code?: number, reason?: string): void;
+  getBufferedAmount(): number;
+  send(payload: string): number;
+}
+
+interface WebSocketSendOptions {
+  cleanup: () => void;
+  context?: string;
+  warn?: (message: string) => void;
+}
+
+interface WebSocketSendContext {
+  cleanup: () => void;
+  context: string;
+  warn: (message: string) => void;
+}
+
+function closeWebSocket(
+  ws: Pick<WebSocketSendTarget, "close">,
+  context: string,
+  warn: (message: string) => void,
+  code?: number,
+  reason?: string,
+): void {
+  try {
+    ws.close(code, reason);
+  } catch (error) {
+    warn(
+      `[bridge] websocket close failed during ${context}: ${(error as Error).message}`,
+    );
+  }
+}
+
+function closeSlowWebSocket(
+  ws: WebSocketSendTarget,
+  { cleanup, context, warn }: WebSocketSendContext,
+): boolean {
+  const bufferedAmount = ws.getBufferedAmount();
+  if (
+    !Number.isFinite(bufferedAmount) ||
+    bufferedAmount <= WS_BACKPRESSURE_LIMIT_BYTES
+  ) {
+    return false;
+  }
+
+  warn(
+    `[bridge] closing slow websocket during ${context}: ${bufferedAmount}B buffered`,
+  );
+  cleanup();
+  closeWebSocket(ws, context, warn, 1013, "client too slow");
+  return true;
+}
+
+export function sendWebSocketMessage(
+  ws: WebSocketSendTarget,
+  payload: string,
+  {
+    cleanup,
+    context = "message",
+    warn = (message) => console.warn(message),
+  }: WebSocketSendOptions,
+): boolean {
+  const sendContext = { cleanup, context, warn };
+  try {
+    if (closeSlowWebSocket(ws, sendContext)) return false;
+
+    const result = ws.send(payload);
+    if (result === 0) {
+      cleanup();
+      warn(`[bridge] websocket send dropped during ${context}`);
+      closeWebSocket(ws, context, warn);
+      return false;
+    }
+    if (result === -1 && closeSlowWebSocket(ws, sendContext)) return false;
+    return true;
+  } catch (error) {
+    cleanup();
+    warn(
+      `[bridge] websocket send failed during ${context}: ${(error as Error).message}`,
+    );
+    closeWebSocket(ws, context, warn);
+    return false;
+  }
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -21,6 +21,7 @@ import { createSettingsRpcHandler } from "./bridge/settings-rpc";
 import { serveStatic } from "./http/static-files";
 import { createSshTunnelManager } from "./bridge/ssh-tunnel";
 import { createTerminalBridge } from "./bridge/terminal-bridge";
+import { sendWebSocketMessage } from "./bridge/websocket-send";
 import {
   createUpdateHandlers,
   UPDATE_HTTP_IDLE_TIMEOUT_SECONDS,
@@ -89,8 +90,6 @@ interface RpcRequest {
   method: string;
   params?: Record<string, unknown>;
 }
-
-const WS_BACKPRESSURE_LIMIT_BYTES = 8 * 1024 * 1024;
 
 const socketPath = config.socketPath;
 const clientSocketPath = config.clientSocketPath;
@@ -350,37 +349,10 @@ function safeSend(
   payload: string,
   context = "message",
 ): boolean {
-  const bufferedAmount = Number((ws as any).bufferedAmount ?? 0);
-  if (Number.isFinite(bufferedAmount) && bufferedAmount > WS_BACKPRESSURE_LIMIT_BYTES) {
-    console.warn(
-      `[bridge] closing slow websocket during ${context}: ${bufferedAmount}B buffered`,
-    );
-    cleanupWs(ws);
-    try {
-      ws.close(1013, "client too slow");
-    } catch {}
-    return false;
-  }
-  try {
-    const result = ws.send(payload);
-    if (result === -1) {
-      cleanupWs(ws);
-      try {
-        ws.close();
-      } catch {}
-      return false;
-    }
-    return true;
-  } catch (e) {
-    cleanupWs(ws);
-    console.warn(
-      `[bridge] websocket send failed during ${context}: ${(e as Error).message}`,
-    );
-    try {
-      ws.close();
-    } catch {}
-    return false;
-  }
+  return sendWebSocketMessage(ws, payload, {
+    cleanup: () => cleanupWs(ws),
+    context,
+  });
 }
 
 // Broadcast pushed Herdr events to every connected browser.


### PR DESCRIPTION
## Summary

- Treat Bun WebSocket send result `-1` as an accepted, queued message instead of closing the browser connection.
- Treat result `0` as a dropped message and log the send failure before cleanup.
- Use Bun's `getBufferedAmount()` API for the existing 8 MiB slow-client limit, checking again after a backpressured send crosses the limit.
- Add focused regression coverage for queued, dropped, over-limit, and throwing sends.

Fixes #10.

## Verification

- `npx --yes bun@1.3.14 run lint`
- `npx --yes bun@1.3.14 run typecheck`
- `npx --yes bun@1.3.14 test --timeout 10000` — 354 passed
- Focused WebSocket/thin-client/terminal-bridge tests — 24 passed
- `npx --yes bun@1.3.14 run build:darwin-arm64`
- Built binary smoke test: `herdr-gui 0.3.4`
