### PR TITLE
Release 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,27 @@
 # Changelog
 
-## Unreleased
+## 0.3.5 - 2026-08-18
+
+### Added
+
+- View full agent messages as sanitized rendered Markdown or raw text.
+- Collapse individual file sections in the Diff Viewer.
+
+### Changed
+
+- Present Session Inspector activity chronologically as collapsible steps with
+  concise previews.
+- Run numbered command-menu actions with `Alt+1` through `Alt+9` to avoid
+  browser-reserved Command-number shortcuts.
+- Improve mobile and no-wrap Diff Viewer layouts, keeping file headers and
+  navigation controls visible while code scrolls.
 
 ### Fixed
 
 - Keep browser WebSocket connections open when Bun queues outbound data under
-  backpressure, while retaining the 8 MiB slow-client protection.
+  backpressure, while retaining the 8 MiB slow-client protection and accurate
+  disconnect cleanup.
+- Restore text selection after releasing a pane divider outside the window.
 
 ## 0.3.4 - 2026-08-17
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "herdr-gui",
   "private": true,
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "A web GUI client for Herdr (local socket bridge + React dashboard).",
   "license": "MIT",
   "author": "Arthur",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "herdr-gui-server",
   "private": true,
-  "version": "0.3.4",
+  "version": "0.3.5",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "herdr-gui-web",
   "private": true,
-  "version": "0.3.4",
+  "version": "0.3.5",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump the root, web, and server package versions to `0.3.5`.
- Finalize the `0.3.5` changelog for the agent-viewer and Diff Viewer usability improvements, command-menu shortcut change, and browser WebSocket backpressure fix.

## Verification

- `npx --yes bun@1.3.14 run lint`
- `npx --yes bun@1.3.14 run typecheck`
- `npx --yes bun@1.3.14 test --timeout 10000` — 357 passed
- Built and inspected release packages for:
  - `linux-x64`
  - `linux-arm64`
  - `darwin-x64`
  - `darwin-arm64`
- Verified archive contents, `VERSION` metadata, SHA-256 checksums, update manifests, executable formats, and the native Darwin arm64 version output.
