### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.4.0 - 2026-08-20
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "herdr-gui",
   "private": true,
-  "version": "0.3.5",
+  "version": "0.4.0",
   "description": "A web GUI client for Herdr (local socket bridge + React dashboard).",
   "license": "MIT",
   "author": "Arthur",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "herdr-gui-server",
   "private": true,
-  "version": "0.3.5",
+  "version": "0.4.0",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "herdr-gui-web",
   "private": true,
-  "version": "0.3.5",
+  "version": "0.4.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Highlights

- Manage multiple local and SSH-backed Herdr servers from one bridge, with a per-browser active connection, isolated runtime state, persisted profiles, connection testing, automatic SSH supervision, and a connection manager UI.
- Push `pane.agent_status_changed` events per connection so agent working/idle/done transitions reach the browser immediately; hidden or unfocused pages refresh as soon as they become visible, focused, or back online.
- Refine dialogs and notifications; reload the page or PWA from the application menu.
- Fixes for Apple IME commits, Page Up/Page Down scrolling in fullscreen agents, and connection-scoped RPC isolation across server generations.

## Verification

- `bun run precommit` (format, lint, typecheck, 558 tests) green
- All four platform packages built and inspected: archive checksums verify, VERSION reads `herdr-gui 0.4.0 <platform>`, executables are 755, `--version` prints `herdr-gui 0.4.0`

Full details in CHANGELOG.md.