### PR TITLE
Release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.4.1 - 2026-08-20
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "herdr-gui",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A web GUI client for Herdr (local socket bridge + React dashboard).",
   "license": "MIT",
   "author": "Arthur",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "herdr-gui-server",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "herdr-gui-web",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Highlights

- Remove the WebSocket browser-origin check from 0.4.0: it rejected legitimate browsers behind reverse proxies that rewrite the `Host` header, leaving the UI stuck at "Browser disconnected from bridge". Access control is once again the deployment's responsibility (authentication, HTTPS at the proxy, VPN, or firewall), as documented in SECURITY.md.

## Verification

- `bun run precommit` (format, lint, typecheck, 557 tests) green
- All four platform packages built and inspected: checksums verify, VERSION reads `herdr-gui 0.4.1 <platform>`, executables are 755, `--version` prints `herdr-gui 0.4.1`
- Live check: WS upgrade with rewritten `Host` and public `Origin` completes with no configuration