### PR TITLE
Allow WebSocket origins behind Host-rewriting reverse proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Allow browser WebSocket connections through reverse proxies that rewrite the
+  `Host` header by configuring `HERDR_GUI_ALLOWED_ORIGINS` (or
+  `--allowed-origins`), so deployments behind such proxies no longer sit at
+  "Browser disconnected from bridge".
+
 ## 0.4.0 - 2026-08-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ full list.
 | `--host <addr>` | `HOST` | `127.0.0.1` |
 | `--port <n>` | `PORT` | `8787` |
 | `--password <pw>` | `HERDR_GUI_PASSWORD` | _(generated token for non-localhost)_ |
+| `--allowed-origins <list>` | `HERDR_GUI_ALLOWED_ORIGINS` | _(same-origin WebSocket only)_ |
 | `--socket-path <path>` | `HERDR_SOCKET_PATH` | `~/.config/herdr/herdr.sock` |
 | `--client-socket-path <p>` | `HERDR_CLIENT_SOCKET_PATH` | `~/.config/herdr/herdr-client.sock` |
 | `--ssh-host <user@host>` | `HERDR_SSH_HOST` | _(auto tunnel remote Herdr sockets)_ |
@@ -217,6 +218,22 @@ Additional runtime settings:
 | `HERDR_GUI_UPDATE_BASE_URL` | Override the latest release asset directory (HTTPS; loopback HTTP allowed) |
 | `HERDR_GUI_DISABLE_UPDATE_CHECK=1` | Disable update checks |
 | `HERDR_GUI_RESTART_SUPERVISOR=0\|1` | Declare or override external supervisor detection |
+
+### Reverse proxies that rewrite the Host header
+
+The bridge accepts browser WebSocket upgrades only when the request `Origin`
+matches the request host. Reverse proxies that terminate TLS and forward to an
+internal address rewrite the `Host` header, which breaks that match and leaves
+the UI stuck at "Browser disconnected from bridge". List each public origin
+the GUI is reached through, for example:
+
+```sh
+HERDR_GUI_ALLOWED_ORIGINS=https://gui.example.com herdr-gui --host 0.0.0.0
+```
+
+Entries are comma-separated origins (scheme + host + optional port); entries
+without a scheme match both `http` and `https` on that host. Prefer
+configuring the proxy to preserve the original `Host` header when possible.
 
 A custom update mirror uses the same flat asset layout as GitHub Releases. It
 must provide each platform archive, its `.sha256` file, and the corresponding

--- a/server/src/config/server-config.ts
+++ b/server/src/config/server-config.ts
@@ -3,6 +3,7 @@ import { dirname, join, resolve } from "node:path";
 import { existsSync } from "node:fs";
 import { parseArgs } from "node:util";
 import { createHash } from "node:crypto";
+import { parseAllowedOrigins } from "../http/websocket-origin";
 import { validateSshDestination } from "../bridge/ssh-command";
 import { defaultAuthTokenPath, loadOrCreateAuthToken } from "./auth-token";
 
@@ -10,6 +11,7 @@ type CliArgs = Partial<{
   host: string;
   port: string;
   password: string;
+  "allowed-origins": string;
   "socket-path": string;
   "client-socket-path": string;
   "ssh-host": string;
@@ -26,6 +28,7 @@ export type ServerConfig = {
   port: number;
   password: string;
   authRequired: boolean;
+  allowedOrigins: Set<string>;
   generatedAuthToken?: string;
   generatedAuthTokenPath?: string;
   socketPath: string;
@@ -42,6 +45,7 @@ const cliOptions = {
   host: { type: "string" },
   port: { type: "string" },
   password: { type: "string" },
+  "allowed-origins": { type: "string" },
   "socket-path": { type: "string" },
   "client-socket-path": { type: "string" },
   "ssh-host": { type: "string" },
@@ -85,6 +89,9 @@ Options (flags override env vars):
   --host <addr>              listen address        (env HOST,            default 127.0.0.1)
   --port <n>                 listen port           (env PORT,            default 8787)
   --password <pw>            fixed login password  (env HERDR_GUI_PASSWORD; otherwise a token is generated)
+  --allowed-origins <list>   extra browser origins allowed to open the WebSocket,
+                             comma-separated         (env HERDR_GUI_ALLOWED_ORIGINS;
+                             for reverse proxies that rewrite the Host header)
   --socket-path <path>       control socket        (env HERDR_SOCKET_PATH)
   --client-socket-path <p>   render socket         (env HERDR_CLIENT_SOCKET_PATH)
   --ssh-host <user@host>     remote Herdr over SSH (env HERDR_SSH_HOST)
@@ -122,6 +129,11 @@ Options (flags override env vars):
     process.exit(1);
   }
   const password = configuredPassword || generatedAuthToken || "";
+  const allowedOrigins = parseAllowedOrigins(
+    (typeof args["allowed-origins"] === "string" && args["allowed-origins"]) ||
+      process.env.HERDR_GUI_ALLOWED_ORIGINS ||
+      undefined,
+  );
 
   const sshHostValue =
     (typeof args["ssh-host"] === "string" && args["ssh-host"]) ||
@@ -153,6 +165,7 @@ Options (flags override env vars):
     port,
     password,
     authRequired,
+    allowedOrigins,
     generatedAuthToken,
     generatedAuthTokenPath,
     socketPath,

--- a/server/src/http/websocket-origin.test.ts
+++ b/server/src/http/websocket-origin.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { isAllowedWebSocketOrigin } from "./websocket-origin";
+import {
+  isAllowedWebSocketOrigin,
+  parseAllowedOrigins,
+} from "./websocket-origin";
 
-function request(origin?: string) {
-  return new Request("http://127.0.0.1:8787/ws", {
+function request(origin?: string, url = "http://127.0.0.1:8787/ws") {
+  return new Request(url, {
     headers: origin === undefined ? undefined : { origin },
   });
 }
@@ -28,5 +31,37 @@ describe("WebSocket browser origin boundary", () => {
     ]) {
       expect(isAllowedWebSocketOrigin(request(origin))).toBeFalse();
     }
+  });
+
+  test("accepts allowlisted origins when a proxy rewrites the Host header", () => {
+    const allowed = parseAllowedOrigins("https://gui.example.com");
+    // The proxy forwarded the request with an internal Host.
+    const req = request("https://gui.example.com", "http://192.0.2.8:8787/ws");
+    expect(isAllowedWebSocketOrigin(req, allowed)).toBeTrue();
+    expect(isAllowedWebSocketOrigin(req)).toBeFalse();
+    // Unlisted origins stay rejected even with an allowlist configured.
+    expect(
+      isAllowedWebSocketOrigin(
+        request("https://attacker.example", "http://192.0.2.8:8787/ws"),
+        allowed,
+      ),
+    ).toBeFalse();
+  });
+
+  test("parseAllowedOrigins normalizes schemes, ports, and bare hosts", () => {
+    expect(
+      parseAllowedOrigins(
+        "https://gui.example.com, gui2.example.com:8443, http://plain.example/path",
+      ),
+    ).toEqual(
+      new Set([
+        "https://gui.example.com",
+        "https://gui2.example.com:8443",
+        "http://gui2.example.com:8443",
+        "http://plain.example",
+      ]),
+    );
+    expect(parseAllowedOrigins(undefined)).toEqual(new Set());
+    expect(parseAllowedOrigins(" , not a url ")).toEqual(new Set());
   });
 });

--- a/server/src/http/websocket-origin.ts
+++ b/server/src/http/websocket-origin.ts
@@ -1,4 +1,7 @@
-export function isAllowedWebSocketOrigin(request: Request): boolean {
+export function isAllowedWebSocketOrigin(
+  request: Request,
+  allowedOrigins?: ReadonlySet<string>,
+): boolean {
   const origin = request.headers.get("origin");
   // Non-browser clients do not send Origin. Authentication and the local OS
   // boundary continue to govern those clients.
@@ -6,13 +9,54 @@ export function isAllowedWebSocketOrigin(request: Request): boolean {
 
   try {
     const originUrl = new URL(origin);
+    if (
+      (originUrl.protocol !== "http:" && originUrl.protocol !== "https:") ||
+      origin !== originUrl.origin
+    ) {
+      return false;
+    }
+    // Reverse proxies that terminate TLS and forward to an internal address
+    // rewrite the Host header, so the browser origin no longer matches the
+    // request host. Deployments behind such proxies list their public origin
+    // explicitly (env HERDR_GUI_ALLOWED_ORIGINS / --allowed-origins).
+    if (allowedOrigins?.has(origin)) return true;
     const requestUrl = new URL(request.url);
-    return (
-      (originUrl.protocol === "http:" || originUrl.protocol === "https:") &&
-      origin === originUrl.origin &&
-      originUrl.host === requestUrl.host
-    );
+    return originUrl.host === requestUrl.host;
   } catch {
     return false;
   }
+}
+
+/**
+ * Normalizes a comma-separated allowlist into a set of exact origins
+ * (scheme + host + optional port). Entries without a scheme match both http
+ * and https on that host. Invalid entries are skipped.
+ */
+export function parseAllowedOrigins(raw: string | undefined): Set<string> {
+  const allowed = new Set<string>();
+  if (!raw) return allowed;
+  for (const entry of raw.split(",")) {
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+    try {
+      if (trimmed.includes("://")) {
+        const url = new URL(trimmed);
+        if (
+          (url.protocol === "http:" || url.protocol === "https:") &&
+          url.origin !== "null"
+        ) {
+          allowed.add(url.origin);
+        }
+      } else {
+        const url = new URL(`https://${trimmed}`);
+        if (url.host) {
+          allowed.add(`https://${url.host}`);
+          allowed.add(`http://${url.host}`);
+        }
+      }
+    } catch {
+      // Skip malformed entries; the allowlist stays fail-closed.
+    }
+  }
+  return allowed;
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1107,7 +1107,7 @@ function main() {
           }
 
           if (url.pathname === "/ws") {
-            if (!isAllowedWebSocketOrigin(req)) {
+            if (!isAllowedWebSocketOrigin(req, config.allowedOrigins)) {
               return new Response("forbidden websocket origin", {
                 status: 403,
               });


### PR DESCRIPTION
## Problem

The browser-origin boundary introduced in #18 (released in 0.4.0) accepts WebSocket upgrades only when the request `Origin` host matches the request host. Deployments behind reverse proxies that terminate TLS and forward to an internal address rewrite the `Host` header, so legitimate browsers are rejected with 403 and the UI sits at "Browser disconnected from bridge". This is a 0.4.0 regression for proxied deployments: HTTP works, the page loads, but the bridge WebSocket never connects.

## Changes

- New `HERDR_GUI_ALLOWED_ORIGINS` env var / `--allowed-origins` flag: a comma-separated list of extra browser origins allowed to open the WebSocket. Entries are full origins (`scheme://host[:port]`); entries without a scheme match both `http` and `https` on that host.
- The same-host rule and all other rejection paths are unchanged. Forwarded headers (`X-Forwarded-Host` etc.) are deliberately **not** trusted, since browser-supplied requests can set them.
- README documents the setting and recommends preserving the original `Host` header when possible.

## Verification

- `bun run precommit` (format, lint, typecheck, 560 tests) green, including new allowlist cases
- Live check against a running bridge: with the allowlist configured, a WS upgrade with a rewritten `Host` and the allowlisted browser origin upgrades (101); an unlisted origin is still rejected (403)
- Reproduced the failure first: rewritten `Host` + public origin → 403 `forbidden websocket origin` without the allowlist