### PR TITLE
Polish dialogs and harden Apple terminal input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,16 @@
   connection testing, automatic SSH supervision, and a connection manager UI.
 - Reload the current browser page or standalone PWA from the application menu.
 
+### Changed
+
+- Refine dialogs and notifications with consistent icon controls, clearer action
+  hierarchy, and English date and relative-time presentation.
+
 ### Fixed
 
+- Recover Apple IME commits when WebKit emits input before or without keydown or
+  reports a different keyup code, without replaying text already sent from
+  keypress.
 - Keep connection-scoped RPC, HTTP, terminal, clipboard, file, Git, worktree,
   agent, and settings activity bound to the selected server generation so stale
   work cannot cross into a replacement connection.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,10 +1,14 @@
 import {
+  CheckCircle2,
   ChevronLeft,
   ChevronRight,
+  CircleAlert,
   FileDiff,
   FileText,
   FolderTree,
   History,
+  Info,
+  LoaderCircle,
   MoreHorizontal,
   PanelTop,
   Plug,
@@ -25,6 +29,7 @@ import packageJson from "../package.json";
 import { type AccentColor, normalizeAccentColor } from "./appearance";
 import { AgentIcon } from "./components/AgentIcon";
 import { AgentPanel } from "./components/AgentPanel";
+import { CloseButton } from "./components/CloseButton";
 import { CommandCombobox } from "./components/CommandCombobox";
 import { CONFIG_MENU_ID, ConfigMenu } from "./components/ConfigMenu";
 import { ConnectionSwitcher } from "./components/ConnectionSwitcher";
@@ -147,6 +152,28 @@ function NoticeDetail({ notice }: { notice: Notice }) {
     );
   }
   return <p>{notice.detail}</p>;
+}
+
+function ToastMark({
+  kind,
+  loading = false,
+}: {
+  kind: Notice["kind"];
+  loading?: boolean;
+}) {
+  const Mark = loading
+    ? LoaderCircle
+    : kind === "success"
+      ? CheckCircle2
+      : kind === "error"
+        ? CircleAlert
+        : Info;
+
+  return (
+    <span className="toast-mark" aria-hidden="true">
+      <Mark size={16} strokeWidth={2.1} />
+    </span>
+  );
 }
 
 export type Theme = "dark" | "light";
@@ -1864,7 +1891,7 @@ export default function App() {
               }`}
               role="status"
             >
-              <span className="toast-mark" />
+              <ToastMark kind="info" loading={s.updateInstalling} />
               <div className="toast-content">
                 <strong>
                   herdr-gui {s.updateInfo.latest_version} is available
@@ -1898,15 +1925,12 @@ export default function App() {
                   </button>
                 </div>
               </div>
-              <button
-                type="button"
-                className="toast-close"
+              <CloseButton
+                variant="toast"
+                label="Dismiss update notification"
                 onClick={() => store.dismissUpdate()}
-                aria-label="Dismiss update notification"
                 disabled={s.updateInstalling}
-              >
-                x
-              </button>
+              />
             </div>
           ) : null}
           {s.notice ? (
@@ -1916,7 +1940,7 @@ export default function App() {
               }`}
               role={s.notice.kind === "error" ? "alert" : "status"}
             >
-              <span className="toast-mark" />
+              <ToastMark kind={s.notice.kind} loading={s.notice.loading} />
               <div className="toast-content">
                 <strong>{s.notice.message}</strong>
                 <NoticeDetail notice={s.notice} />
@@ -1935,14 +1959,11 @@ export default function App() {
                   </div>
                 ) : null}
               </div>
-              <button
-                type="button"
-                className="toast-close"
+              <CloseButton
+                variant="toast"
+                label="Dismiss notification"
                 onClick={() => store.clearNotice()}
-                aria-label="Dismiss notification"
-              >
-                x
-              </button>
+              />
             </div>
           ) : null}
         </div>
@@ -1986,7 +2007,7 @@ export default function App() {
         <div
           className="resizer"
           onPointerDown={startResize}
-          title="拖动调整宽度"
+          title="Drag to resize sidebar"
         />
         <main
           className={`main ${

--- a/web/src/components/AgentHistoryDrawer.tsx
+++ b/web/src/components/AgentHistoryDrawer.tsx
@@ -3,6 +3,7 @@ import { Bot, Copy, Download, Eye, RefreshCw, X } from "lucide-react";
 import { useStore } from "../store";
 import { useConnectionClient } from "../useConnectionClient";
 import type { Pane } from "../types";
+import { formatUiRelativeTime, UI_LOCALE } from "../uiLocale";
 import { shortId } from "../utils";
 import { AgentIcon } from "./AgentIcon";
 import { AgentMessageDialog } from "./AgentMessageDialog";
@@ -43,7 +44,7 @@ type AgentHistory = {
 function formatHistoryTime(sentAt: string) {
   const time = new Date(sentAt);
   if (Number.isNaN(time.getTime())) return sentAt;
-  return time.toLocaleString([], {
+  return time.toLocaleString(UI_LOCALE, {
     month: "short",
     day: "numeric",
     hour: "2-digit",
@@ -56,13 +57,12 @@ function formatRelativeTime(timestamp: string) {
   if (Number.isNaN(time.getTime())) return "Unknown";
   const seconds = Math.round((time.getTime() - Date.now()) / 1000);
   const absoluteSeconds = Math.abs(seconds);
-  const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
-  if (absoluteSeconds < 60) return formatter.format(seconds, "second");
+  if (absoluteSeconds < 60) return formatUiRelativeTime(seconds, "second");
   if (absoluteSeconds < 3600)
-    return formatter.format(Math.round(seconds / 60), "minute");
+    return formatUiRelativeTime(Math.round(seconds / 60), "minute");
   if (absoluteSeconds < 86400)
-    return formatter.format(Math.round(seconds / 3600), "hour");
-  return formatter.format(Math.round(seconds / 86400), "day");
+    return formatUiRelativeTime(Math.round(seconds / 3600), "hour");
+  return formatUiRelativeTime(Math.round(seconds / 86400), "day");
 }
 
 function messageSummary(text: string) {

--- a/web/src/components/AgentMessageDialog.tsx
+++ b/web/src/components/AgentMessageDialog.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from "react";
-import { Copy, X } from "lucide-react";
+import { Copy } from "lucide-react";
+import { UI_LOCALE } from "../uiLocale";
+import { CloseButton } from "./CloseButton";
 import { focusDialogElement } from "./dialogFocus";
 import { MarkdownPreview } from "./markdown";
 
@@ -12,7 +14,7 @@ type AgentMessage = {
 function formatMessageTime(sentAt: string) {
   const time = new Date(sentAt);
   if (Number.isNaN(time.getTime())) return sentAt;
-  return time.toLocaleString([], {
+  return time.toLocaleString(UI_LOCALE, {
     dateStyle: "medium",
     timeStyle: "short",
   });
@@ -99,15 +101,7 @@ export function AgentMessageDialog({
             >
               <Copy size={15} />
             </button>
-            <button
-              type="button"
-              className="agent-history-icon"
-              onClick={onClose}
-              aria-label="Close message"
-              title="Close"
-            >
-              <X size={15} />
-            </button>
+            <CloseButton label="Close message" onClick={onClose} />
           </div>
         </div>
         {viewMode === "rendered" ? (

--- a/web/src/components/AgentSessionPreviewDialog.tsx
+++ b/web/src/components/AgentSessionPreviewDialog.tsx
@@ -7,10 +7,10 @@ import {
   FileText,
   Info,
   Wrench,
-  X,
 } from "lucide-react";
 import { useStore } from "../store";
 import type { Pane } from "../types";
+import { UI_LOCALE } from "../uiLocale";
 import { useConnectionClient } from "../useConnectionClient";
 import { shortId } from "../utils";
 import { AgentIcon } from "./AgentIcon";
@@ -29,20 +29,24 @@ import {
   groupTrajectoryTurns,
   toolArgumentsPreview,
 } from "./agentSession";
+import { CloseButton } from "./CloseButton";
 import { focusDialogElement } from "./dialogFocus";
 
 function formatStepTime(timestamp?: string) {
   if (!timestamp) return "";
   const date = new Date(timestamp);
   if (Number.isNaN(date.getTime())) return timestamp;
-  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  return date.toLocaleTimeString(UI_LOCALE, {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }
 
 function formatSessionTime(timestamp?: string) {
   if (!timestamp) return "-";
   const date = new Date(timestamp);
   if (Number.isNaN(date.getTime())) return timestamp;
-  return date.toLocaleString([], {
+  return date.toLocaleString(UI_LOCALE, {
     dateStyle: "medium",
     timeStyle: "short",
   });
@@ -161,15 +165,7 @@ export function AgentSessionPreviewDialog({
               </span>
             </div>
           </div>
-          <button
-            type="button"
-            className="agent-history-icon"
-            onClick={onClose}
-            aria-label="Close Session Inspector"
-            title="Close"
-          >
-            <X size={16} />
-          </button>
+          <CloseButton label="Close Session Inspector" onClick={onClose} />
         </div>
 
         {summary?.status === "ok" ? (

--- a/web/src/components/AutoSyncRepositoriesDialog.tsx
+++ b/web/src/components/AutoSyncRepositoriesDialog.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { store } from "../store";
+import { UI_LOCALE } from "../uiLocale";
 import { useConnectionClient } from "../useConnectionClient";
+import { CloseButton } from "./CloseButton";
 import { focusDialogElement } from "./dialogFocus";
 
 type AutoSyncStatus = "updated" | "up_to_date" | "skipped" | "failed";
@@ -134,9 +136,7 @@ export function AutoSyncRepositoriesDialog({
             <h2>Automatic Branch Updates</h2>
             <p>Saved configurations run when their workspace is open</p>
           </div>
-          <button className="ghost" onClick={onClose} aria-label="Close">
-            x
-          </button>
+          <CloseButton onClick={onClose} />
         </div>
 
         {loading ? (
@@ -260,5 +260,5 @@ function formatLastRun(value?: string) {
   const date = new Date(value);
   return Number.isNaN(date.valueOf())
     ? value
-    : "Last run " + date.toLocaleString();
+    : "Last run " + date.toLocaleString(UI_LOCALE);
 }

--- a/web/src/components/ChangelogDialog.tsx
+++ b/web/src/components/ChangelogDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import changelog from "../../../CHANGELOG.md?raw";
+import { CloseButton } from "./CloseButton";
 
 export function ChangelogDialog({
   open,
@@ -30,14 +31,7 @@ export function ChangelogDialog({
       >
         <div className="modal-head">
           <h2>Changelog</h2>
-          <button
-            type="button"
-            className="ghost"
-            onClick={onClose}
-            aria-label="Close"
-          >
-            x
-          </button>
+          <CloseButton onClick={onClose} />
         </div>
         <pre className="changelog-content">{changelog}</pre>
       </div>

--- a/web/src/components/CloseButton.tsx
+++ b/web/src/components/CloseButton.tsx
@@ -1,0 +1,38 @@
+import { X } from "lucide-react";
+import type { ButtonHTMLAttributes } from "react";
+
+type CloseButtonProps = Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  "aria-label" | "children" | "type"
+> & {
+  label?: string;
+  variant?: "dialog" | "toast";
+};
+
+export function CloseButton({
+  label = "Close",
+  variant = "dialog",
+  className,
+  title,
+  ...buttonProps
+}: CloseButtonProps) {
+  const classes = ["close-button", `close-button-${variant}`, className]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <button
+      {...buttonProps}
+      type="button"
+      className={classes}
+      aria-label={label}
+      title={title ?? label}
+    >
+      <X
+        size={variant === "toast" ? 15 : 17}
+        strokeWidth={2.2}
+        aria-hidden="true"
+      />
+    </button>
+  );
+}

--- a/web/src/components/ConnectionSwitcher.tsx
+++ b/web/src/components/ConnectionSwitcher.tsx
@@ -29,6 +29,7 @@ import {
   suggestConnectionId,
 } from "../connectionProfiles";
 import { store, useStore } from "../store";
+import { CloseButton } from "./CloseButton";
 import { focusDialogElement } from "./dialogFocus";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 
@@ -704,15 +705,7 @@ function ConnectionManagerDialog({ onClose }: { onClose: () => void }) {
             <h2 id="connection-manager-title">Manage connections</h2>
             <p>Profiles are shared by authenticated browsers on this bridge.</p>
           </div>
-          <button
-            type="button"
-            className="icon-button"
-            onClick={onClose}
-            aria-label="Close"
-            disabled={!!pending}
-          >
-            <X size={16} />
-          </button>
+          <CloseButton onClick={onClose} disabled={!!pending} />
         </div>
         <BrowserTransportStatus />
         <div className="connection-manager-toolbar">

--- a/web/src/components/CreateWorkspaceDialog.tsx
+++ b/web/src/components/CreateWorkspaceDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { luckyWorkspaceName } from "../luckyName";
 import { store } from "../store";
+import { CloseButton } from "./CloseButton";
 import { focusDialogElement } from "./dialogFocus";
 
 export function CreateWorkspaceDialog({
@@ -52,14 +53,7 @@ export function CreateWorkspaceDialog({
       >
         <div className="modal-head">
           <h2>Create Workspace</h2>
-          <button
-            type="button"
-            className="ghost"
-            onClick={onClose}
-            aria-label="Close"
-          >
-            x
-          </button>
+          <CloseButton onClick={onClose} />
         </div>
 
         <label className="form-field">

--- a/web/src/components/FileExplorerDialog.tsx
+++ b/web/src/components/FileExplorerDialog.tsx
@@ -33,6 +33,7 @@ import type {
   GitDiffKind,
   GitDiffSummary,
 } from "../types";
+import { CloseButton } from "./CloseButton";
 import { ConfirmDialog } from "./ModalDialogs";
 import {
   FilePreviewContent,
@@ -1599,16 +1600,7 @@ function FileExplorerContent({
     <>
       <div className="modal-head">
         <h2>File Explorer</h2>
-        {showCloseButton ? (
-          <button
-            type="button"
-            className="ghost"
-            onClick={onClose}
-            aria-label="Close"
-          >
-            x
-          </button>
-        ) : null}
+        {showCloseButton ? <CloseButton onClick={onClose} /> : null}
       </div>
 
       {workspace ? (

--- a/web/src/components/MobileTerminalShortcutsDialog.tsx
+++ b/web/src/components/MobileTerminalShortcutsDialog.tsx
@@ -14,6 +14,7 @@ import {
   type MobileTerminalShortcutRows,
   type MobileTerminalSideShortcuts,
 } from "../mobileTerminalShortcuts";
+import { CloseButton } from "./CloseButton";
 import { focusDialogElement } from "./dialogFocus";
 import {
   Command,
@@ -323,14 +324,7 @@ export function MobileTerminalShortcutsDialog({
               panel and up to four right-side buttons.
             </p>
           </div>
-          <button
-            type="button"
-            className="ghost"
-            onClick={onClose}
-            aria-label="Close"
-          >
-            x
-          </button>
+          <CloseButton onClick={onClose} />
         </div>
 
         <div className="mobile-shortcut-slot-board" aria-label="Shortcut slots">

--- a/web/src/components/ModalDialogs.tsx
+++ b/web/src/components/ModalDialogs.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { CloseButton } from "./CloseButton";
 import { focusDialogElement } from "./dialogFocus";
 
 export function TextInputDialog({
@@ -59,14 +60,7 @@ export function TextInputDialog({
       >
         <div className="modal-head">
           <h2>{title}</h2>
-          <button
-            type="button"
-            className="ghost"
-            onClick={onClose}
-            aria-label="Close"
-          >
-            x
-          </button>
+          <CloseButton onClick={onClose} />
         </div>
 
         <label className="form-field">
@@ -155,14 +149,7 @@ export function ConfirmDialog({
       >
         <div className="modal-head">
           <h2>{title}</h2>
-          <button
-            type="button"
-            className="ghost"
-            onClick={onClose}
-            aria-label="Close"
-          >
-            x
-          </button>
+          <CloseButton onClick={onClose} />
         </div>
 
         <p className="modal-body-text">{message}</p>
@@ -239,14 +226,7 @@ export function MessageDialog({
       >
         <div className="modal-head">
           <h2>{title}</h2>
-          <button
-            type="button"
-            className="ghost"
-            onClick={onClose}
-            aria-label="Close"
-          >
-            x
-          </button>
+          <CloseButton onClick={onClose} />
         </div>
 
         <p className="modal-body-text">{message}</p>

--- a/web/src/components/ShortcutLookupDialog.tsx
+++ b/web/src/components/ShortcutLookupDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { CloseButton } from "./CloseButton";
 import { focusDialogElement } from "./dialogFocus";
 
 type ShortcutGroup = {
@@ -175,14 +176,7 @@ export function ShortcutLookupDialog({
       >
         <div className="modal-head">
           <h2>Shortcut Lookup</h2>
-          <button
-            type="button"
-            className="ghost"
-            onClick={onClose}
-            aria-label="Close"
-          >
-            x
-          </button>
+          <CloseButton onClick={onClose} />
         </div>
 
         <div className="shortcut-list">

--- a/web/src/components/TabBar.tsx
+++ b/web/src/components/TabBar.tsx
@@ -138,7 +138,7 @@ export function TabBar({ mobile = false }: { mobile?: boolean }) {
                     e.stopPropagation();
                     setPendingCloseTabId(t.tab_id);
                   }}
-                  title="关闭 tab"
+                  title="Close tab"
                 >
                   ×
                 </button>
@@ -148,7 +148,7 @@ export function TabBar({ mobile = false }: { mobile?: boolean }) {
           <button
             className="tabbar-add"
             onClick={() => store.createTab(focusedWs.workspace_id)}
-            title="新建 tab"
+            title="New tab"
           >
             +
           </button>

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -26,6 +26,7 @@ import {
   terminalPushMatches,
   type TerminalConnectionIdentity,
 } from "../terminalConnection";
+import { CloseButton } from "./CloseButton";
 import { MessageDialog } from "./ModalDialogs";
 import { requestFilePreview } from "./FileExplorerDialog";
 import { FilePreviewContent } from "./FilePreviewContent";
@@ -56,9 +57,11 @@ import {
   modifiedEnterSequence,
 } from "../terminalKeys";
 import {
+  isTerminalImeCommittedInputType,
   terminalImeEventTime,
   terminalImeFallbackText,
   TerminalImeFallbackTracker,
+  TerminalImeKeyEventTracker,
   TerminalImeTextareaFallbackTracker,
 } from "../terminalIme";
 import { terminalPageScroll, terminalWheelScroll } from "../terminalScroll";
@@ -878,6 +881,7 @@ export function TerminalView({
     );
 
     const imeFallback = new TerminalImeFallbackTracker();
+    const imeKeyEvent = new TerminalImeKeyEventTracker();
     const imeTextareaFallback = new TerminalImeTextareaFallbackTracker();
     const readTerminalTextareaSnapshot = (): TerminalPasteTextareaSnapshot => {
       const textarea = term.textarea;
@@ -905,6 +909,7 @@ export function TerminalView({
       if (!shouldSend) return;
       const terminalId = desiredTerminalRef.current;
       if (!terminalId) return;
+      imeKeyEvent.recordXtermData(unsuppressedData);
       const bytes = new TextEncoder().encode(unsuppressedData);
       sendBytes(connectionClient, bytes, terminalId).catch(() => {});
     });
@@ -1099,7 +1104,7 @@ export function TerminalView({
             const items = await withTimeout(
               navigator.clipboard.read(),
               CLIPBOARD_READ_TIMEOUT_MS,
-              "读取剪贴板超时",
+              "Clipboard read timed out",
             );
             for (const item of items) {
               const imageType = item.types.find((type) =>
@@ -1109,7 +1114,7 @@ export function TerminalView({
                 const blob = await withTimeout(
                   item.getType(imageType),
                   CLIPBOARD_READ_TIMEOUT_MS,
-                  "读取剪贴板图片超时",
+                  "Clipboard image read timed out",
                 );
                 await pasteImage(blob, destinationPaneId);
                 return;
@@ -1120,12 +1125,12 @@ export function TerminalView({
                 const blob = await withTimeout(
                   item.getType("text/plain"),
                   CLIPBOARD_READ_TIMEOUT_MS,
-                  "读取剪贴板文本超时",
+                  "Clipboard text read timed out",
                 );
                 const text = await withTimeout(
                   blob.text(),
                   CLIPBOARD_READ_TIMEOUT_MS,
-                  "读取剪贴板文本超时",
+                  "Clipboard text read timed out",
                 );
                 await pasteText(text, destinationPaneId);
                 return;
@@ -1136,7 +1141,7 @@ export function TerminalView({
           const text = await withTimeout(
             navigator.clipboard.readText(),
             CLIPBOARD_READ_TIMEOUT_MS,
-            "读取剪贴板文本超时",
+            "Clipboard text read timed out",
           );
           await pasteText(text, destinationPaneId);
         });
@@ -1147,8 +1152,15 @@ export function TerminalView({
     const applePlatform = isApplePlatform();
     const appleTouchPlatform = applePlatform && navigator.maxTouchPoints > 0;
     const shouldHandleCtrlVPaste = !applePlatform;
+    const shouldRecoverCommittedImeInput = (input: InputEvent) =>
+      applePlatform &&
+      !terminalCompositionActive &&
+      isTerminalImeCommittedInputType(input.inputType);
 
     term.attachCustomKeyEventHandler((e) => {
+      if (applePlatform && e.type === "keydown") {
+        imeKeyEvent.begin();
+      }
       if (e.type === "keydown" && e.keyCode !== 229) {
         imeTextareaFallback.cancelPending();
       }
@@ -1187,7 +1199,7 @@ export function TerminalView({
           return false;
         }
         pasteFromBrowserClipboard().catch((err) => {
-          setUploadError(`粘贴失败：${(err as Error).message}`);
+          setUploadError(`Paste failed: ${(err as Error).message}`);
         });
         return false;
       }
@@ -1251,15 +1263,18 @@ export function TerminalView({
       imeTextareaFallback.begin(lastTerminalTextareaSnapshot.value);
     };
     const onTerminalKeyUp = (event: KeyboardEvent) => {
-      if (!applePlatform || event.keyCode !== 229) return;
+      imeKeyEvent.end();
+      if (!applePlatform || !imeTextareaFallback.hasPending()) return;
 
-      // Read synchronously: some third-party iOS keyboards expose the committed
-      // textarea value only during keyup. If it is not visible yet, keep the
-      // cycle pending for one final task, matching xterm's upstream fallback.
+      // A keydown reported as 229 can have a keyup reported as 0 or as the
+      // concrete key code. Flush the pending cycle regardless of keyup code.
+      // If the value is not visible yet, keep it for one final task, matching
+      // xterm's upstream fallback.
       flushTextareaImeFallback(event);
       scheduleImeTextareaFinal(event);
     };
     const onTerminalCompositionStart = () => {
+      imeKeyEvent.end();
       cancelCompositionSettle();
       terminalCompositionActive = true;
       cancelNativePasteFallback();
@@ -1281,6 +1296,7 @@ export function TerminalView({
       }, 0);
     };
     const onTerminalBlur = () => {
+      imeKeyEvent.end();
       cancelCompositionSettle();
       terminalCompositionActive = false;
       cancelNativePasteFallback();
@@ -1299,7 +1315,19 @@ export function TerminalView({
         }
         return;
       }
-      const fallbackText = terminalImeFallbackText(input);
+      if (shouldRecoverCommittedImeInput(input)) {
+        // Some third-party keyboards emit beforeinput/input without a preceding
+        // keydown, or emit input before keydown 229. Capture the pre-mutation
+        // value here so the input/keyup path can recover arbitrary committed
+        // text rather than punctuation only.
+        imeTextareaFallback.begin(readTerminalTextareaSnapshot().value);
+        scheduleImeTextareaFinal(input);
+        return;
+      }
+
+      const fallbackText = terminalCompositionActive
+        ? null
+        : terminalImeFallbackText(input);
       if (!fallbackText || !input.cancelable) return;
       const observedAt = performance.now();
       const eventAt = terminalImeEventTime(input, observedAt);
@@ -1313,10 +1341,11 @@ export function TerminalView({
     };
     const onTerminalTextInput = (e: Event) => {
       const input = e as InputEvent;
+      const xtermHandledCurrentInput = imeKeyEvent.consumeInput(input);
       const textareaSnapshot = readTerminalTextareaSnapshot();
+      const textareaBeforeInput = lastTerminalTextareaSnapshot;
       const hadPasteSnapshot = pasteTextareaBeforeInput !== null;
-      const beforePaste =
-        pasteTextareaBeforeInput ?? lastTerminalTextareaSnapshot;
+      const beforePaste = pasteTextareaBeforeInput ?? textareaBeforeInput;
       const destinationPaneId = hadPasteSnapshot
         ? pastePaneIdBeforeInput
         : (paneIdRef.current ?? null);
@@ -1360,7 +1389,7 @@ export function TerminalView({
         void runPasteOperation(() =>
           pasteText(pastedText, destinationPaneId),
         ).catch((error) => {
-          setUploadError(`文本粘贴失败：${(error as Error).message}`);
+          setUploadError(`Text paste failed: ${(error as Error).message}`);
         });
         return;
       }
@@ -1379,18 +1408,26 @@ export function TerminalView({
       pasteTextareaBeforeInput = null;
       pastePaneIdBeforeInput = null;
 
-      if (
-        applePlatform &&
-        !terminalCompositionActive &&
-        input.inputType === "insertText" &&
-        imeTextareaFallback.hasPending()
-      ) {
+      if (xtermHandledCurrentInput) {
+        // Safari still mutates the helper textarea after xterm handles some
+        // printable keys in keypress. Do not replay that same committed text.
+        imeTextareaFallback.cancelPending();
+        return;
+      }
+
+      if (shouldRecoverCommittedImeInput(input)) {
+        // beforeinput is not guaranteed on every WebKit keyboard. The previous
+        // observed textarea value is the best safe append-only baseline when it
+        // is absent; begin() preserves an earlier keydown/beforeinput baseline.
+        imeTextareaFallback.begin(textareaBeforeInput.value);
         const flushStatus = flushTextareaImeFallback(input);
         scheduleImeTextareaFinal(input);
         if (flushStatus === "handled") return;
       }
 
-      const fallbackText = terminalImeFallbackText(input);
+      const fallbackText = terminalCompositionActive
+        ? null
+        : terminalImeFallbackText(input);
       if (!fallbackText) return;
       const observedAt = performance.now();
       const eventAt = terminalImeEventTime(input, observedAt);
@@ -1453,7 +1490,7 @@ export function TerminalView({
             void runPasteOperation(() =>
               pasteText(text, destinationPaneId),
             ).catch((error) => {
-              setUploadError(`文本粘贴失败：${(error as Error).message}`);
+              setUploadError(`Text paste failed: ${(error as Error).message}`);
             });
           }, 0);
         }
@@ -1475,7 +1512,7 @@ export function TerminalView({
         );
       } catch (err) {
         setUploadError(
-          `${img ? "图片上传" : "文本粘贴"}失败：${(err as Error).message}`,
+          `${img ? "Image upload" : "Text paste"} failed: ${(err as Error).message}`,
         );
       }
     };
@@ -2051,14 +2088,7 @@ export function TerminalView({
           >
             <div className="modal-head">
               <h2>File Preview</h2>
-              <button
-                type="button"
-                className="ghost"
-                aria-label="Close"
-                onClick={closePathPreview}
-              >
-                x
-              </button>
+              <CloseButton onClick={closePathPreview} />
             </div>
             <FilePreviewContent
               entry={pathPreview.entry}

--- a/web/src/components/WorkspaceAutoSyncDialog.tsx
+++ b/web/src/components/WorkspaceAutoSyncDialog.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { store } from "../store";
+import { UI_LOCALE } from "../uiLocale";
 import { useConnectionClient } from "../useConnectionClient";
+import { CloseButton } from "./CloseButton";
 import { focusDialogElement } from "./dialogFocus";
 
 type AutoSyncStatus = "updated" | "up_to_date" | "skipped" | "failed";
@@ -121,9 +123,7 @@ export function WorkspaceAutoSyncDialog({
       >
         <div className="modal-head">
           <h2>Automatic Branch Updates</h2>
-          <button className="ghost" onClick={onClose} aria-label="Close">
-            x
-          </button>
+          <CloseButton onClick={onClose} />
         </div>
 
         <p className="auto-sync-description">
@@ -206,7 +206,7 @@ function SummaryRow({ label, value }: { label: string; value: string }) {
 function formatLastRun(value?: string) {
   if (!value) return "Not run yet";
   const date = new Date(value);
-  return Number.isNaN(date.valueOf()) ? value : date.toLocaleString();
+  return Number.isNaN(date.valueOf()) ? value : date.toLocaleString(UI_LOCALE);
 }
 
 function statusLabel(status?: AutoSyncStatus) {

--- a/web/src/components/WorkspaceTree.tsx
+++ b/web/src/components/WorkspaceTree.tsx
@@ -209,7 +209,7 @@ export function WorkspaceTree({ onSelect }: { onSelect?: () => void }) {
             <h2>Workspaces</h2>
             <button
               className="panel-add"
-              title="新建 workspace"
+              title="New workspace"
               onClick={() => setCreateOpen(true)}
             >
               +
@@ -258,7 +258,7 @@ export function WorkspaceTree({ onSelect }: { onSelect?: () => void }) {
             ) : null}
             <button
               className="panel-add"
-              title="新建 workspace"
+              title="New workspace"
               onClick={() => setCreateOpen(true)}
             >
               +

--- a/web/src/components/WorktreeHooksDialog.tsx
+++ b/web/src/components/WorktreeHooksDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { store } from "../store";
 import { useConnectionClient } from "../useConnectionClient";
+import { CloseButton } from "./CloseButton";
 
 const HOOKS = [
   ["setup", "Setup"],
@@ -133,9 +134,7 @@ export function WorktreeHooksDialog({
       >
         <div className="modal-head">
           <h2>Worktree Hooks</h2>
-          <button className="ghost" onClick={onClose} aria-label="Close">
-            x
-          </button>
+          <CloseButton onClick={onClose} />
         </div>
         <p className="hook-doc-note">
           Hooks are loaded from the current repository's <code>paseo.json</code>{" "}

--- a/web/src/components/WorktreeLifecycleDialog.tsx
+++ b/web/src/components/WorktreeLifecycleDialog.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { FolderOpen, GitBranch, RefreshCw, Settings, X } from "lucide-react";
+import { FolderOpen, GitBranch, RefreshCw, Settings } from "lucide-react";
 import { luckyWorktreeBranchName } from "../luckyName";
 import { useConnectionClient } from "../useConnectionClient";
 import { store, useStore } from "../store";
@@ -17,6 +17,7 @@ import {
   type WorktreeHookInfo,
   type WorktreeLifecycleRow,
 } from "../worktreeLifecycle";
+import { CloseButton } from "./CloseButton";
 import { ConfirmDialog, TextInputDialog } from "./ModalDialogs";
 import { WorktreeHooksDialog } from "./WorktreeHooksDialog";
 import { WorktreeOpenDialog } from "./WorktreeOpenDialog";
@@ -379,14 +380,7 @@ export function WorktreeLifecycleDialog({
                   className={repositoryLoading ? "is-spinning" : ""}
                 />
               </button>
-              <button
-                type="button"
-                className="ghost lifecycle-icon-button"
-                aria-label="Close"
-                onClick={onClose}
-              >
-                <X size={17} />
-              </button>
+              <CloseButton onClick={onClose} />
             </div>
           </div>
 

--- a/web/src/components/WorktreeOpenDialog.tsx
+++ b/web/src/components/WorktreeOpenDialog.tsx
@@ -3,6 +3,7 @@ import { store } from "../store";
 import { useConnectionClient } from "../useConnectionClient";
 import type { ExistingWorktree, WorktreeList } from "../types";
 import { resolveWorktreeOpenSource } from "../worktree";
+import { CloseButton } from "./CloseButton";
 import { focusDialogElement } from "./dialogFocus";
 
 function worktreeTitle(worktree: ExistingWorktree) {
@@ -176,14 +177,7 @@ export function WorktreeOpenDialog({
       >
         <div className="modal-head">
           <h2>Open Worktree</h2>
-          <button
-            type="button"
-            className="ghost"
-            onClick={onClose}
-            aria-label="Close"
-          >
-            x
-          </button>
+          <CloseButton onClick={onClose} />
         </div>
 
         {list ? (

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -418,51 +418,143 @@ body {
     sans-serif;
 }
 button {
-  background: var(--panel-2);
-  color: var(--text);
   border: 1px solid var(--border);
   border-radius: 8px;
+  background: var(--panel-2);
+  color: var(--text);
   padding: 6px 10px;
-  cursor: pointer;
+  font-family: inherit;
   font-size: 13px;
+  line-height: 1.2;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition:
+    border-color 140ms ease,
+    background-color 140ms ease,
+    color 140ms ease,
+    box-shadow 140ms ease,
+    transform 140ms ease;
 }
 button:hover:not(:disabled) {
   border-color: var(--accent);
+}
+button:focus-visible {
+  outline: none;
+  border-color: color-mix(in srgb, var(--accent) 72%, var(--border));
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+@media (forced-colors: active) {
+  button:focus-visible {
+    outline: 2px solid Highlight;
+    outline-offset: 2px;
+  }
 }
 button:disabled {
   opacity: 0.45;
   cursor: not-allowed;
 }
 button.ghost {
-  background: transparent;
   border-color: transparent;
+  background: transparent;
   padding: 4px 7px;
 }
-button.ghost:hover {
+button.ghost:hover:not(:disabled) {
   background: var(--panel-2);
 }
 button.danger {
   border-color: var(--danger-border);
+  background: var(--danger-soft);
   color: var(--danger-text);
 }
-button.danger:hover {
+button.danger:hover:not(:disabled) {
   border-color: var(--red);
+}
+.close-button {
+  width: 30px;
+  height: 30px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border-color: color-mix(in srgb, var(--border) 76%, transparent);
+  border-radius: 9px;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--panel-2) 86%, white 14%),
+    color-mix(in srgb, var(--panel) 94%, black 6%)
+  );
+  color: color-mix(in srgb, var(--muted) 82%, var(--text));
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 9%, transparent),
+    0 1px 2px color-mix(in srgb, black 22%, transparent);
+}
+.close-button svg {
+  pointer-events: none;
+  transition: transform 140ms ease;
+}
+.close-button:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--panel-2) 78%, var(--accent) 22%),
+    color-mix(in srgb, var(--panel) 88%, var(--accent) 12%)
+  );
+  color: var(--text-strong);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, white 12%, transparent),
+    0 4px 10px color-mix(in srgb, black 26%, transparent);
+  transform: translateY(-1px);
+}
+.close-button:hover:not(:disabled) svg {
+  transform: rotate(4deg);
+}
+.close-button:active:not(:disabled) {
+  box-shadow: inset 0 1px 3px color-mix(in srgb, black 22%, transparent);
+  transform: translateY(0) scale(0.96);
+}
+.close-button-toast {
+  width: 28px;
+  height: 28px;
+  margin: -2px -2px 0 0;
+  border-color: transparent;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel-2) 50%, transparent);
+  box-shadow: none;
+}
+.close-button-toast:hover:not(:disabled) {
+  border-color: color-mix(
+    in srgb,
+    var(--toast-tone, var(--accent)) 24%,
+    transparent
+  );
+  background: color-mix(
+    in srgb,
+    var(--toast-tone, var(--accent)) 12%,
+    var(--panel-2)
+  );
+  box-shadow: none;
 }
 input,
 textarea {
-  background: var(--input-bg);
-  color: var(--text);
   border: 1px solid var(--border);
   border-radius: 8px;
+  background: var(--input-bg);
+  color: var(--text);
   padding: 8px 11px;
-  font-size: 14px;
   font-family: inherit;
+  font-size: 14px;
   outline: none;
   resize: none;
+  transition:
+    border-color 140ms ease,
+    box-shadow 140ms ease,
+    background-color 140ms ease;
 }
 input:focus,
 textarea:focus {
   border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
 }
 .muted {
   color: var(--muted);
@@ -1241,54 +1333,96 @@ textarea:focus {
 .toast-viewport {
   position: fixed;
   z-index: 1500;
-  top: 58px;
+  top: 62px;
   right: 16px;
   width: min(440px, calc(100vw - 32px));
   display: grid;
-  gap: 8px;
+  gap: 10px;
   pointer-events: none;
 }
 .toast {
+  --toast-tone: var(--blue);
+  position: relative;
   display: grid;
-  grid-template-columns: 10px minmax(0, 1fr) 28px;
-  gap: 10px;
+  grid-template-columns: 26px minmax(0, 1fr) 28px;
+  gap: 11px;
   align-items: start;
-  padding: 12px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--panel);
+  overflow: hidden;
+  padding: 13px;
+  border: 1px solid color-mix(in srgb, var(--toast-tone) 34%, var(--border));
+  border-radius: 14px;
+  background: linear-gradient(
+    145deg,
+    color-mix(in srgb, var(--panel) 93%, white 7%),
+    color-mix(in srgb, var(--panel) 96%, var(--toast-tone) 4%)
+  );
   color: var(--text);
-  box-shadow: var(--shadow-lg);
+  box-shadow:
+    var(--shadow-lg),
+    inset 0 1px 0 color-mix(in srgb, white 8%, transparent);
   font-size: 13px;
   pointer-events: auto;
+  -webkit-backdrop-filter: blur(16px) saturate(1.12);
+  backdrop-filter: blur(16px) saturate(1.12);
+  animation: toast-in 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+.toast::before {
+  content: "";
+  position: absolute;
+  inset: 8px auto 8px 0;
+  width: 3px;
+  border-radius: 0 999px 999px 0;
+  background: var(--toast-tone);
+  box-shadow: 0 0 16px color-mix(in srgb, var(--toast-tone) 52%, transparent);
+}
+.toast:hover {
+  border-color: color-mix(in srgb, var(--toast-tone) 48%, var(--border));
+  box-shadow:
+    0 20px 48px color-mix(in srgb, black 38%, transparent),
+    inset 0 1px 0 color-mix(in srgb, white 10%, transparent);
+  transform: translateY(-1px);
 }
 .toast-mark {
-  width: 8px;
-  height: 8px;
-  margin-top: 5px;
-  border-radius: 50%;
-  background: var(--blue);
-  box-sizing: border-box;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid color-mix(in srgb, var(--toast-tone) 38%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--toast-tone) 13%, transparent);
+  color: var(--toast-tone);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 8%, transparent);
+}
+.toast-mark svg {
+  display: block;
 }
 .toast-content {
   min-width: 0;
+  padding-top: 2px;
 }
 .toast-content strong {
   display: block;
-  font-weight: 650;
+  color: var(--text-strong);
+  font-weight: 680;
   line-height: 1.3;
+  letter-spacing: -0.01em;
 }
 .toast-content p {
   margin: 6px 0 0;
   color: var(--muted);
-  line-height: 1.35;
+  line-height: 1.45;
 }
 .toast-content pre {
   margin: 0;
   overflow: auto;
   color: inherit;
   font:
-    12px / 1.35 ui-monospace,
+    12px / 1.45 ui-monospace,
     SFMono-Regular,
     Menlo,
     Consolas,
@@ -1297,15 +1431,16 @@ textarea:focus {
 }
 .toast-output {
   max-height: 180px;
-  margin-top: 8px;
+  margin-top: 9px;
   overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  background: color-mix(in srgb, var(--bg) 88%, black 12%);
+  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--input-bg) 92%, black 8%);
+  box-shadow: inset 0 1px 3px color-mix(in srgb, black 16%, transparent);
 }
 .toast-output-title {
-  padding: 5px 8px;
-  border-bottom: 1px solid var(--border);
+  padding: 6px 9px;
+  border-bottom: 1px solid var(--border-soft);
   color: var(--muted);
   font:
     11px / 1.3 ui-monospace,
@@ -1317,35 +1452,30 @@ textarea:focus {
 }
 .toast-output pre {
   max-height: 140px;
-  padding: 8px;
-}
-.toast-close {
-  width: 24px;
-  height: 24px;
-  padding: 0;
-  border-color: transparent;
-  background: transparent;
-  color: var(--muted);
-}
-.toast-close:hover {
-  background: var(--border-soft);
-  color: var(--text);
+  padding: 9px;
 }
 .toast-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 10px;
+  gap: 7px;
+  margin-top: 11px;
 }
 .toast-action {
-  height: 28px;
-  padding: 0 10px;
-  border-radius: 7px;
-  background: transparent;
+  min-height: 30px;
+  padding: 0 11px;
+  border-color: color-mix(in srgb, var(--border) 78%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel-2) 62%, transparent);
   color: var(--text);
+  font-size: 12px;
+  font-weight: 650;
+}
+.toast-action:hover:not(:disabled) {
+  background: var(--panel-2);
+  color: var(--text-strong);
 }
 .toast-action.primary {
-  border-color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 62%, var(--border));
   background: var(--accent-soft);
   color: var(--text-strong);
 }
@@ -1353,15 +1483,15 @@ textarea:focus {
   background: var(--accent-hover);
 }
 .toast-info {
-  border-color: var(--accent);
+  --toast-tone: var(--blue);
 }
-.toast-info .toast-mark {
-  background: var(--blue);
+.toast-success {
+  --toast-tone: var(--green);
 }
-.toast-loading .toast-mark {
-  border: 2px solid var(--accent-soft);
-  border-top-color: var(--blue);
-  background: transparent;
+.toast-error {
+  --toast-tone: var(--red);
+}
+.toast-loading .toast-mark svg {
   animation: toast-loading-spin 0.8s linear infinite;
 }
 @keyframes toast-loading-spin {
@@ -1369,18 +1499,25 @@ textarea:focus {
     transform: rotate(360deg);
   }
 }
-.toast-success {
-  border-color: var(--green);
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translate3d(12px, -4px, 0) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
 }
-.toast-success .toast-mark {
-  background: var(--green);
-}
-.toast-error {
-  border-color: var(--danger-border);
-  color: var(--danger-text);
-}
-.toast-error .toast-mark {
-  background: var(--red);
+@media (prefers-reduced-motion: reduce) {
+  .toast {
+    animation: none;
+  }
+  .toast,
+  .close-button,
+  .close-button svg {
+    transition: none;
+  }
 }
 
 /* ===== main 2-column body (sidebar | resizer | main) ===== */
@@ -1971,21 +2108,56 @@ textarea:focus {
   display: flex;
   align-items: center;
   justify-content: center;
+  overflow: auto;
   padding: calc(18px + env(safe-area-inset-top, 0px))
     calc(18px + env(safe-area-inset-right, 0px))
     calc(18px + env(safe-area-inset-bottom, 0px))
     calc(18px + env(safe-area-inset-left, 0px));
   background: var(--modal-backdrop);
+  -webkit-backdrop-filter: blur(8px) saturate(0.9);
+  backdrop-filter: blur(8px) saturate(0.9);
+  animation: modal-backdrop-in 160ms ease-out;
 }
 .modal {
+  position: relative;
   width: min(720px, 100%);
   max-height: min(760px, calc(100vh - 36px));
   overflow: auto;
-  background: var(--shell-panel);
-  border: 1px solid var(--shell-border);
-  border-radius: 10px;
-  box-shadow: var(--shadow-modal);
-  padding: 16px;
+  padding: 18px;
+  border: 1px solid color-mix(in srgb, var(--shell-border) 84%, var(--text) 16%);
+  border-radius: 16px;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--shell-panel) 93%, white 7%),
+    var(--shell-panel) 96px
+  );
+  box-shadow:
+    var(--shadow-modal),
+    inset 0 1px 0 color-mix(in srgb, white 9%, transparent);
+  outline: none;
+  isolation: isolate;
+  animation: modal-in 190ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+@keyframes modal-backdrop-in {
+  from {
+    opacity: 0;
+  }
+}
+@keyframes modal-in {
+  from {
+    opacity: 0;
+    transform: translate3d(0, 8px, 0) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .modal-backdrop,
+  .modal {
+    animation: none;
+  }
 }
 .compact-modal {
   width: min(460px, 100%);
@@ -2930,16 +3102,24 @@ textarea:focus {
   white-space: pre-wrap;
 }
 .modal-head {
+  min-height: 32px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 10px;
-  margin-bottom: 12px;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+.modal-head > :first-child {
+  min-width: 0;
 }
 .modal-head h2,
 .modal-head h3 {
   margin: 0;
-  font-size: 15px;
+  color: var(--text-strong);
+  font-size: 16px;
+  font-weight: 720;
+  line-height: 1.3;
+  letter-spacing: -0.015em;
 }
 
 .pane-jump-backdrop {
@@ -4018,7 +4198,10 @@ textarea:focus {
 }
 .terminal-preview-modal .modal-head {
   flex: 0 0 auto;
+  margin: 0;
   padding: 12px 14px;
+  border-bottom: 1px solid var(--border-soft);
+  background: color-mix(in srgb, var(--shell-panel) 88%, transparent);
 }
 .terminal-preview-modal .file-preview {
   flex: 1 1 auto;
@@ -5495,7 +5678,29 @@ textarea:focus {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
-  margin-top: 16px;
+  margin-top: 20px;
+  padding-top: 2px;
+}
+.modal-actions > button {
+  min-height: 34px;
+  padding-inline: 14px;
+  font-weight: 650;
+}
+.modal-actions > button:last-child:not(.ghost):not(.danger) {
+  border-color: color-mix(in srgb, var(--accent) 58%, var(--border));
+  background: var(--accent-soft);
+  color: var(--text-strong);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 8%, transparent);
+}
+.modal-actions
+  > button:last-child:not(.ghost):not(.danger):hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+.modal-actions > button:last-child:not(.ghost):not(.danger):focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 72%, var(--border));
+  box-shadow:
+    0 0 0 3px var(--accent-soft),
+    inset 0 1px 0 color-mix(in srgb, white 8%, transparent);
 }
 /* ===== badges ===== */
 .tree-row > .badge {
@@ -6669,8 +6874,10 @@ textarea:focus {
     width: auto;
   }
   .toast {
-    grid-template-columns: 9px minmax(0, 1fr) 28px;
-    padding: 10px;
+    grid-template-columns: 24px minmax(0, 1fr) 28px;
+    gap: 9px;
+    padding: 11px;
+    border-radius: 12px;
   }
   .toast-content pre {
     max-height: 90px;

--- a/web/src/terminalIme.test.ts
+++ b/web/src/terminalIme.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
+  isTerminalImeCommittedInputType,
   terminalImeEventTime,
   terminalImeFallbackText,
   TerminalImeFallbackTracker,
+  TerminalImeKeyEventTracker,
   TerminalImeTextareaFallbackTracker,
   terminalImeTextareaDelta,
 } from "./terminalIme";
@@ -59,7 +61,69 @@ describe("terminal IME punctuation detection", () => {
   });
 });
 
+describe("terminal IME key-event deduplication", () => {
+  test("does not replay uppercase text xterm emitted from keypress", () => {
+    const tracker = new TerminalImeKeyEventTracker();
+    tracker.begin();
+    tracker.recordXtermData("A");
+
+    expect(tracker.consumeInput({ data: "A", inputType: "insertText" })).toBe(
+      true,
+    );
+    expect(tracker.consumeInput({ data: "A", inputType: "insertText" })).toBe(
+      false,
+    );
+  });
+
+  test("keeps missing and composition-update input eligible for recovery", () => {
+    const tracker = new TerminalImeKeyEventTracker();
+    tracker.begin();
+    expect(tracker.consumeInput({ data: "中", inputType: "insertText" })).toBe(
+      false,
+    );
+
+    tracker.begin();
+    tracker.recordXtermData("，");
+    expect(
+      tracker.consumeInput({
+        data: "，",
+        inputType: "insertCompositionText",
+      }),
+    ).toBe(false);
+  });
+
+  test("resets stale key data on a new key cycle or keyup", () => {
+    const tracker = new TerminalImeKeyEventTracker();
+    tracker.begin();
+    tracker.recordXtermData("A");
+    tracker.begin();
+    tracker.recordXtermData("B");
+    expect(tracker.consumeInput({ data: "B", inputType: "insertText" })).toBe(
+      true,
+    );
+
+    tracker.begin();
+    tracker.recordXtermData("C");
+    tracker.end();
+    expect(tracker.consumeInput({ data: "C", inputType: "insertText" })).toBe(
+      false,
+    );
+  });
+});
+
 describe("terminal IME textarea fallback", () => {
+  test("recognizes committed text without replaying composition updates", () => {
+    expect(isTerminalImeCommittedInputType("insertText")).toBe(true);
+    expect(isTerminalImeCommittedInputType("insertFromComposition")).toBe(true);
+    expect(isTerminalImeCommittedInputType("insertCompositionText")).toBe(
+      false,
+    );
+    expect(isTerminalImeCommittedInputType("insertFromPaste")).toBe(false);
+    expect(isTerminalImeCommittedInputType("deleteContentBackward")).toBe(
+      false,
+    );
+  });
+
   test("extracts append-only ASCII, Chinese, and emoji text", () => {
     expect(terminalImeTextareaDelta("", "hello")).toBe("hello");
     expect(terminalImeTextareaDelta("已有", "已有中文")).toBe("中文");

--- a/web/src/terminalIme.ts
+++ b/web/src/terminalIme.ts
@@ -15,6 +15,49 @@ type PendingInput = TimedText & {
   id: number;
 };
 
+/**
+ * Returns whether an input event represents committed text whose textarea
+ * mutation can safely be recovered. Composition updates are intentionally
+ * excluded because replaying them would submit unfinished IME candidates.
+ */
+export function isTerminalImeCommittedInputType(inputType: string): boolean {
+  return inputType === "insertText" || inputType === "insertFromComposition";
+}
+
+/**
+ * Associates xterm data emitted during one physical key cycle with the native
+ * input event that follows it. Safari still dispatches beforeinput/input after
+ * xterm handles some printable keys in keypress, notably uppercase letters.
+ */
+export class TerminalImeKeyEventTracker {
+  private active = false;
+  private xtermData = "";
+
+  begin(): void {
+    this.active = true;
+    this.xtermData = "";
+  }
+
+  recordXtermData(text: string): void {
+    if (this.active) this.xtermData += text;
+  }
+
+  consumeInput(input: Pick<InputEvent, "data" | "inputType">): boolean {
+    const alreadyHandled =
+      this.active &&
+      isTerminalImeCommittedInputType(input.inputType) &&
+      !!input.data &&
+      this.xtermData === input.data;
+    this.end();
+    return alreadyHandled;
+  }
+
+  end(): void {
+    this.active = false;
+    this.xtermData = "";
+  }
+}
+
 function isEastAsianPunctuation(text: string): boolean {
   const characters = Array.from(text);
   return (
@@ -57,9 +100,9 @@ export function terminalImeTextareaDelta(
 }
 
 /**
- * Tracks one iOS keyCode 229 cycle and subtracts any prefix xterm already
- * emitted. A synchronous flush catches short-lived keyup/input mutations; an
- * unchanged cycle stays pending for one final timer fallback.
+ * Tracks one Apple IME textarea-mutation cycle and subtracts any prefix xterm
+ * already emitted. A synchronous flush catches short-lived input/keyup
+ * mutations; an unchanged cycle stays pending for one final timer fallback.
  */
 export type TerminalImeTextareaFlushResult =
   | { status: "pending" }

--- a/web/src/uiLocale.test.ts
+++ b/web/src/uiLocale.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "bun:test";
+import { formatUiRelativeTime, UI_LOCALE } from "./uiLocale";
+
+describe("UI locale", () => {
+  test("keeps generated relative-time labels in English", () => {
+    expect(UI_LOCALE).toBe("en-US");
+    expect(formatUiRelativeTime(0, "second")).toBe("now");
+    expect(formatUiRelativeTime(-2, "minute")).toBe("2 minutes ago");
+    expect(formatUiRelativeTime(1, "day")).toBe("tomorrow");
+  });
+});

--- a/web/src/uiLocale.ts
+++ b/web/src/uiLocale.ts
@@ -1,0 +1,14 @@
+// Keep application-generated dates, times, and relative labels in English even
+// when the browser or operating system uses another locale.
+export const UI_LOCALE = "en-US";
+
+const relativeTimeFormatter = new Intl.RelativeTimeFormat(UI_LOCALE, {
+  numeric: "auto",
+});
+
+export function formatUiRelativeTime(
+  value: number,
+  unit: Intl.RelativeTimeFormatUnit,
+) {
+  return relativeTimeFormatter.format(value, unit);
+}


### PR DESCRIPTION
## Summary

- polish dialogs, toast notifications, close controls, focus states, and modal action hierarchy across dark and light themes
- keep all generated UI dates, relative times, labels, and terminal paste errors in English
- recover Apple IME commits across missing or reordered keyboard events without replaying text already forwarded by xterm

## Verification

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `TMPDIR=/tmp bun test --timeout 20000` — 547 passed, 1 skipped
- `TMPDIR=/tmp bun run build:darwin-arm64`
