### PR TITLE
Push agent status changes via per-pane event subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,15 @@
 
 ### Fixed
 
-- Recover Apple IME commits when WebKit emits input before or without keydown or
-  reports a different keyup code, without replaying text already sent from
+- Push `pane.agent_status_changed` events from each connection so agent
+  working/idle/done transitions reach the browser immediately instead of
+  waiting for the next metadata poll, which could leave agents looking idle
+  while they work.
+- Refresh workspace metadata as soon as a hidden or unfocused page becomes
+  visible, focused, or back online, so browser timer throttling no longer
+  leaves statuses stale.
+- Recover Apple IME commits when WebKit emits input before or without keydown
+  or reports a different keyup code, without replaying text already sent from
   keypress.
 - Keep connection-scoped RPC, HTTP, terminal, clipboard, file, Git, worktree,
   agent, and settings activity bound to the selected server generation so stale

--- a/docs/multi-herdr-connections-implementation.md
+++ b/docs/multi-herdr-connections-implementation.md
@@ -55,7 +55,9 @@ Each `ConnectionRuntime` owns its own:
 - immutable connection identity and manager generation;
 - control/render socket paths and `HerdrClient`;
 - terminal bridge, thin clients, viewer maps, and clipboard relay;
-- event subscription and reconnect lifecycle;
+- event subscription and reconnect lifecycle, plus a per-pane
+  `pane.agent_status_changed` subscription that follows agent membership so
+  status transitions reach browsers without waiting for metadata polling;
 - file, Git, worktree, hooks, agent-session, settings, and auto-sync services;
 - local transport or supervised SSH tunnel;
 - cleanup and status publication.
@@ -317,6 +319,8 @@ server seam if Bun exposes one.
 - Profiles/persistence/service: `server/src/connections/profiles.ts`,
   `server/src/connections/profile-service.ts`
 - Runtime composition: `server/src/connections/runtime.ts`
+- Event/agent-status subscriptions: `server/src/connections/subscription-loop.ts`,
+  `server/src/connections/agent-status-subscription.ts`
 - RPC/HTTP protocol: `server/src/connections/protocol.ts`,
   `server/src/connections/rpc-routing.ts`,
   `server/src/connections/http-routing.ts`

--- a/server/src/bridge/herdr-client.ts
+++ b/server/src/bridge/herdr-client.ts
@@ -4,6 +4,11 @@ import * as net from "node:net";
 const MAX_NDJSON_LINE_BYTES = 1024 * 1024;
 const SUBSCRIPTION_ACK_TIMEOUT_MS = 8000;
 
+/** Subscription selector: a bare event type or a parameterized subscription. */
+export type HerdrSubscription =
+  | string
+  | { type: string; [key: string]: unknown };
+
 /**
  * Minimal NDJSON client for the Herdr local socket.
  *
@@ -122,7 +127,7 @@ export class HerdrClient extends EventEmitter {
    * promise that resolves once the subscription is acknowledged.
    */
   subscribe(
-    types: string[],
+    types: HerdrSubscription[],
     ackTimeoutMs = SUBSCRIPTION_ACK_TIMEOUT_MS,
   ): {
     close: () => void;
@@ -175,7 +180,11 @@ export class HerdrClient extends EventEmitter {
         JSON.stringify({
           id: "sub",
           method: "events.subscribe",
-          params: { subscriptions: types.map((t) => ({ type: t })) },
+          params: {
+            subscriptions: types.map((t) =>
+              typeof t === "string" ? { type: t } : t,
+            ),
+          },
         }) + "\n",
       );
     });

--- a/server/src/connections/agent-status-subscription.test.ts
+++ b/server/src/connections/agent-status-subscription.test.ts
@@ -1,0 +1,444 @@
+import { afterEach, expect, test } from "bun:test";
+import * as net from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+import { HerdrClient } from "../bridge/herdr-client";
+import {
+  agentPaneIdsFromPaneList,
+  createAgentStatusSubscriptionLoop,
+  samePaneIds,
+} from "./agent-status-subscription";
+
+const servers: net.Server[] = [];
+const sockets = new Set<net.Socket>();
+const paths: string[] = [];
+
+afterEach(async () => {
+  for (const socket of sockets) socket.destroy();
+  sockets.clear();
+  await Promise.all(
+    servers
+      .splice(0)
+      .map(
+        (server) =>
+          new Promise<void>((resolve) => server.close(() => resolve())),
+      ),
+  );
+  for (const path of paths.splice(0)) {
+    try {
+      await import("node:fs").then((fs) => fs.unlinkSync(path));
+    } catch {
+      // The socket path is already gone.
+    }
+  }
+});
+
+type SubscribeCall = {
+  subscriptions: Array<{ type: string; pane_id?: string }>;
+  socket: net.Socket;
+  suppressAck?: boolean;
+};
+
+function fakeHerdr(options: {
+  panes: () => unknown[];
+  ackSubscribe?: (call: SubscribeCall) => void;
+  deferLists?: () => boolean;
+}) {
+  const path = join(
+    tmpdir(),
+    `agent-status-test-${randomBytes(4).toString("hex")}.sock`,
+  );
+  paths.push(path);
+  const subscribeCalls: SubscribeCall[] = [];
+  const deferredLists: Array<() => void> = [];
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    let input = "";
+    socket.on("data", (chunk) => {
+      input += chunk.toString();
+      const newline = input.indexOf("\n");
+      if (newline < 0) return;
+      const request = JSON.parse(input.slice(0, newline));
+      input = input.slice(newline + 1);
+      if (request.method === "pane.list") {
+        const respond = () => {
+          socket.write(
+            `${JSON.stringify({ id: request.id, result: { panes: options.panes() } })}\n`,
+          );
+          socket.end();
+        };
+        if (options.deferLists?.()) {
+          deferredLists.push(respond);
+          return;
+        }
+        respond();
+        return;
+      }
+      if (request.method === "events.subscribe") {
+        const call: SubscribeCall = {
+          subscriptions: request.params?.subscriptions ?? [],
+          socket,
+        };
+        subscribeCalls.push(call);
+        options.ackSubscribe?.(call);
+        if (!call.suppressAck) {
+          socket.write(
+            `${JSON.stringify({ id: request.id, result: { type: "subscription_started" } })}\n`,
+          );
+        }
+        return;
+      }
+      socket.write(`${JSON.stringify({ id: request.id, result: {} })}\n`);
+      socket.end();
+    });
+  });
+  servers.push(server);
+  const ready = new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(path, resolve);
+  });
+  return { path, ready, subscribeCalls, deferredLists };
+}
+
+function pushStatusEvent(call: SubscribeCall, paneId: string, status: string) {
+  call.socket.write(
+    `${JSON.stringify({
+      event: "pane.agent_status_changed",
+      data: {
+        pane_id: paneId,
+        workspace_id: "w1",
+        agent_status: status,
+        agent: "pi",
+      },
+    })}\n`,
+  );
+}
+
+function agentPane(paneId: string, agent = "pi") {
+  return { pane_id: paneId, agent, agent_status: "idle" };
+}
+
+function plainPane(paneId: string) {
+  return { pane_id: paneId, agent_status: "unknown" };
+}
+
+async function waitFor(
+  condition: () => boolean,
+  timeoutMs = 2000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (condition()) return;
+    await Bun.sleep(5);
+  }
+  throw new Error("condition was not met before the timeout");
+}
+
+test("collects sorted pane ids that currently host an agent", () => {
+  expect(
+    agentPaneIdsFromPaneList({
+      panes: [
+        agentPane("w1:p2"),
+        plainPane("w1:p1"),
+        agentPane("w1:p1", ""),
+        agentPane("w1:p3", "pi"),
+        { pane_id: 7, agent: "pi" },
+        "junk",
+        agentPane("w1:p2", "pi"),
+      ],
+    }),
+  ).toEqual(["w1:p2", "w1:p3"]);
+  expect(agentPaneIdsFromPaneList({})).toEqual([]);
+  expect(agentPaneIdsFromPaneList(null)).toEqual([]);
+  expect(samePaneIds(["a", "b"], ["a", "b"])).toBe(true);
+  expect(samePaneIds(["a", "b"], ["b", "a"])).toBe(false);
+  expect(samePaneIds(["a"], ["a", "b"])).toBe(false);
+});
+
+test("subscribes per agent pane and forwards status events", async () => {
+  const herdr = fakeHerdr({
+    panes: () => [agentPane("w1:p1"), plainPane("w1:p2")],
+  });
+  await herdr.ready;
+  const client = new HerdrClient(herdr.path);
+  const events: unknown[] = [];
+  client.on("event", (event) => events.push(event));
+  const loop = createAgentStatusSubscriptionLoop({
+    herdr: client,
+    connectionId: "test",
+    retryDelayMs: 10,
+    rebuildDebounceMs: 5,
+    membershipPollMs: 50,
+  });
+
+  loop.start();
+  await waitFor(() => herdr.subscribeCalls.length === 1);
+  expect(herdr.subscribeCalls[0]?.subscriptions).toEqual([
+    { type: "pane.agent_status_changed", pane_id: "w1:p1" },
+  ]);
+
+  pushStatusEvent(herdr.subscribeCalls[0]!, "w1:p1", "working");
+  await waitFor(() => events.length === 1);
+  expect(events[0]).toMatchObject({
+    event: "pane.agent_status_changed",
+    data: { pane_id: "w1:p1", agent_status: "working" },
+  });
+
+  await loop.stop();
+  expect(loop.isRunning()).toBe(false);
+});
+
+test("rebuilds the subscription when a membership event changes the pane set", async () => {
+  let panes = [agentPane("w1:p1")];
+  const herdr = fakeHerdr({ panes: () => panes });
+  await herdr.ready;
+  const client = new HerdrClient(herdr.path);
+  const loop = createAgentStatusSubscriptionLoop({
+    herdr: client,
+    connectionId: "test",
+    retryDelayMs: 10,
+    rebuildDebounceMs: 5,
+    membershipPollMs: 10_000,
+  });
+
+  loop.start();
+  await waitFor(() => herdr.subscribeCalls.length === 1);
+
+  panes = [agentPane("w1:p1"), agentPane("w1:p2")];
+  loop.handleHerdrEvent({
+    event: "pane_agent_detected",
+    data: { type: "pane_agent_detected" },
+  });
+  await waitFor(() => herdr.subscribeCalls.length === 2);
+  expect(herdr.subscribeCalls[1]?.subscriptions).toEqual([
+    { type: "pane.agent_status_changed", pane_id: "w1:p1" },
+    { type: "pane.agent_status_changed", pane_id: "w1:p2" },
+  ]);
+
+  panes = [agentPane("w1:p2")];
+  loop.handleHerdrEvent({
+    event: "workspace_closed",
+    data: { type: "workspace_closed" },
+  });
+  await waitFor(() => herdr.subscribeCalls.length === 3);
+  expect(herdr.subscribeCalls[2]?.subscriptions).toEqual([
+    { type: "pane.agent_status_changed", pane_id: "w1:p2" },
+  ]);
+
+  await loop.stop();
+});
+
+test("ignores unrelated events and membership events that do not change the set", async () => {
+  const herdr = fakeHerdr({ panes: () => [agentPane("w1:p1")] });
+  await herdr.ready;
+  const client = new HerdrClient(herdr.path);
+  const loop = createAgentStatusSubscriptionLoop({
+    herdr: client,
+    connectionId: "test",
+    retryDelayMs: 10,
+    rebuildDebounceMs: 5,
+    membershipPollMs: 10_000,
+  });
+
+  loop.start();
+  await waitFor(() => herdr.subscribeCalls.length === 1);
+
+  loop.handleHerdrEvent({
+    event: "pane_focused",
+    data: { type: "pane_focused" },
+  });
+  loop.handleHerdrEvent({
+    event: "pane.agent_status_changed",
+    data: { pane_id: "w1:p1" },
+  });
+  loop.handleHerdrEvent({
+    event: "pane_closed",
+    data: { type: "pane_closed", pane_id: "w1:p9" },
+  });
+  await Bun.sleep(100);
+  expect(herdr.subscribeCalls.length).toBe(1);
+
+  await loop.stop();
+});
+
+test("retries with a fresh listing when herdr rejects the subscription", async () => {
+  const herdr = fakeHerdr({
+    panes: () => [agentPane("w1:p1")],
+    ackSubscribe: (call) => {
+      if (herdr.subscribeCalls.length === 1) {
+        call.suppressAck = true;
+        call.socket.write(
+          `${JSON.stringify({ id: "sub", error: { message: "pane not found" } })}\n`,
+        );
+        call.socket.end();
+      }
+    },
+  });
+  await herdr.ready;
+  const client = new HerdrClient(herdr.path);
+  const errors: string[] = [];
+  const loop = createAgentStatusSubscriptionLoop({
+    herdr: client,
+    connectionId: "test",
+    onSubscribeError: (error) => errors.push(error.message),
+    retryDelayMs: 10,
+    rebuildDebounceMs: 5,
+    membershipPollMs: 10_000,
+  });
+
+  loop.start();
+  await waitFor(() => herdr.subscribeCalls.length === 2);
+  expect(errors).toEqual(["pane not found"]);
+
+  await loop.stop();
+});
+
+test("waits for an agent pane before subscribing", async () => {
+  let panes: unknown[] = [plainPane("w1:p1")];
+  const herdr = fakeHerdr({ panes: () => panes });
+  await herdr.ready;
+  const client = new HerdrClient(herdr.path);
+  const loop = createAgentStatusSubscriptionLoop({
+    herdr: client,
+    connectionId: "test",
+    retryDelayMs: 10,
+    rebuildDebounceMs: 5,
+    membershipPollMs: 10_000,
+  });
+
+  loop.start();
+  await Bun.sleep(50);
+  expect(herdr.subscribeCalls.length).toBe(0);
+
+  panes = [agentPane("w1:p1")];
+  loop.handleHerdrEvent({
+    event: "pane_agent_detected",
+    data: { type: "pane_agent_detected" },
+  });
+  await waitFor(() => herdr.subscribeCalls.length === 1);
+
+  await loop.stop();
+});
+
+test("resubscribes when the subscription socket closes", async () => {
+  const herdr = fakeHerdr({ panes: () => [agentPane("w1:p1")] });
+  await herdr.ready;
+  const client = new HerdrClient(herdr.path);
+  const loop = createAgentStatusSubscriptionLoop({
+    herdr: client,
+    connectionId: "test",
+    retryDelayMs: 10,
+    rebuildDebounceMs: 5,
+    membershipPollMs: 10_000,
+  });
+
+  loop.start();
+  await waitFor(() => herdr.subscribeCalls.length === 1);
+  herdr.subscribeCalls[0]?.socket.destroy();
+  await waitFor(() => herdr.subscribeCalls.length === 2);
+
+  await loop.stop();
+});
+
+test("honors a rebuild requested while a listing was in flight", async () => {
+  let panes: unknown[] = [];
+  let defer = true;
+  const herdr = fakeHerdr({ panes: () => panes, deferLists: () => defer });
+  await herdr.ready;
+  const client = new HerdrClient(herdr.path);
+  const loop = createAgentStatusSubscriptionLoop({
+    herdr: client,
+    connectionId: "test",
+    retryDelayMs: 10,
+    rebuildDebounceMs: 0,
+    membershipPollMs: 10_000,
+  });
+
+  loop.start();
+  // The first listing is now in flight and held by the fake server. The
+  // membership event's debounce wake fires while no waiter is registered.
+  await waitFor(() => herdr.deferredLists.length === 1);
+  loop.handleHerdrEvent({
+    event: "pane_agent_detected",
+    data: { type: "pane_agent_detected" },
+  });
+  await Bun.sleep(20);
+  // The listing snapshot predates the agent, but the rebuild request must not
+  // stall until the fallback poll: the loop must re-list immediately.
+  defer = false;
+  herdr.deferredLists.shift()?.();
+  panes = [agentPane("w1:p1")];
+  await waitFor(() => herdr.subscribeCalls.length === 1);
+  expect(herdr.subscribeCalls[0]?.subscriptions).toEqual([
+    { type: "pane.agent_status_changed", pane_id: "w1:p1" },
+  ]);
+
+  await loop.stop();
+});
+
+test("recovers when subscribe throws synchronously", async () => {
+  const herdr = fakeHerdr({ panes: () => [agentPane("w1:p1")] });
+  await herdr.ready;
+  const client = new HerdrClient(herdr.path);
+  let thrown = false;
+  const flaky = {
+    call: (method: string, params: Record<string, unknown>, timeout?: number) =>
+      client.call(method, params, timeout),
+    subscribe: (
+      types: Parameters<HerdrClient["subscribe"]>[0],
+      ackTimeoutMs?: number,
+    ) => {
+      if (!thrown) {
+        thrown = true;
+        throw new Error("boom");
+      }
+      return client.subscribe(types, ackTimeoutMs);
+    },
+  } as unknown as HerdrClient;
+  const errors: string[] = [];
+  const loop = createAgentStatusSubscriptionLoop({
+    herdr: flaky,
+    connectionId: "test",
+    onSubscribeError: (error) => errors.push(error.message),
+    retryDelayMs: 10,
+    rebuildDebounceMs: 5,
+    membershipPollMs: 10_000,
+  });
+
+  loop.start();
+  await waitFor(() => herdr.subscribeCalls.length === 1);
+  expect(errors).toEqual(["boom"]);
+  expect(loop.isRunning()).toBe(true);
+
+  await loop.stop();
+});
+
+test("stop is idempotent and closes the active subscription", async () => {
+  const herdr = fakeHerdr({ panes: () => [agentPane("w1:p1")] });
+  await herdr.ready;
+  const client = new HerdrClient(herdr.path);
+  const loop = createAgentStatusSubscriptionLoop({
+    herdr: client,
+    connectionId: "test",
+    retryDelayMs: 10,
+    rebuildDebounceMs: 5,
+    membershipPollMs: 10_000,
+  });
+
+  loop.start();
+  await waitFor(() => herdr.subscribeCalls.length === 1);
+  const activeSocket = herdr.subscribeCalls[0]?.socket;
+  let activeClosed = false;
+  activeSocket?.on("close", () => {
+    activeClosed = true;
+  });
+  await Promise.all([loop.stop(), loop.stop()]);
+  expect(loop.isRunning()).toBe(false);
+  await waitFor(() => activeClosed);
+
+  const calls = herdr.subscribeCalls.length;
+  await Bun.sleep(50);
+  expect(herdr.subscribeCalls.length).toBe(calls);
+});

--- a/server/src/connections/agent-status-subscription.ts
+++ b/server/src/connections/agent-status-subscription.ts
@@ -1,0 +1,360 @@
+import type { HerdrClient } from "../bridge/herdr-client";
+
+/**
+ * Herdr emits `pane.agent_status_changed` only through parameterized per-pane
+ * subscriptions, so the static event subscription never sees agent status
+ * transitions. This loop tracks panes that currently host an agent and keeps a
+ * dedicated subscription socket open for their status events. Membership is
+ * seeded from `pane.list`, refreshed when membership events arrive, and
+ * re-polled periodically as a fallback. Status events themselves reach the
+ * shared HerdrClient `event` emitter like every other subscription message.
+ */
+
+export type AgentStatusSubscriptionLoop = {
+  start: () => void;
+  stop: () => Promise<void>;
+  /** Feed shared HerdrClient `event` emissions so membership changes rebuild. */
+  handleHerdrEvent: (event: unknown) => void;
+  isRunning: () => boolean;
+};
+
+type Subscription = {
+  close: () => void;
+  ready: Promise<void>;
+  closed: Promise<void>;
+};
+
+type Generation = {
+  id: number;
+  cancelled: Promise<void>;
+  cancel: () => void;
+};
+
+/** Herdr events that can change the set of panes hosting an agent. */
+const MEMBERSHIP_EVENT_TYPES = new Set([
+  "pane_agent_detected",
+  "pane_closed",
+  "tab_closed",
+  "workspace_closed",
+]);
+
+function herdrEventName(event: unknown): string | null {
+  if (!event || typeof event !== "object" || Array.isArray(event)) return null;
+  const envelope = event as {
+    event?: unknown;
+    data?: unknown;
+  };
+  if (typeof envelope.event === "string" && envelope.event) {
+    return envelope.event;
+  }
+  const data = envelope.data;
+  if (data && typeof data === "object" && !Array.isArray(data)) {
+    const type = (data as { type?: unknown }).type;
+    if (typeof type === "string" && type) return type;
+  }
+  return null;
+}
+
+export function agentPaneIdsFromPaneList(result: unknown): string[] {
+  const panes = (result as { panes?: unknown } | null)?.panes;
+  if (!Array.isArray(panes)) return [];
+  const ids = new Set<string>();
+  for (const pane of panes) {
+    if (!pane || typeof pane !== "object" || Array.isArray(pane)) continue;
+    const record = pane as { pane_id?: unknown; agent?: unknown };
+    if (
+      typeof record.pane_id === "string" &&
+      record.pane_id.length > 0 &&
+      typeof record.agent === "string" &&
+      record.agent.length > 0
+    ) {
+      ids.add(record.pane_id);
+    }
+  }
+  return Array.from(ids).sort();
+}
+
+export function samePaneIds(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((id, index) => id === b[index]);
+}
+
+export function createAgentStatusSubscriptionLoop(args: {
+  herdr: HerdrClient;
+  connectionId: string;
+  onSubscribeError?: (error: Error) => void;
+  onListError?: (error: Error) => void;
+  log?: (message: string) => void;
+  retryDelayMs?: number;
+  rebuildDebounceMs?: number;
+  membershipPollMs?: number;
+}): AgentStatusSubscriptionLoop {
+  const retryDelayMs = args.retryDelayMs ?? 2000;
+  const rebuildDebounceMs = args.rebuildDebounceMs ?? 300;
+  const membershipPollMs = args.membershipPollMs ?? 30000;
+
+  let running = false;
+  let generation: Generation | null = null;
+  let loopTask: Promise<void> | null = null;
+  let stopTask: Promise<void> | null = null;
+  let active: Subscription | null = null;
+  let rebuildTimer: ReturnType<typeof setTimeout> | null = null;
+  let rebuildRequested = false;
+  let rebuildWaiters: Array<() => void> = [];
+
+  function newGeneration(): Generation {
+    let cancel!: () => void;
+    const cancelled = new Promise<void>((resolve) => {
+      cancel = resolve;
+    });
+    return { id: (generation?.id ?? 0) + 1, cancelled, cancel };
+  }
+
+  function current(expected: Generation): boolean {
+    return running && generation === expected;
+  }
+
+  function report(
+    callback: ((error: Error) => void) | undefined,
+    error: unknown,
+  ) {
+    if (!callback) return;
+    try {
+      callback(error instanceof Error ? error : new Error(String(error)));
+    } catch {
+      // Observers must not break the subscription loop.
+    }
+  }
+
+  function log(message: string) {
+    try {
+      args.log?.(message);
+    } catch {
+      // Observers must not break the subscription loop.
+    }
+  }
+
+  function wakeRebuild() {
+    const waiters = rebuildWaiters;
+    rebuildWaiters = [];
+    for (const resolve of waiters) resolve();
+  }
+
+  /** Resolves on timeout, cancellation, or a rebuild wake, whichever first. */
+  function wait(
+    ms: number,
+    expected: Generation,
+    wakeOnRebuild: boolean,
+  ): Promise<void> {
+    return new Promise((resolve) => {
+      const timer = setTimeout(finish, ms);
+      function finish() {
+        clearTimeout(timer);
+        if (wakeOnRebuild) {
+          rebuildWaiters = rebuildWaiters.filter((waiter) => waiter !== finish);
+        }
+        resolve();
+      }
+      if (wakeOnRebuild) rebuildWaiters.push(finish);
+      void expected.cancelled.then(finish);
+    });
+  }
+
+  function closeSubscription(subscription: Subscription) {
+    try {
+      subscription.close();
+    } catch {
+      // The socket is already considered closed.
+    }
+  }
+
+  async function listAgentPaneIds(): Promise<string[] | null> {
+    try {
+      // Bounded so a hung downstream cannot hold runtime stop hostage.
+      const result = await args.herdr.call("pane.list", {}, 5000);
+      return agentPaneIdsFromPaneList(result);
+    } catch (error) {
+      report(args.onListError, error);
+      return null;
+    }
+  }
+
+  function requestRebuild() {
+    if (!running) return;
+    rebuildRequested = true;
+    if (rebuildTimer) return;
+    rebuildTimer = setTimeout(() => {
+      rebuildTimer = null;
+      wakeRebuild();
+    }, rebuildDebounceMs);
+  }
+
+  /**
+   * Holds the subscription until it closes or the pane set changes. Returns
+   * "closed" (socket lost), "rebuild" (membership changed), or "cancelled".
+   */
+  async function holdSubscription(
+    subscription: Subscription,
+    paneIds: string[],
+    expected: Generation,
+  ): Promise<"closed" | "rebuild" | "cancelled"> {
+    for (;;) {
+      // Check the flag before sleeping: a rebuild wake that fired while no
+      // waiter was registered (e.g. mid-RPC) must not be lost, otherwise the
+      // rebuild would stall until the fallback poll.
+      if (rebuildRequested) {
+        rebuildRequested = false;
+        const latest = await listAgentPaneIds();
+        if (!current(expected)) return "cancelled";
+        if (latest === null) {
+          await wait(retryDelayMs, expected, true);
+          if (!current(expected)) return "cancelled";
+          continue;
+        }
+        if (!samePaneIds(latest, paneIds)) return "rebuild";
+        continue;
+      }
+      const closed = await Promise.race([
+        subscription.closed.then(() => true as const),
+        wait(membershipPollMs, expected, true).then(() => false as const),
+      ]);
+      if (!current(expected)) return "cancelled";
+      if (closed) return "closed";
+      // Woken by a membership wake or the fallback poll: verify the set.
+      rebuildRequested = false;
+      const latest = await listAgentPaneIds();
+      if (!current(expected)) return "cancelled";
+      if (latest === null) {
+        await wait(retryDelayMs, expected, true);
+        if (!current(expected)) return "cancelled";
+        continue;
+      }
+      if (!samePaneIds(latest, paneIds)) return "rebuild";
+      // Set unchanged: keep holding the current subscription.
+    }
+  }
+
+  async function run(expected: Generation) {
+    while (current(expected)) {
+      const paneIds = await listAgentPaneIds();
+      if (!current(expected)) return;
+      if (paneIds === null) {
+        await wait(retryDelayMs, expected, false);
+        continue;
+      }
+      if (paneIds.length === 0) {
+        // Nothing to subscribe to yet; sleep until a membership event or the
+        // fallback poll wakes the loop. A rebuild requested while the listing
+        // was in flight skips the sleep so it is honored immediately.
+        if (!rebuildRequested) {
+          await wait(membershipPollMs, expected, true);
+        }
+        rebuildRequested = false;
+        continue;
+      }
+
+      let subscription: Subscription;
+      try {
+        subscription = args.herdr.subscribe(
+          paneIds.map((paneId) => ({
+            type: "pane.agent_status_changed",
+            pane_id: paneId,
+          })),
+        );
+      } catch (error) {
+        // A synchronous subscribe failure is transient like an ack failure;
+        // it must never kill the loop.
+        report(args.onSubscribeError, error);
+        await wait(retryDelayMs, expected, false);
+        continue;
+      }
+      active = subscription;
+      const readyFailure = await Promise.race([
+        subscription.ready.then(
+          () => null as null,
+          (error: unknown) =>
+            error instanceof Error ? error : new Error(String(error)),
+        ),
+        expected.cancelled.then(() => new Error("cancelled")),
+      ]);
+      if (!current(expected)) {
+        if (active === subscription) active = null;
+        closeSubscription(subscription);
+        return;
+      }
+      if (readyFailure) {
+        if (active === subscription) active = null;
+        closeSubscription(subscription);
+        report(args.onSubscribeError, readyFailure);
+        // The pane set raced us (e.g. a pane closed mid-subscribe). The loop
+        // re-lists panes before the next attempt.
+        await wait(retryDelayMs, expected, false);
+        continue;
+      }
+
+      // Do not clear rebuildRequested here: a membership event that arrived
+      // while the subscribe was in flight must survive into holdSubscription's
+      // first check instead of stalling until the fallback poll.
+      log(
+        `subscribed to agent status events connection=${args.connectionId} panes=${paneIds.length}`,
+      );
+      const outcome = await holdSubscription(subscription, paneIds, expected);
+      if (active === subscription) active = null;
+      closeSubscription(subscription);
+      if (outcome === "cancelled") return;
+      if (outcome === "closed") {
+        await wait(retryDelayMs, expected, false);
+      }
+      // "rebuild" loops immediately with a fresh listing.
+    }
+  }
+
+  return {
+    start() {
+      if (running || loopTask) return;
+      running = true;
+      stopTask = null;
+      const expected = newGeneration();
+      generation = expected;
+      const task = run(expected).catch((error) =>
+        report(args.onSubscribeError, error),
+      );
+      loopTask = task.finally(() => {
+        if (generation === expected) {
+          running = false;
+          generation = null;
+          loopTask = null;
+        }
+      });
+    },
+
+    stop() {
+      if (stopTask) return stopTask;
+      if (!running && !loopTask) return Promise.resolve();
+      running = false;
+      const expected = generation;
+      generation = null;
+      expected?.cancel();
+      rebuildRequested = false;
+      if (rebuildTimer) {
+        clearTimeout(rebuildTimer);
+        rebuildTimer = null;
+      }
+      const subscription = active;
+      active = null;
+      if (subscription) closeSubscription(subscription);
+      wakeRebuild();
+      const task = loopTask ?? Promise.resolve();
+      stopTask = task.finally(() => {
+        loopTask = null;
+      });
+      return stopTask;
+    },
+
+    handleHerdrEvent(event: unknown) {
+      const name = herdrEventName(event);
+      if (name && MEMBERSHIP_EVENT_TYPES.has(name)) requestRebuild();
+    },
+
+    isRunning: () => running,
+  };
+}

--- a/server/src/connections/runtime.ts
+++ b/server/src/connections/runtime.ts
@@ -27,6 +27,7 @@ import {
   createWorktreeRemovalCoordinator,
   createWorktreeRemovalRuntime,
 } from "../worktree/remove";
+import { createAgentStatusSubscriptionLoop } from "./agent-status-subscription";
 import { sanitizeConnectionError } from "./manager";
 import { createEventSubscriptionLoop } from "./subscription-loop";
 import { type ConnectionIdentity, LEGACY_DEFAULT_CONNECTION } from "./types";
@@ -187,7 +188,27 @@ export function createLegacyConnectionRuntime(args: {
     },
   });
 
-  const onHerdrEvent = (event: unknown) => args.onEvent(event, identity);
+  const agentStatusSubscriptions = createAgentStatusSubscriptionLoop({
+    herdr,
+    connectionId: identity.id,
+    onSubscribeError: (error) =>
+      console.error(
+        `[bridge] agent status subscribe failed connection=${identity.id}:`,
+        sanitizeConnectionError(error),
+        "- retrying",
+      ),
+    onListError: (error) =>
+      console.error(
+        `[bridge] agent status pane list failed connection=${identity.id}:`,
+        sanitizeConnectionError(error),
+      ),
+    log: (message) => console.log(`[bridge] ${message}`),
+  });
+
+  const onHerdrEvent = (event: unknown) => {
+    agentStatusSubscriptions.handleHerdrEvent(event);
+    args.onEvent(event, identity);
+  };
   const onHerdrError = (error: unknown) => args.onError?.(error, identity);
   herdr.on("event", onHerdrEvent);
   herdr.on("error", onHerdrError);
@@ -237,6 +258,7 @@ export function createLegacyConnectionRuntime(args: {
     backgroundStarted = true;
     workspaceAutoSync.start();
     subscriptionLoop.start();
+    agentStatusSubscriptions.start();
   }
 
   function stop() {
@@ -247,12 +269,14 @@ export function createLegacyConnectionRuntime(args: {
     const autoSyncStop = workspaceAutoSync.stop();
     terminalBridge.dispose();
     const subscriptionStop = subscriptionLoop.stop();
+    const agentStatusStop = agentStatusSubscriptions.stop();
     const transportCleanup = sshTunnel.cleanupAutoSshTunnel();
     const transportStop =
       transportStart?.catch(() => undefined) ?? Promise.resolve();
     stopTask = Promise.all([
       autoSyncStop,
       subscriptionStop,
+      agentStatusStop,
       transportCleanup,
       transportStop,
     ])

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -299,6 +299,48 @@ describe("bridge connection lifecycle", () => {
     expect(received).toEqual([{ connection_id: "legacy-default", ...push }]);
   });
 
+  test("dispatches agent status events that omit data.type", async () => {
+    class ManualWebSocket extends HangingWebSocket {
+      static instance: ManualWebSocket;
+
+      constructor() {
+        super();
+        ManualWebSocket.instance = this;
+        queueMicrotask(() => {
+          this.readyState = ManualWebSocket.OPEN;
+          this.onopen?.();
+        });
+      }
+    }
+    installBrowserGlobals(ManualWebSocket as unknown as typeof WebSocket);
+    const bridge = createTestBridge();
+    const events: unknown[] = [];
+    bridge.onEvent((event) => events.push(event));
+    bridge.connect();
+    await Bun.sleep(1);
+    sendHello(ManualWebSocket.instance);
+
+    const statusEvent = {
+      event: "pane.agent_status_changed",
+      data: {
+        pane_id: "w1:p1",
+        workspace_id: "w1",
+        agent_status: "working",
+        agent: "pi",
+      },
+    };
+    ManualWebSocket.instance.onmessage?.({
+      data: JSON.stringify({
+        connection_id: "legacy-default",
+        ...statusEvent,
+      }),
+    } as MessageEvent);
+
+    expect(events).toEqual([
+      { connection_id: "legacy-default", ...statusEvent },
+    ]);
+  });
+
   test("keeps event and terminal listeners compatible with scoped pushes", async () => {
     class ManualWebSocket extends HangingWebSocket {
       static instance: ManualWebSocket;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -162,7 +162,8 @@ export interface HerdrEventMsg {
   connection_id: string;
   connection_generation?: number;
   event: string;
-  data: { type: string; [k: string]: unknown };
+  /** Some Herdr events (e.g. pane.agent_status_changed) omit data.type. */
+  data: { type?: string; [k: string]: unknown };
 }
 
 export interface TerminalPush {
@@ -691,7 +692,6 @@ export class Bridge {
         !msg.data ||
         typeof msg.data !== "object" ||
         Array.isArray(msg.data) ||
-        typeof msg.data.type !== "string" ||
         !this.pushGenerationMatches(
           msg.connection_id,
           msg.connection_generation,

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -1605,6 +1605,22 @@ export const store = {
         );
       }
     });
+    // Browsers throttle timers in hidden tabs, which stalls the metadata
+    // poll that carries agent statuses. Catch up as soon as the page is
+    // visible, focused, or back online instead of waiting out the throttle.
+    const refreshOnReturn = () => {
+      if (state.connectionPaused || state.status !== "connected") return;
+      void refreshNow();
+    };
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", () => {
+        if (!document.hidden) refreshOnReturn();
+      });
+    }
+    if (typeof window !== "undefined") {
+      window.addEventListener("focus", refreshOnReturn);
+      window.addEventListener("online", refreshOnReturn);
+    }
     // If the server requires a password and the session is missing/expired,
     // bounce to the login page instead of spinning on a failing socket.
     fetch("/api/health", {


### PR DESCRIPTION
Follow-up to the multi-connection support in #18.

## Problem

Agent running-status transitions (working/idle/done) had no push channel. Herdr emits `pane.agent_status_changed` only through per-pane parameterized subscriptions, which the bridge never made, so status sync relied solely on the 1s `pane.list` poll. Browsers throttle timers in hidden tabs, so an agent could stay showing a stale status (e.g. idle after starting work) until the tab regained focus.

## Changes

- Bridge: new per-connection subscription loop (`server/src/connections/agent-status-subscription.ts`) that tracks panes with a detected agent. The pane set is seeded from `pane.list` and rebuilt on `pane_agent_detected`/`pane_closed`/`tab_closed`/`workspace_closed` with a debounced wake plus a fallback poll; membership changes requested mid-RPC are never lost, and transient subscribe failures retry without killing the loop.
- Bridge: `HerdrClient.subscribe` accepts parameterized subscriptions (e.g. `{ type, pane_id }`).
- Web: accept dot-named events whose wire data has no `type` field (previously dropped by validation).
- Web: refresh metadata immediately when the page becomes visible, the window regains focus, or the network comes back online.

## Verification

- `bun run format`, `bun run lint`, `bun run typecheck` (web + server)
- `bun run test`: 558 pass, including 10 new subscription-loop cases (rebuild races, retry, stop) and event-validation coverage
- Live end-to-end against herdr 0.8.0: status transitions reach the UI in ~0.1-0.5s instead of waiting for the next poll