### PR TITLE
Add page reload to application menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Reload the current browser page or standalone PWA from the application menu.
+
 ## 0.3.5 - 2026-08-18
 
 ### Added

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -216,6 +216,7 @@ preserved in the browser.
 - Installable as a standalone PWA from iOS/iPadOS Safari, macOS Safari, Chrome,
   or Edge. PWA mode removes browser chrome but still requires a reachable
   herdr-gui server; it does not provide offline access.
+- Reload the current browser or standalone PWA from **Menu → Reload page**.
 
 Mobile shortcut layouts and appearance preferences are stored in the current
 browser and do not change Herdr server configuration.
@@ -253,7 +254,7 @@ The in-app reference is available from **Menu → Keyboard shortcuts**.
 | Shortcut | Action |
 | --- | --- |
 | `Cmd/Ctrl+K` | Open or close the command menu |
-| `Cmd+1` … `Cmd+9` while the command menu is open | Run the corresponding numbered visible action |
+| `Alt/Option+1` … `Alt/Option+9` while the command menu is open | Run the corresponding numbered visible action |
 | `Ctrl+Tab` / `Ctrl+Shift+Tab` | Open and navigate the recent Pane switcher |
 | `Cmd+B` | Toggle the desktop sidebar |
 | `Cmd+T` | Create a tab in the focused workspace |
@@ -265,9 +266,8 @@ The in-app reference is available from **Menu → Keyboard shortcuts**.
 | `Ctrl+Shift+G` | Open Diff Viewer |
 | `Esc` | Dismiss the current menu, dialog, notification, or update banner |
 
-A host browser can reserve shortcuts such as `Cmd+1` … `Cmd+9`, `Cmd+T`, and
-`Cmd+W`; they are most reliable in an installed PWA or another
-standalone/webview host.
+A host browser can reserve shortcuts such as `Cmd+T` and `Cmd+W`; they are most
+reliable in an installed PWA or another standalone/webview host.
 
 ### Terminal
 

--- a/web/src/components/ConfigMenu.test.ts
+++ b/web/src/components/ConfigMenu.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { reloadApplicationPage } from "./ConfigMenu";
+
+describe("application menu actions", () => {
+  test("reloads the current page", () => {
+    let reloadCount = 0;
+
+    reloadApplicationPage({
+      reload() {
+        reloadCount += 1;
+      },
+    });
+
+    expect(reloadCount).toBe(1);
+  });
+});

--- a/web/src/components/ConfigMenu.tsx
+++ b/web/src/components/ConfigMenu.tsx
@@ -11,6 +11,7 @@ import {
   Palette,
   Pause,
   Play,
+  RefreshCw,
   ScrollText,
   Server,
   Sun,
@@ -36,6 +37,12 @@ import { MobileTerminalShortcutsDialog } from "./MobileTerminalShortcutsDialog";
 
 const APP_VERSION = packageJson.version;
 export const CONFIG_MENU_ID = "herdr-config-menu";
+
+export function reloadApplicationPage(
+  target: Pick<Location, "reload"> = window.location,
+) {
+  target.reload();
+}
 
 type HealthInfo = {
   socket?: string;
@@ -337,6 +344,15 @@ export function ConfigMenu({
                 onClick={() => {
                   setOpen(false);
                   setShortcutsOpen(true);
+                }}
+              />
+              <ConfigMenuItem
+                icon={<RefreshCw size={15} />}
+                label="Reload page"
+                description="Refresh the application"
+                onClick={() => {
+                  setOpen(false);
+                  reloadApplicationPage();
                 }}
               />
               <ConfigMenuItem

--- a/web/src/components/ShortcutLookupDialog.tsx
+++ b/web/src/components/ShortcutLookupDialog.tsx
@@ -14,7 +14,7 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
     title: "Global",
     shortcuts: [
       { keys: "Cmd/Ctrl+K", description: "Open or close the command menu" },
-      { keys: "Cmd+1 ... Cmd+9 in menu", description: "Run a numbered command menu action" },
+      { keys: "Alt/Option+1 ... Alt/Option+9 in menu", description: "Run a numbered command menu action" },
       { keys: "Cmd+B", description: "Toggle the sidebar on desktop" },
       { keys: "Ctrl+Tab / Ctrl+Shift+Tab", description: "Open the recent pane switcher" },
       { keys: "Cmd+T", description: "Create a tab in the focused workspace" },


### PR DESCRIPTION
## Summary

- Add **Reload page** to **Menu → Help & updates** so standalone PWAs can refresh without browser chrome.
- Route the action through the browser's native `location.reload()` behavior.
- Add regression coverage for the reload action.
- Document the PWA menu action and correct the displayed numbered-action shortcut to `Alt/Option+1` through `Alt/Option+9`.

## Verification

- `npx --yes bun@1.3.14 run lint`
- `npx --yes bun@1.3.14 run typecheck`
- `npx --yes bun@1.3.14 test --timeout 10000` — 358 passed
- Focused menu tests — 8 passed
- `npx --yes bun@1.3.14 run build:darwin-arm64`
- Built binary smoke test: `herdr-gui 0.3.5`
