### PR TITLE
UX fixes, Mermaid previews, system theme, and release automation

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,0 +1,95 @@
+name: Cut Release
+
+# One-click release without any manual version-bump PR: bumps the three
+# package.json versions, finalizes the CHANGELOG "Unreleased" section, runs
+# the precommit gates, lands the release commit on main through an automated
+# pull request (branch protection requires PRs on main; the bot opens and
+# merges its own), tags the merge commit, pushes the tag, then starts the
+# Release workflow on it.
+#
+# No secrets or protection changes are required: the workflow only uses
+# GITHUB_TOKEN and follows the same PR rules as everyone else.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release (X.Y.Z, or patch/minor/major)
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+concurrency:
+  group: cut-release
+  cancel-in-progress: false
+
+jobs:
+  cut:
+    name: Bump, merge, tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.cut.outputs.tag }}
+      version: ${{ steps.cut.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+      - run: bun install --frozen-lockfile
+      - run: bun install --frozen-lockfile
+        working-directory: web
+      - run: bun install --frozen-lockfile
+        working-directory: server
+      - run: bun run precommit
+      - id: cut
+        name: Create the release commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          bun scripts/cut-release.ts "${{ inputs.version }}"
+      - name: Land the release on main and tag it
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.cut.outputs.tag }}
+          VERSION: ${{ steps.cut.outputs.version }}
+        run: |
+          set -euo pipefail
+          branch="release/${TAG}"
+          git checkout -b "$branch"
+          git push origin "$branch"
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "Release $VERSION" \
+            --body "Automated release commit for $TAG: version bump and changelog finalization. Created by the Cut Release workflow."
+          # Branch protection requires a PR (no approvals, no required
+          # checks), so the bot merges its own. Retry while GitHub computes
+          # mergeability for the fresh PR.
+          merged=""
+          for attempt in $(seq 1 12); do
+            if gh pr merge "$branch" --squash --delete-branch; then
+              merged=1
+              break
+            fi
+            sleep 5
+          done
+          if [ -z "$merged" ]; then
+            echo "error: could not merge the release PR $branch" >&2
+            exit 1
+          fi
+          # Point the tag at the squash-merge commit on main (the script
+          # tagged its local pre-merge commit) and push it.
+          git fetch origin main
+          git tag -f -a "$TAG" -m "herdr-gui $VERSION" origin/main
+          git push origin "$TAG"
+      - name: Dispatch Release on the new tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run "Release" --ref "${{ steps.cut.outputs.tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  # Allows the Cut Release workflow (or a maintainer) to dispatch a release
+  # run on an existing tag ref.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -130,10 +133,17 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
       - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true
+      - name: Extract release notes from the changelog
+        run: >-
+          bun scripts/changelog-notes.ts "${GITHUB_REF_NAME#v}"
+          > release-notes.md
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -143,5 +153,5 @@ jobs:
           scripts/install-herdr-gui.sh
           --verify-tag
           --latest
-          --generate-notes
+          --notes-file release-notes.md
           --title "herdr-gui $GITHUB_REF_NAME"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,22 @@ changes.
 ## Release & Changelog Notes
 
 Keep `CHANGELOG.md` concise: summarize user-visible highlights and important
-fixes only. Before every release, update `CHANGELOG.md`, commit the code, then
-build and publish release archives. Public releases are created from `v*` tags
-by `.github/workflows/release.yml`.
+fixes only, and accumulate entries under `## Unreleased` as changes land.
+
+Cutting a release takes one action, no manual version-bump PR:
+
+- GitHub: run the **Cut Release** workflow from the Actions tab with a version
+  (`X.Y.Z` or `patch`/`minor`/`major`). It runs the precommit gates, bumps the
+  three `package.json` versions, finalizes the changelog section, lands the
+  release commit on `main` through an automated PR that the workflow opens and
+  merges itself (branch protection requires PRs on `main`; no protection
+  changes or extra secrets are needed), tags the merge commit, and starts the
+  Release workflow on the tag.
+- Local: `bun run release:cut <X.Y.Z | patch | minor | major>` from a clean
+  `main` checkout creates the release commit and tag locally. Pushing them is
+  subject to the same branch protection as any other push, so prefer the CI
+  path above.
+
+Public releases are built and published by `.github/workflows/release.yml`
+from `v*` tags, with release notes taken from the version's `CHANGELOG.md`
+section.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Paste text or images into the terminal on mobile from a configurable Paste
+  shortcut button, using the same upload-and-paste-path flow as desktop paste.
+- Render Mermaid diagrams in the file previewer: `.mmd`/`.mermaid` files get a
+  Raw/Rendered toggle, and Mermaid code fences inside Markdown previews render
+  inline as theme-aware SVG diagrams.
+- Appearance: new "System" theme option that follows the OS color scheme
+  (`prefers-color-scheme`) and switches live when the OS theme changes; the
+  persisted preference is applied before first paint to avoid a theme flash.
+- Releases no longer require a manual version-bump PR: the new **Cut Release**
+  workflow (or `bun run release:cut <version>` locally) bumps versions,
+  finalizes the changelog, lands the release commit on `main` through an
+  automated self-merging PR, tags it, and starts the release pipeline in one
+  step. GitHub release notes now come from the version's `CHANGELOG.md`
+  section instead of auto-generated PR lists.
+
+### Changed
+
+- Creating the first connection profile no longer drops the default local
+  server from the list: it is persisted as a writable `Local` profile with the
+  same socket paths and auto-connect enabled, so the localhost Herdr remains
+  available alongside newly added profiles.
+- SSH connection profiles no longer require remote socket paths: leave them
+  empty and the bridge infers the default Herdr sockets under the remote home
+  directory (`~/.config/herdr/herdr.sock` and
+  `~/.config/herdr/herdr-client.sock`) at connect time.
+
+### Fixed
+
+- Use the theme-aware code surface for Markdown fenced code blocks in the file
+  previewer: light mode no longer renders them as a low-contrast dark box
+  (they previously always used the dark terminal background).
+- Replace the browser-native `window.confirm` when removing a connection with
+  the in-app confirmation dialog (Escape/Enter/focus handling included).
+- Keep popovers, dialogs, and menus open while terminal output streams in:
+  frame-driven terminal refocusing no longer steals focus from overlay UI,
+  which previously collapsed the connection menu (and other popovers) the
+  moment a working agent produced output.
+
 ## 0.4.1 - 2026-08-20
 
 ### Fixed

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -173,7 +173,10 @@ Lifecycle to manage saved per-checkout settings.
 - Search files that have been loaded into the tree.
 - See Git status badges on changed files and directories.
 - Preview text with line numbers, syntax highlighting, and `Cmd/Ctrl+F` search.
-- Render Markdown with a Raw/Rendered toggle.
+- Render Markdown with a Raw/Rendered toggle, including Mermaid code fences
+  rendered as diagrams.
+- Render `.mmd`/`.mermaid` Mermaid sources as diagrams with a Raw/Rendered
+  toggle.
 - Preview common image formats; unsupported binary files remain download-only.
 - Drag files onto the workspace root or a directory to upload them.
 - Download files directly or directories as workspace-scoped `.tar.gz`
@@ -211,6 +214,8 @@ preserved in the browser.
 - Up to four optional terminal side buttons.
 - Shortcut actions for control keys, arrows, Enter variants, and full/half-page
   terminal scrolling.
+- A Paste shortcut that sends clipboard text to the pane and uploads clipboard
+  images, pasting the uploaded path like the desktop paste flow.
 - A mobile pane switcher for tabs containing multiple panes.
 - A bundled glyph-only Nerd Font fallback for common terminal icons.
 - Installable as a standalone PWA from iOS/iPadOS Safari, macOS Safari, Chrome,
@@ -234,7 +239,7 @@ browser and do not change Herdr server configuration.
   count, or pause the other clients.
 - Enable browser task-completion notifications that return directly to the
   relevant pane.
-- Choose light/dark themes and persistent accent colors.
+- Choose light/dark themes (or follow the system color scheme) and persistent accent colors.
 - Install and manage a systemd or launchd user service from the CLI.
 - Check for herdr-gui releases and perform a checksum-verified, one-click binary
   update when running a standalone binary under a supported supervisor.

--- a/README.md
+++ b/README.md
@@ -166,21 +166,26 @@ Use the connection selector beside the application title to add, test, connect,
 disconnect, edit, and remove Herdr servers. Profiles are shared by every
 authenticated browser connected to the bridge, while each browser independently
 selects the connection it displays. Local profiles attach to existing Unix
-sockets; they never start Herdr.
+sockets; they never start Herdr. When the first profile is created, the
+default local server is kept as a writable `Local` profile instead of being
+dropped, so the localhost Herdr stays in the list.
 
 ![Connection selector showing local and SSH profiles](docs/screenshots/multi-connection-selector.png)
 
 SSH profiles require an already-running remote Herdr server and accept only an
-OpenSSH alias or `user@host`, plus explicit remote control and render socket
-paths. Configure ports, jump hosts, identities, and other transport details in
+OpenSSH alias or `user@host`. The remote control and render socket paths are
+optional: leave them empty and herdr-gui resolves the default Herdr sockets
+(`~/.config/herdr/herdr.sock` and `~/.config/herdr/herdr-client.sock`) under
+the remote home directory over SSH. Configure ports, jump hosts, identities,
+and other transport details in
 `~/.ssh/config`; herdr-gui uses the normal OpenSSH host-key and agent/Keychain
 policies and does not store passwords, private keys, passphrases, or arbitrary
-SSH options. A typical profile uses:
+SSH options. A typical profile needs only a destination:
 
 ```text
 Destination: workbox
-Control socket: /home/you/.config/herdr/herdr.sock
-Render socket:  /home/you/.config/herdr/herdr-client.sock
+Control socket: (empty - auto)
+Render socket:  (empty - auto)
 ```
 
 Connection profiles are stored atomically in

--- a/USAGE.md
+++ b/USAGE.md
@@ -134,15 +134,19 @@ http://192.0.2.23:8781/?token=<token>
 
 标题旁的连接选择器可以添加、测试、连接、断开、编辑和删除 Herdr server。
 Profile 由同一个 bridge 的所有已认证浏览器共享，但每个浏览器独立选择当前展示的
-连接。Local profile 只附着已经存在的 Unix socket，不会启动 Herdr。
+连接。Local profile 只附着已经存在的 Unix socket，不会启动 Herdr。创建首个
+profile 时，默认本地 server 会以可写的 `Local` profile 保留在列表中，而不是被
+移除。
 
 SSH profile 要求远端 Herdr server 已经运行，并填写 OpenSSH Host alias 或
-`user@host`，以及远端 control/render socket 的绝对路径。例如：
+`user@host`。远端 control/render socket 路径可留空：herdr-gui 会在连接时通过
+SSH 解析远端 home 目录下的默认 socket（`~/.config/herdr/herdr.sock` 与
+`~/.config/herdr/herdr-client.sock`）。例如：
 
 ```text
 SSH destination: devbox
-Control socket: /home/dev/.config/herdr/herdr.sock
-Render socket:  /home/dev/.config/herdr/herdr-client.sock
+Control socket: （留空自动推断）
+Render socket:  （留空自动推断）
 ```
 
 端口、跳板机和 identity 等连接参数应放在 `~/.ssh/config`：

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "package:linux-arm64": "scripts/package-release.sh linux-arm64",
     "package:darwin-x64": "scripts/package-release.sh darwin-x64",
     "package:darwin-arm64": "scripts/package-release.sh darwin-arm64",
+    "release:cut": "bun scripts/cut-release.ts",
+    "changelog:notes": "bun scripts/changelog-notes.ts",
     "format": "biome format --write .",
     "format:check": "biome format .",
     "lint": "eslint .",

--- a/scripts/changelog-notes.ts
+++ b/scripts/changelog-notes.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env bun
+// Print the CHANGELOG section for a released version; used as the body of the
+// GitHub release notes.
+//
+// Usage: bun scripts/changelog-notes.ts <X.Y.Z>
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CHANGELOG_PATH = fileURLToPath(
+  new URL(join("..", "CHANGELOG.md"), import.meta.url),
+);
+
+export function extractChangelogSection(
+  changelogText: string,
+  version: string,
+): string {
+  const heading = new RegExp(
+    `^## ${version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}( .*)?$`,
+    "m",
+  ).exec(changelogText);
+  if (!heading || heading.index === undefined) {
+    throw new Error(`CHANGELOG.md has no section for ${version}`);
+  }
+  const rest = changelogText.slice(heading.index + heading[0].length);
+  const nextHeading = rest.search(/^## /m);
+  const body = (nextHeading === -1 ? rest : rest.slice(0, nextHeading)).trim();
+  if (!body) {
+    throw new Error(`CHANGELOG.md section for ${version} is empty`);
+  }
+  return body;
+}
+
+if (import.meta.main) {
+  const version = process.argv[2];
+  if (!version) {
+    console.error("Usage: bun scripts/changelog-notes.ts <X.Y.Z>");
+    process.exit(1);
+  }
+  console.log(
+    extractChangelogSection(readFileSync(CHANGELOG_PATH, "utf8"), version),
+  );
+}

--- a/scripts/cut-release.test.ts
+++ b/scripts/cut-release.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test";
+import { extractChangelogSection } from "./changelog-notes";
+import {
+  parsePackageVersion,
+  replacePackageVersion,
+  resolveNextVersion,
+  rotateChangelog,
+} from "./cut-release";
+
+const PACKAGE_JSON = `{
+  "name": "herdr-gui",
+  "private": true,
+  "version": "0.4.1",
+  "scripts": {
+    "test": "bun test"
+  }
+}
+`;
+
+const CHANGELOG = `# Changelog
+
+## Unreleased
+
+### Added
+
+- Shiny new feature.
+
+### Fixed
+
+- Important fix.
+
+## 0.4.1 - 2026-08-20
+
+### Changed
+
+- Previous release entry.
+
+## 0.4.0 - 2026-08-20
+
+- Older entry.
+`;
+
+describe("parsePackageVersion", () => {
+  test("reads the top-level version", () => {
+    expect(parsePackageVersion(PACKAGE_JSON)).toBe("0.4.1");
+  });
+
+  test("rejects package.json without a version", () => {
+    expect(() => parsePackageVersion(`{ "name": "x" }`)).toThrow("version");
+  });
+});
+
+describe("replacePackageVersion", () => {
+  test("replaces only the version line and preserves the rest", () => {
+    const next = replacePackageVersion(PACKAGE_JSON, "0.4.1", "0.4.2");
+    expect(parsePackageVersion(next)).toBe("0.4.2");
+    expect(next).toBe(
+      PACKAGE_JSON.replace('"version": "0.4.1"', '"version": "0.4.2"'),
+    );
+  });
+
+  test("rejects an unexpected current version", () => {
+    expect(() => replacePackageVersion(PACKAGE_JSON, "9.9.9", "0.4.2")).toThrow(
+      "expected",
+    );
+  });
+});
+
+describe("resolveNextVersion", () => {
+  test("supports patch, minor, and major keywords", () => {
+    expect(resolveNextVersion("0.4.1", "patch")).toBe("0.4.2");
+    expect(resolveNextVersion("0.4.1", "minor")).toBe("0.5.0");
+    expect(resolveNextVersion("0.4.1", "major")).toBe("1.0.0");
+  });
+
+  test("accepts an explicit version greater than the current one", () => {
+    expect(resolveNextVersion("0.4.1", "0.4.10")).toBe("0.4.10");
+    expect(resolveNextVersion("0.4.1", "0.5.0")).toBe("0.5.0");
+  });
+
+  test("rejects versions that are not greater than the current one", () => {
+    expect(() => resolveNextVersion("0.4.1", "0.4.1")).toThrow("greater");
+    expect(() => resolveNextVersion("0.4.1", "0.3.9")).toThrow("greater");
+    expect(() => resolveNextVersion("0.4.1", "0.4.0")).toThrow("greater");
+  });
+
+  test("rejects malformed input", () => {
+    expect(() => resolveNextVersion("0.4.1", "0.4")).toThrow("X.Y.Z");
+    expect(() => resolveNextVersion("0.4.1", "next")).toThrow("X.Y.Z");
+    expect(() => resolveNextVersion("0.4.1", "")).toThrow("X.Y.Z");
+    expect(() => resolveNextVersion("0.4", "patch")).toThrow("X.Y.Z");
+  });
+});
+
+describe("rotateChangelog", () => {
+  test("moves the Unreleased entries under a dated version heading", () => {
+    const next = rotateChangelog(CHANGELOG, "0.4.2", "2026-08-21");
+    expect(next).toContain("## Unreleased\n\n## 0.4.2 - 2026-08-21\n");
+    expect(next).toContain(
+      "## 0.4.2 - 2026-08-21\n\n### Added\n\n- Shiny new feature.\n\n### Fixed\n\n- Important fix.\n\n## 0.4.1 - 2026-08-20",
+    );
+    expect(next).toContain("## 0.4.0 - 2026-08-20");
+  });
+
+  test("handles Unreleased as the last section", () => {
+    const text = "# Changelog\n\n## Unreleased\n\n- Only entry.\n";
+    const next = rotateChangelog(text, "1.0.0", "2026-08-21");
+    expect(next).toBe(
+      "# Changelog\n\n## Unreleased\n\n## 1.0.0 - 2026-08-21\n\n- Only entry.\n\n",
+    );
+  });
+
+  test("rejects an empty Unreleased section", () => {
+    const text =
+      "# Changelog\n\n## Unreleased\n\n## 0.4.1 - 2026-08-20\n\n- Old.\n";
+    expect(() => rotateChangelog(text, "0.4.2", "2026-08-21")).toThrow(
+      "no entries",
+    );
+  });
+
+  test("rejects a duplicate version section", () => {
+    expect(() => rotateChangelog(CHANGELOG, "0.4.1", "2026-08-21")).toThrow(
+      "already has a section",
+    );
+  });
+
+  test("rejects a changelog without an Unreleased section", () => {
+    expect(() =>
+      rotateChangelog(
+        "# Changelog\n\n## 0.4.1\n\n- Old.\n",
+        "0.4.2",
+        "2026-08-21",
+      ),
+    ).toThrow("Unreleased");
+  });
+});
+
+describe("extractChangelogSection", () => {
+  test("extracts a middle section without the heading", () => {
+    expect(extractChangelogSection(CHANGELOG, "0.4.1")).toBe(
+      "### Changed\n\n- Previous release entry.",
+    );
+  });
+
+  test("extracts the final section", () => {
+    expect(extractChangelogSection(CHANGELOG, "0.4.0")).toBe("- Older entry.");
+  });
+
+  test("rejects missing or empty sections", () => {
+    expect(() => extractChangelogSection(CHANGELOG, "9.9.9")).toThrow(
+      "no section",
+    );
+    const text = "# Changelog\n\n## 0.4.2 - 2026-08-21\n\n## 0.4.1\n\n- Old.\n";
+    expect(() => extractChangelogSection(text, "0.4.2")).toThrow("empty");
+  });
+});

--- a/scripts/cut-release.ts
+++ b/scripts/cut-release.ts
@@ -1,0 +1,226 @@
+#!/usr/bin/env bun
+// Cut a release without a version-bump PR: bump the three package.json
+// versions, finalize the CHANGELOG "Unreleased" section, commit, tag, and
+// optionally push. Pushing the tag (or dispatching the Release workflow on
+// it) builds and publishes the release.
+//
+// Usage:
+//   bun scripts/cut-release.ts <X.Y.Z | patch | minor | major> [--push]
+//   bun scripts/cut-release.ts 0.4.2            # commit + tag locally
+//   bun scripts/cut-release.ts patch --push     # commit, tag, push to origin
+//
+// Flags:
+//   --push        Push the release commit and tag to origin.
+//   --any-branch  Allow cutting from a branch other than main.
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const PACKAGE_FILES = [
+  "package.json",
+  "web/package.json",
+  "server/package.json",
+];
+const CHANGELOG_FILE = "CHANGELOG.md";
+const RELEASE_FILES = [...PACKAGE_FILES, CHANGELOG_FILE];
+
+const SEMVER_RE = /^(\d+)\.(\d+)\.(\d+)$/;
+
+export function parsePackageVersion(packageJsonText: string): string {
+  const match = /^(\s*)"version": "([^"]+)"/m.exec(packageJsonText);
+  if (!match) {
+    throw new Error('package.json has no top-level "version" field');
+  }
+  return match[2];
+}
+
+export function replacePackageVersion(
+  packageJsonText: string,
+  expectedCurrent: string,
+  next: string,
+): string {
+  const match = /^(\s*)"version": "([^"]+)"/m.exec(packageJsonText);
+  if (!match || match.index === undefined) {
+    throw new Error('package.json has no top-level "version" field');
+  }
+  if (match[2] !== expectedCurrent) {
+    throw new Error(
+      `package.json version is ${match[2]}, expected ${expectedCurrent}`,
+    );
+  }
+  return `${packageJsonText.slice(0, match.index)}${match[1]}"version": "${next}"${packageJsonText.slice(
+    match.index + match[0].length,
+  )}`;
+}
+
+export function resolveNextVersion(current: string, input: string): string {
+  const currentMatch = SEMVER_RE.exec(current);
+  if (!currentMatch) {
+    throw new Error(`Current version "${current}" is not in X.Y.Z form`);
+  }
+  const currentTuple = [
+    Number(currentMatch[1]),
+    Number(currentMatch[2]),
+    Number(currentMatch[3]),
+  ];
+  if (input === "patch") {
+    return `${currentTuple[0]}.${currentTuple[1]}.${currentTuple[2] + 1}`;
+  }
+  if (input === "minor") {
+    return `${currentTuple[0]}.${currentTuple[1] + 1}.0`;
+  }
+  if (input === "major") {
+    return `${currentTuple[0] + 1}.0.0`;
+  }
+  const nextMatch = SEMVER_RE.exec(input);
+  if (!nextMatch) {
+    throw new Error(`Version "${input}" must be X.Y.Z or patch|minor|major`);
+  }
+  const candidate = [
+    Number(nextMatch[1]),
+    Number(nextMatch[2]),
+    Number(nextMatch[3]),
+  ];
+  for (let index = 0; index < 3; index += 1) {
+    if (candidate[index] > currentTuple[index]) return input;
+    if (candidate[index] < currentTuple[index]) break;
+  }
+  throw new Error(
+    `Version ${input} must be greater than the current ${current}`,
+  );
+}
+
+export function rotateChangelog(
+  changelogText: string,
+  version: string,
+  date: string,
+): string {
+  if (new RegExp(`^## ${version}( |$)`, "m").test(changelogText)) {
+    throw new Error(`CHANGELOG.md already has a section for ${version}`);
+  }
+  const unreleasedMatch = /^## Unreleased\s*$/m.exec(changelogText);
+  if (!unreleasedMatch || unreleasedMatch.index === undefined) {
+    throw new Error('CHANGELOG.md has no "## Unreleased" section');
+  }
+  const bodyStart = unreleasedMatch.index + unreleasedMatch[0].length;
+  const rest = changelogText.slice(bodyStart);
+  const nextHeading = rest.search(/^## /m);
+  const body = (nextHeading === -1 ? rest : rest.slice(0, nextHeading)).trim();
+  if (!/^- /m.test(body)) {
+    throw new Error(
+      'CHANGELOG.md "Unreleased" section has no entries to release',
+    );
+  }
+  const before = changelogText.slice(0, unreleasedMatch.index);
+  const after = nextHeading === -1 ? "" : rest.slice(nextHeading);
+  const tail = after.endsWith("\n") || after === "" ? after : `${after}\n`;
+  return `${before}## Unreleased\n\n## ${version} - ${date}\n\n${body}\n\n${tail}`;
+}
+
+function git(...args: string[]): string {
+  return execFileSync("git", args, { cwd: REPO_ROOT, encoding: "utf8" }).trim();
+}
+
+function abort(message: string): never {
+  console.error(`cut-release: ${message}`);
+  process.exit(1);
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const input = args.find((arg) => !arg.startsWith("--"));
+  const push = args.includes("--push");
+  const anyBranch = args.includes("--any-branch");
+  if (!input || args.includes("--help")) {
+    console.log(
+      "Usage: bun scripts/cut-release.ts <X.Y.Z | patch | minor | major> [--push] [--any-branch]",
+    );
+    process.exit(input ? 0 : 1);
+  }
+
+  const branch = git("rev-parse", "--abbrev-ref", "HEAD");
+  if (branch !== "main" && !anyBranch) {
+    abort(
+      `on branch "${branch}"; releases are cut from main (pass --any-branch to override)`,
+    );
+  }
+  const dirty = git("status", "--porcelain", "--", ...RELEASE_FILES);
+  if (dirty) {
+    abort(
+      `release files have uncommitted changes, commit or stash them first:\n${dirty}`,
+    );
+  }
+
+  const current = parsePackageVersion(
+    readFileSync(join(REPO_ROOT, "package.json"), "utf8"),
+  );
+  const version = resolveNextVersion(current, input);
+  const tag = `v${version}`;
+
+  try {
+    git("rev-parse", "--verify", "--quiet", `refs/tags/${tag}`);
+    abort(`tag ${tag} already exists locally`);
+  } catch {
+    // Tag does not exist yet.
+  }
+  if (push && git("ls-remote", "--tags", "origin", tag)) {
+    abort(`tag ${tag} already exists on origin`);
+  }
+
+  const date = new Date().toISOString().slice(0, 10);
+  // Compute every output before writing anything so a validation failure
+  // leaves the worktree untouched.
+  const packageWrites = PACKAGE_FILES.map((file) => {
+    const path = join(REPO_ROOT, file);
+    const text = readFileSync(path, "utf8");
+    return {
+      path,
+      text: replacePackageVersion(text, parsePackageVersion(text), version),
+    };
+  });
+  const changelogPath = join(REPO_ROOT, CHANGELOG_FILE);
+  const changelogWrite = rotateChangelog(
+    readFileSync(changelogPath, "utf8"),
+    version,
+    date,
+  );
+  for (const { path, text } of packageWrites) {
+    writeFileSync(path, text);
+  }
+  writeFileSync(changelogPath, changelogWrite);
+
+  git("add", ...RELEASE_FILES);
+  git("commit", "-m", `Release ${version}`);
+  git("tag", "-a", tag, "-m", `herdr-gui ${version}`);
+  console.log(`Created release commit and tag ${tag} (version ${version}).`);
+
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `version=${version}\ntag=${tag}\n`,
+    );
+  }
+
+  if (push) {
+    git("push", "origin", `HEAD:${branch}`);
+    git("push", "origin", tag);
+    console.log(
+      `Pushed ${branch} and ${tag}. The Release workflow builds and publishes the archives.`,
+    );
+  } else {
+    console.log(
+      `Not pushed. When ready: git push origin HEAD:${branch} && git push origin ${tag}`,
+    );
+  }
+}
+
+if (import.meta.main) {
+  try {
+    main();
+  } catch (error) {
+    abort(error instanceof Error ? error.message : String(error));
+  }
+}

--- a/server/src/connections/profile-service.test.ts
+++ b/server/src/connections/profile-service.test.ts
@@ -76,8 +76,8 @@ function ssh(id: string, autoConnect = false): SshConnectionProfile {
     label: id.toUpperCase(),
     type: "ssh",
     ssh_destination: `operator@${id}`,
-    remote_control_socket_path: `/home/operator/${id}/herdr.sock`,
-    remote_client_socket_path: `/home/operator/${id}/herdr-client.sock`,
+    remote_control_socket_path: `/remote/${id}.sock`,
+    remote_client_socket_path: `/remote/${id}-client.sock`,
     auto_connect: autoConnect,
   };
 }
@@ -388,8 +388,66 @@ describe("connection profile service", () => {
     expect(store.load()).toEqual({
       version: 2,
       default_connection_id: "alpha",
-      profiles: [local("alpha")],
+      profiles: [
+        {
+          id: "local",
+          label: "Local",
+          type: "local",
+          control_socket_path: legacy.control_socket_path,
+          client_socket_path: legacy.client_socket_path,
+          auto_connect: true,
+        },
+        local("alpha"),
+      ],
     });
+    // The seeded local profile keeps the previous default server connected
+    // as an ordinary writable profile.
+    expect(service.list().map(({ id }) => id)).toEqual(["local", "alpha"]);
+    expect(service.list()[0]).toMatchObject({
+      id: "local",
+      label: "Local",
+      state: "ready",
+      read_only: false,
+    });
+  });
+
+  test("first create named local seeds the default server under a distinct id", async () => {
+    const store = new ConnectionProfileStore({ path: tempPath() });
+    const bootstrap = loadConnectionProfileBootstrap({
+      store,
+      legacyProfile: legacy,
+      explicitLegacyOverride: false,
+    });
+    const manager = new ConnectionManager<FakeRuntime>(
+      bootstrap.defaultConnectionId,
+    );
+    const service = new ConnectionProfileService({
+      manager,
+      store,
+      bootstrap,
+      createRuntime: runtimeFactory(new Map()),
+    });
+
+    await expect(service.create(local("local"))).resolves.toMatchObject({
+      id: "local",
+      is_default: true,
+    });
+    expect(store.load()).toEqual({
+      version: 2,
+      default_connection_id: "local",
+      profiles: [
+        {
+          id: "localhost",
+          label: "Local",
+          type: "local",
+          control_socket_path: legacy.control_socket_path,
+          client_socket_path: legacy.client_socket_path,
+          auto_connect: true,
+        },
+        local("local"),
+      ],
+    });
+    expect(service.list().map(({ id }) => id)).toEqual(["localhost", "local"]);
   });
 
   test("first create cannot leave a failed synthetic cleanup reconnectable", async () => {
@@ -430,7 +488,7 @@ describe("connection profile service", () => {
       is_default: true,
     });
     expect(manager.has("legacy-default")).toBeFalse();
-    expect(service.list().map(({ id }) => id)).toEqual(["alpha"]);
+    expect(service.list().map(({ id }) => id)).toEqual(["local", "alpha"]);
     expect(() => manager.start("legacy-default")).toThrow("unknown connection");
   });
 
@@ -1071,8 +1129,8 @@ describe("connection profile service", () => {
       type: "ssh",
       state: "disconnected",
       ssh_destination: "operator@remote",
-      remote_control_socket_path: "/home/operator/remote/herdr.sock",
-      remote_client_socket_path: "/home/operator/remote/herdr-client.sock",
+      remote_control_socket_path: "/remote/remote.sock",
+      remote_client_socket_path: "/remote/remote-client.sock",
       read_only: false,
     });
     expect(store.load()).toEqual({

--- a/server/src/connections/profile-service.ts
+++ b/server/src/connections/profile-service.ts
@@ -315,6 +315,12 @@ export class ConnectionProfileService<
       const previousRegistry = this.registry;
       const migration =
         !previousRegistry && !this.args.bootstrap.explicitLegacyOverride;
+      // The first persisted profile retires the synthetic legacy default.
+      // Keep the local server in the list by persisting it as a writable
+      // Local profile with the same socket paths instead of dropping it.
+      const migrationSeed = migration
+        ? this.localMigrationSeed(profile.id)
+        : null;
       const nextRegistry: PersistedConnectionRegistry = previousRegistry
         ? {
             ...previousRegistry,
@@ -324,16 +330,25 @@ export class ConnectionProfileService<
         : {
             version: CONNECTION_PROFILE_FILE_VERSION,
             default_connection_id: profile.id,
-            profiles: [profile],
+            profiles: migrationSeed ? [migrationSeed, profile] : [profile],
           };
       await this.args.store.save(nextRegistry);
       try {
+        if (migrationSeed) {
+          this.args.manager.register({
+            identity: connectionIdentityForProfile(migrationSeed),
+            createRuntime: this.args.createRuntime(migrationSeed),
+          });
+        }
         this.args.manager.register({
           identity: connectionIdentityForProfile(profile),
           createRuntime: this.args.createRuntime(profile),
         });
       } catch (error) {
         try {
+          if (migrationSeed && this.args.manager.has(migrationSeed.id)) {
+            await this.args.manager.unregister(migrationSeed.id);
+          }
           if (previousRegistry) await this.args.store.save(previousRegistry);
           else await this.args.store.clear();
         } catch (rollbackError) {
@@ -346,12 +361,21 @@ export class ConnectionProfileService<
         }
         throw error;
       }
+      if (migrationSeed) {
+        this.profiles.set(migrationSeed.id, {
+          profile: migrationSeed,
+          readOnly: false,
+        });
+      }
       this.profiles.set(profile.id, { profile, readOnly: false });
       this.registry = nextRegistry;
       if (migration) {
         this.args.manager.setDefault(profile.id);
         await this.args.manager.unregister(LEGACY_DEFAULT_CONNECTION_ID);
         this.profiles.delete(LEGACY_DEFAULT_CONNECTION_ID);
+      }
+      if (migrationSeed) {
+        await this.startManaged(migrationSeed.id, true).catch(() => undefined);
       }
       if (
         profile.auto_connect ||
@@ -361,6 +385,24 @@ export class ConnectionProfileService<
       }
       return this.item(profile.id);
     });
+  }
+
+  private localMigrationSeed(
+    newProfileId: string,
+  ): LocalConnectionProfile | null {
+    const legacyProfile = this.args.bootstrap.registrations.find(
+      (registration) =>
+        registration.profile.id === LEGACY_DEFAULT_CONNECTION_ID,
+    )?.profile;
+    if (!legacyProfile || legacyProfile.type !== "local") return null;
+    return {
+      id: newProfileId === "local" ? "localhost" : "local",
+      label: "Local",
+      type: "local",
+      control_socket_path: legacyProfile.control_socket_path,
+      client_socket_path: legacyProfile.client_socket_path,
+      auto_connect: true,
+    };
   }
 
   update(

--- a/server/src/connections/profiles.test.ts
+++ b/server/src/connections/profiles.test.ts
@@ -50,8 +50,8 @@ function ssh(id = "remote") {
     label: "Remote",
     type: "ssh" as const,
     ssh_destination: "operator@dev-box",
-    remote_control_socket_path: "/home/operator/.config/herdr/herdr.sock",
-    remote_client_socket_path: "/home/operator/.config/herdr/herdr-client.sock",
+    remote_control_socket_path: "/remote/herdr.sock",
+    remote_client_socket_path: "/remote/herdr-client.sock",
     auto_connect: false,
   };
 }
@@ -158,6 +158,17 @@ describe("connection profile validation", () => {
         validateSshConnectionProfile({ ...ssh(), [forbidden]: "secret" }),
       ).toThrow(`unknown field: ${forbidden}`);
     }
+  });
+
+  test("accepts empty SSH socket paths for remote home inference", () => {
+    const inferred = {
+      ...ssh(),
+      remote_control_socket_path: "",
+      remote_client_socket_path: "",
+    };
+    expect(validateSshConnectionProfile(inferred)).toEqual(inferred);
+    const mixed = { ...ssh(), remote_client_socket_path: "" };
+    expect(validateSshConnectionProfile(mixed)).toEqual(mixed);
   });
 
   test("rejects reserved IDs, control characters, relative/traversal paths, and unknown fields", () => {

--- a/server/src/connections/profiles.ts
+++ b/server/src/connections/profiles.ts
@@ -164,6 +164,9 @@ export function validateLocalConnectionProfile(
 }
 
 function validateRemoteSocketPath(value: unknown, field: string): string {
+  // An empty path asks the bridge to infer the default Herdr socket location
+  // under the remote home directory at connect time.
+  if (value === "") return "";
   if (
     typeof value !== "string" ||
     value.length < 2 ||
@@ -223,7 +226,11 @@ export function validateSshConnectionProfile(
     value.remote_client_socket_path,
     "remote_client_socket_path",
   );
-  if (remoteControlSocketPath === remoteClientSocketPath) {
+  if (
+    remoteControlSocketPath &&
+    remoteClientSocketPath &&
+    remoteControlSocketPath === remoteClientSocketPath
+  ) {
     throw new Error("remote control and render socket paths must differ");
   }
   return {

--- a/server/src/connections/ssh-profile-runtime.test.ts
+++ b/server/src/connections/ssh-profile-runtime.test.ts
@@ -12,8 +12,8 @@ function profile(): SshConnectionProfile {
     label: "Secret Host Label",
     type: "ssh",
     ssh_destination: "operator@dev-box",
-    remote_control_socket_path: "/home/operator/.config/herdr/herdr.sock",
-    remote_client_socket_path: "/home/operator/.config/herdr/herdr-client.sock",
+    remote_control_socket_path: "/remote/herdr.sock",
+    remote_client_socket_path: "/remote/herdr-client.sock",
     auto_connect: false,
   };
 }
@@ -44,6 +44,23 @@ describe("SSH profile runtime socket allocation", () => {
       remoteClientSocketPath: profile().remote_client_socket_path,
       hasExplicitSocketPath: true,
       hasExplicitClientSocketPath: true,
+    });
+  });
+
+  test("maps empty profile socket paths to remote home inference", () => {
+    const config = createSshProfileRuntimeConfig({
+      ...profile(),
+      remote_control_socket_path: "",
+      remote_client_socket_path: "",
+    });
+    directories.push(config.ownedRuntimeDirectory!);
+
+    expect(config).toMatchObject({
+      sshHost: "operator@dev-box",
+      hasExplicitSocketPath: false,
+      hasExplicitClientSocketPath: false,
+      remoteSocketPath: undefined,
+      remoteClientSocketPath: undefined,
     });
   });
 

--- a/server/src/connections/ssh-profile-runtime.ts
+++ b/server/src/connections/ssh-profile-runtime.ts
@@ -36,15 +36,21 @@ export function createSshProfileRuntimeConfig(
         "SSH runtime directory must be a private directory with short socket paths",
       );
     }
+    const remoteControlSocketPath =
+      profile.remote_control_socket_path || undefined;
+    const remoteClientSocketPath =
+      profile.remote_client_socket_path || undefined;
     return {
       socketPath,
       clientSocketPath,
       sshHost: profile.ssh_destination,
       session: undefined,
-      hasExplicitSocketPath: true,
-      hasExplicitClientSocketPath: true,
-      remoteSocketPath: profile.remote_control_socket_path,
-      remoteClientSocketPath: profile.remote_client_socket_path,
+      // Empty profile socket paths mean "infer": the tunnel resolves the
+      // default Herdr sockets under the remote home directory over SSH.
+      hasExplicitSocketPath: remoteControlSocketPath !== undefined,
+      hasExplicitClientSocketPath: remoteClientSocketPath !== undefined,
+      remoteSocketPath: remoteControlSocketPath,
+      remoteClientSocketPath: remoteClientSocketPath,
       ownedRuntimeDirectory: directory,
     };
   } catch (error) {

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -34,6 +34,7 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-unicode-graphemes": "^0.4.0",
         "@xterm/xterm": "^6.0.0",
+        "beautiful-mermaid": "^1.1.3",
         "cmdk": "^1.1.1",
         "codemirror": "^6.0.2",
         "diff2html": "^3.4.56",
@@ -375,6 +376,8 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.38", "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw=="],
 
+    "beautiful-mermaid": ["beautiful-mermaid@1.1.3", "https://registry.npmjs.org/beautiful-mermaid/-/beautiful-mermaid-1.1.3.tgz", { "dependencies": { "elkjs": "^0.11.0", "entities": "^7.0.1" } }, "sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg=="],
+
     "browserslist": ["browserslist@4.28.2", "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
     "bun-types": ["bun-types@1.3.14", "https://registry.npmjs.org/bun-types/-/bun-types-1.3.14.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
@@ -400,6 +403,10 @@
     "diff2html": ["diff2html@3.4.56", "https://registry.npmjs.org/diff2html/-/diff2html-3.4.56.tgz", { "dependencies": { "@profoundlogic/hogan": "^3.0.4", "diff": "^8.0.3" }, "optionalDependencies": { "highlight.js": "11.11.1" } }, "sha512-u9gfn+BlbHcyO7vItCIC4z49LJDUt31tODzOfAuJ5R1E7IdlRL6KjugcB9zOpejD+XiR+dDZbsnHSQ3g6A/u8A=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.376", "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz", {}, "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA=="],
+
+    "elkjs": ["elkjs@0.11.1", "https://registry.npmjs.org/elkjs/-/elkjs-0.11.1.tgz", {}, "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg=="],
+
+    "entities": ["entities@7.0.1", "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "esbuild": ["esbuild@0.21.5", "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 

--- a/web/index.html
+++ b/web/index.html
@@ -9,6 +9,22 @@
     <link rel="icon" type="image/png" href="/herdr-icon.png" />
     <link rel="apple-touch-icon" href="/herdr-icon.png" />
     <title>herdr-gui</title>
+    <script>
+      // Apply the persisted theme before first paint to avoid a flash of the
+      // default dark theme. "system" resolves via the OS color scheme.
+      try {
+        const storedTheme = localStorage.getItem("theme");
+        const resolvedTheme =
+          storedTheme === "light" || storedTheme === "dark"
+            ? storedTheme
+            : storedTheme === "system" &&
+                window.matchMedia("(prefers-color-scheme: light)").matches
+              ? "light"
+              : "dark";
+        document.documentElement.dataset.theme = resolvedTheme;
+        document.documentElement.style.colorScheme = resolvedTheme;
+      } catch {}
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/web/package.json
+++ b/web/package.json
@@ -40,6 +40,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-unicode-graphemes": "^0.4.0",
     "@xterm/xterm": "^6.0.0",
+    "beautiful-mermaid": "^1.1.3",
     "cmdk": "^1.1.1",
     "codemirror": "^6.0.2",
     "diff2html": "^3.4.56",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -26,7 +26,15 @@ import {
   useState,
 } from "react";
 import packageJson from "../package.json";
-import { type AccentColor, normalizeAccentColor } from "./appearance";
+import {
+  type AccentColor,
+  normalizeAccentColor,
+  normalizeThemePreference,
+  type ResolvedTheme,
+  resolveSystemTheme,
+  SYSTEM_THEME_QUERY,
+  type ThemePreference,
+} from "./appearance";
 import { AgentIcon } from "./components/AgentIcon";
 import { AgentPanel } from "./components/AgentPanel";
 import { CloseButton } from "./components/CloseButton";
@@ -176,7 +184,7 @@ function ToastMark({
   );
 }
 
-export type Theme = "dark" | "light";
+export type Theme = ThemePreference;
 type SidebarActivity = "workspaces" | "files" | "diff";
 type MobileView = "workspaces" | "session";
 
@@ -242,7 +250,11 @@ function loadSidebarWidth(): number {
 }
 
 function loadTheme(): Theme {
-  return localStorage.getItem(THEME_KEY) === "light" ? "light" : "dark";
+  return normalizeThemePreference(localStorage.getItem(THEME_KEY));
+}
+
+function loadSystemTheme(): ResolvedTheme {
+  return resolveSystemTheme(window.matchMedia(SYSTEM_THEME_QUERY));
 }
 
 function loadAccentColor(): AccentColor {
@@ -900,6 +912,9 @@ export default function App() {
     diff: "workspaces",
   });
   const [theme, setTheme] = useState<Theme>(() => loadTheme());
+  const [systemTheme, setSystemTheme] = useState<ResolvedTheme>(() =>
+    loadSystemTheme(),
+  );
   const [accentColor, setAccentColor] = useState<AccentColor>(() =>
     loadAccentColor(),
   );
@@ -1611,13 +1626,22 @@ export default function App() {
     selectPaneJumpIndex,
     toggleFileExplorer,
   ]);
+  useEffect(() => {
+    const media = window.matchMedia(SYSTEM_THEME_QUERY);
+    const onChange = (event: MediaQueryListEvent) => {
+      setSystemTheme(resolveSystemTheme(event));
+    };
+    media.addEventListener("change", onChange);
+    return () => media.removeEventListener("change", onChange);
+  }, []);
   useLayoutEffect(() => {
-    document.documentElement.dataset.theme = theme;
-    document.documentElement.style.colorScheme = theme;
+    const resolvedTheme = theme === "system" ? systemTheme : theme;
+    document.documentElement.dataset.theme = resolvedTheme;
+    document.documentElement.style.colorScheme = resolvedTheme;
     localStorage.setItem(THEME_KEY, theme);
     document.documentElement.dataset.accent = accentColor;
     localStorage.setItem(ACCENT_COLOR_KEY, accentColor);
-  }, [accentColor, theme]);
+  }, [accentColor, systemTheme, theme]);
   useEffect(() => {
     localStorage.setItem(
       MOBILE_TERMINAL_SHORTCUTS_STORAGE_KEY,

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -993,6 +993,22 @@ describe("bridge connection lifecycle", () => {
       remote_control_socket_path: "/remote/herdr.sock",
       remote_client_socket_path: "/remote/herdr-client.sock",
     });
+    expect(
+      parseConnectionSummary({
+        ...base,
+        source: "ssh-profile",
+        type: "ssh",
+        read_only: false,
+        auto_connect: false,
+        ssh_destination: "operator@dev-box",
+        remote_control_socket_path: "",
+        remote_client_socket_path: "",
+      }),
+    ).toMatchObject({
+      type: "ssh",
+      remote_control_socket_path: "",
+      remote_client_socket_path: "",
+    });
     for (const invalidSsh of [
       {
         type: "ssh",

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -98,7 +98,11 @@ export function parseConnectionSummary(
         item.remote_client_socket_path,
         "Remote render socket",
       );
-      if (controlPath === clientPath || !destination) return null;
+      if (
+        (controlPath && clientPath && controlPath === clientPath) ||
+        !destination
+      )
+        return null;
     } catch {
       return null;
     }

--- a/web/src/appearance.test.ts
+++ b/web/src/appearance.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { normalizeAccentColor } from "./appearance";
+import {
+  normalizeAccentColor,
+  normalizeThemePreference,
+  resolveSystemTheme,
+} from "./appearance";
+
+const matches = (value: boolean) => ({ matches: value });
 
 describe("appearance preferences", () => {
   test("accepts supported accent colors", () => {
@@ -13,5 +19,22 @@ describe("appearance preferences", () => {
     expect(normalizeAccentColor(null)).toBe("neutral");
     expect(normalizeAccentColor("")).toBe("neutral");
     expect(normalizeAccentColor("orange")).toBe("neutral");
+  });
+
+  test("accepts supported theme preferences, including system", () => {
+    expect(normalizeThemePreference("dark")).toBe("dark");
+    expect(normalizeThemePreference("light")).toBe("light");
+    expect(normalizeThemePreference("system")).toBe("system");
+  });
+
+  test("falls back to the dark theme for missing or unknown values", () => {
+    expect(normalizeThemePreference(null)).toBe("dark");
+    expect(normalizeThemePreference("")).toBe("dark");
+    expect(normalizeThemePreference("auto")).toBe("dark");
+  });
+
+  test("resolves the system theme from the color-scheme media query", () => {
+    expect(resolveSystemTheme(matches(true))).toBe("light");
+    expect(resolveSystemTheme(matches(false))).toBe("dark");
   });
 });

--- a/web/src/appearance.ts
+++ b/web/src/appearance.ts
@@ -15,3 +15,28 @@ export function normalizeAccentColor(value: string | null): AccentColor {
     ? (value as AccentColor)
     : "neutral";
 }
+
+export const THEME_OPTIONS = [
+  { value: "dark", label: "Dark" },
+  { value: "light", label: "Light" },
+  { value: "system", label: "System" },
+] as const;
+
+export type ThemePreference = (typeof THEME_OPTIONS)[number]["value"];
+export type ResolvedTheme = "dark" | "light";
+
+export function normalizeThemePreference(
+  value: string | null,
+): ThemePreference {
+  return value === "light" || value === "dark" || value === "system"
+    ? value
+    : "dark";
+}
+
+export function resolveSystemTheme(
+  media: Pick<MediaQueryList, "matches">,
+): ResolvedTheme {
+  return media.matches ? "light" : "dark";
+}
+
+export const SYSTEM_THEME_QUERY = "(prefers-color-scheme: light)";

--- a/web/src/components/ConfigMenu.tsx
+++ b/web/src/components/ConfigMenu.tsx
@@ -15,6 +15,7 @@ import {
   ScrollText,
   Server,
   Sun,
+  SunMoon,
   Users,
   Wifi,
 } from "lucide-react";
@@ -200,7 +201,13 @@ export function ConfigMenu({
               <div className="config-title">Preferences</div>
               <div className="config-preference-row">
                 <span className="config-item-icon">
-                  {theme === "light" ? <Sun size={15} /> : <Moon size={15} />}
+                  {theme === "system" ? (
+                    <SunMoon size={15} />
+                  ) : theme === "light" ? (
+                    <Sun size={15} />
+                  ) : (
+                    <Moon size={15} />
+                  )}
                 </span>
                 <div className="config-item-copy">
                   <strong>Theme</strong>
@@ -224,6 +231,15 @@ export function ConfigMenu({
                     onClick={() => onThemeChange("dark")}
                   >
                     <Moon size={14} />
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="Use system theme"
+                    aria-pressed={theme === "system"}
+                    className={theme === "system" ? "is-active" : ""}
+                    onClick={() => onThemeChange("system")}
+                  >
+                    <SunMoon size={14} />
                   </button>
                 </div>
               </div>

--- a/web/src/components/ConnectionSwitcher.tsx
+++ b/web/src/components/ConnectionSwitcher.tsx
@@ -414,25 +414,25 @@ function SshProfileForm({
         />
       </label>
       <label className="form-field">
-        <span>Remote control socket path</span>
+        <span>Remote control socket path (optional)</span>
         <input
           value={draft.remoteControlSocketPath}
           onChange={(event) =>
             update("remoteControlSocketPath", event.target.value)
           }
-          placeholder="/home/user/.config/herdr/herdr.sock"
+          placeholder="Auto: ~/.config/herdr/herdr.sock"
           autoCapitalize="none"
           spellCheck={false}
         />
       </label>
       <label className="form-field">
-        <span>Remote render socket path</span>
+        <span>Remote render socket path (optional)</span>
         <input
           value={draft.remoteClientSocketPath}
           onChange={(event) =>
             update("remoteClientSocketPath", event.target.value)
           }
-          placeholder="/home/user/.config/herdr/herdr-client.sock"
+          placeholder="Auto: ~/.config/herdr/herdr-client.sock"
           autoCapitalize="none"
           spellCheck={false}
         />
@@ -446,10 +446,12 @@ function SshProfileForm({
         Connect automatically when herdr-gui starts
       </label>
       <p className="connection-profile-security-note">
-        Authentication comes from the bridge service user&apos;s OpenSSH config,
-        ssh-agent, or system Keychain. Establish host trust outside herdr-gui.
-        Passwords, keys, passphrases, commands, ports, and SSH options are never
-        stored here.
+        Leave the socket paths empty and herdr-gui infers the default Herdr
+        sockets under the remote home directory at connect time. Authentication
+        comes from the bridge service user&apos;s OpenSSH config, ssh-agent, or
+        system Keychain. Establish host trust outside herdr-gui. Passwords,
+        keys, passphrases, commands, ports, and SSH options are never stored
+        here.
       </p>
       {feedback ? (
         <div
@@ -765,11 +767,25 @@ function ConnectionManagerDialog({ onClose }: { onClose: () => void }) {
                       <code title={connection.ssh_destination}>
                         Destination: {connection.ssh_destination}
                       </code>
-                      <code title={connection.remote_control_socket_path}>
-                        Remote control: {connection.remote_control_socket_path}
+                      <code
+                        title={
+                          connection.remote_control_socket_path ||
+                          "Inferred under the remote home directory"
+                        }
+                      >
+                        Remote control:{" "}
+                        {connection.remote_control_socket_path ||
+                          "auto (~/.config/herdr/herdr.sock)"}
                       </code>
-                      <code title={connection.remote_client_socket_path}>
-                        Remote render: {connection.remote_client_socket_path}
+                      <code
+                        title={
+                          connection.remote_client_socket_path ||
+                          "Inferred under the remote home directory"
+                        }
+                      >
+                        Remote render:{" "}
+                        {connection.remote_client_socket_path ||
+                          "auto (~/.config/herdr/herdr-client.sock)"}
                       </code>
                     </>
                   ) : (

--- a/web/src/components/ConnectionSwitcher.tsx
+++ b/web/src/components/ConnectionSwitcher.tsx
@@ -31,6 +31,7 @@ import {
 import { store, useStore } from "../store";
 import { CloseButton } from "./CloseButton";
 import { focusDialogElement } from "./dialogFocus";
+import { ConfirmDialog } from "./ModalDialogs";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 
 type Draft = {
@@ -493,6 +494,9 @@ function ConnectionManagerDialog({ onClose }: { onClose: () => void }) {
   const [editing, setEditing] = useState<
     ConnectionSummary | "new-local" | "new-ssh" | null
   >(null);
+  const [removeTarget, setRemoveTarget] = useState<ConnectionSummary | null>(
+    null,
+  );
   const [pending, setPending] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<Feedback>(null);
   const requestToken = useRef(0);
@@ -547,14 +551,16 @@ function ConnectionManagerDialog({ onClose }: { onClose: () => void }) {
       }
       if (event.key !== "Escape") return;
       event.preventDefault();
-      if (pending) return;
+      // The removal ConfirmDialog handles its own Escape via its capture
+      // listener; do not close the whole manager behind it.
+      if (pending || removeTarget) return;
       if (editing) closeEditing();
       else onClose();
     };
     window.addEventListener("keydown", onKey, { capture: true });
     return () =>
       window.removeEventListener("keydown", onKey, { capture: true });
-  }, [closeEditing, editing, onClose, pending]);
+  }, [closeEditing, editing, onClose, pending, removeTarget]);
 
   const performAction = async (
     key: string,
@@ -922,22 +928,7 @@ function ConnectionManagerDialog({ onClose }: { onClose: () => void }) {
                       type="button"
                       className="danger"
                       disabled={!!pending}
-                      onClick={() => {
-                        if (
-                          !window.confirm(
-                            `Remove connection "${connection.label}"? This disconnects herdr-gui but does not stop the Herdr server.`,
-                          )
-                        )
-                          return;
-                        void performAction(
-                          `remove-${connection.id}`,
-                          () =>
-                            bridge.call("connections.remove", {
-                              id: connection.id,
-                            }),
-                          "Connection removed.",
-                        );
-                      }}
+                      onClick={() => setRemoveTarget(connection)}
                     >
                       Remove
                     </button>
@@ -947,6 +938,28 @@ function ConnectionManagerDialog({ onClose }: { onClose: () => void }) {
             );
           })}
         </div>
+        <ConfirmDialog
+          open={!!removeTarget}
+          title="Remove Connection"
+          message={
+            removeTarget
+              ? `Remove connection "${removeTarget.label}"? This disconnects herdr-gui but does not stop the Herdr server.`
+              : "Remove this connection?"
+          }
+          confirmLabel="Remove"
+          danger
+          onClose={() => setRemoveTarget(null)}
+          onConfirm={() => {
+            const target = removeTarget;
+            setRemoveTarget(null);
+            if (!target) return;
+            void performAction(
+              `remove-${target.id}`,
+              () => bridge.call("connections.remove", { id: target.id }),
+              "Connection removed.",
+            );
+          }}
+        />
       </div>
     </div>
   );

--- a/web/src/components/FilePreviewContent.tsx
+++ b/web/src/components/FilePreviewContent.tsx
@@ -3,6 +3,7 @@ import type { Extension } from "@codemirror/state";
 import type { EditorView as CodeMirrorEditorView } from "@codemirror/view";
 import type { FileExplorerEntry, FilePreview } from "../types";
 import { MarkdownPreview } from "./markdown";
+import { MermaidDiagram } from "./MermaidDiagram";
 
 export type ActiveFilePreviewSelection = {
   entry: FileExplorerEntry | null;
@@ -204,6 +205,11 @@ function isMarkdownPath(path: string) {
   );
 }
 
+function isMermaidPath(path: string) {
+  const lower = path.toLowerCase();
+  return lower.endsWith(".mmd") || lower.endsWith(".mermaid");
+}
+
 function currentDocumentTheme(): AppTheme {
   return document.documentElement.dataset.theme === "light" ? "light" : "dark";
 }
@@ -245,7 +251,7 @@ export function FilePreviewContent({
 }) {
   const previewSectionRef = useRef<HTMLElement | null>(null);
   const editorViewRef = useRef<CodeMirrorEditorView | null>(null);
-  const [markdownMode, setMarkdownMode] = useState<"rendered" | "raw">(
+  const [previewMode, setPreviewMode] = useState<"rendered" | "raw">(
     "rendered",
   );
   const theme = useDocumentTheme();
@@ -253,15 +259,16 @@ export function FilePreviewContent({
   const previewPath = preview?.path ?? "";
   const hasPreviewText = previewText !== null;
   const hasMarkdownPreview = hasPreviewText && isMarkdownPath(previewPath);
-  const renderMarkdownPreview =
-    hasMarkdownPreview && markdownMode === "rendered";
+  const hasMermaidPreview = hasPreviewText && isMermaidPath(previewPath);
+  const hasRichPreview = hasMarkdownPreview || hasMermaidPreview;
+  const renderRichPreview = hasRichPreview && previewMode === "rendered";
 
   useEffect(() => {
-    setMarkdownMode("rendered");
+    setPreviewMode("rendered");
   }, [previewPath]);
 
   useEffect(() => {
-    if (!hasPreviewText || renderMarkdownPreview) return;
+    if (!hasPreviewText || renderRichPreview) return;
     const onKey = (e: KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
       if (e.key.toLowerCase() !== "f") return;
@@ -275,7 +282,7 @@ export function FilePreviewContent({
     window.addEventListener("keydown", onKey, { capture: true });
     return () =>
       window.removeEventListener("keydown", onKey, { capture: true });
-  }, [hasPreviewText, renderMarkdownPreview]);
+  }, [hasPreviewText, renderRichPreview]);
 
   return (
     <section
@@ -285,7 +292,7 @@ export function FilePreviewContent({
       tabIndex={-1}
       onKeyDownCapture={(e) => {
         if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "f") {
-          if (renderMarkdownPreview) return;
+          if (renderRichPreview) return;
           e.preventDefault();
           e.stopPropagation();
           openPreviewSearch(editorViewRef.current);
@@ -295,17 +302,17 @@ export function FilePreviewContent({
       <div className="file-preview-head">
         <div className="file-preview-title-row">
           <strong>{entry?.name ?? "Preview"}</strong>
-          {hasMarkdownPreview ? (
+          {hasRichPreview ? (
             <button
               type="button"
               className="file-preview-mode-toggle"
               onClick={() =>
-                setMarkdownMode((mode) =>
+                setPreviewMode((mode) =>
                   mode === "rendered" ? "raw" : "rendered",
                 )
               }
             >
-              {markdownMode === "rendered" ? "Raw" : "Rendered"}
+              {previewMode === "rendered" ? "Raw" : "Rendered"}
             </button>
           ) : null}
         </div>
@@ -341,10 +348,13 @@ export function FilePreviewContent({
       {!loading && !error && preview?.truncated ? (
         <div className="file-preview-banner">Preview truncated at 512 KB.</div>
       ) : null}
-      {!loading && !error && hasPreviewText && renderMarkdownPreview ? (
+      {!loading && !error && hasMarkdownPreview && renderRichPreview ? (
         <MarkdownPreview text={previewText} />
       ) : null}
-      {!loading && !error && hasPreviewText && !renderMarkdownPreview ? (
+      {!loading && !error && hasMermaidPreview && renderRichPreview ? (
+        <MermaidDiagram code={previewText} className="file-preview-mermaid" />
+      ) : null}
+      {!loading && !error && hasPreviewText && !renderRichPreview ? (
         <CodeMirrorPreview
           text={previewText}
           path={previewPath}

--- a/web/src/components/MermaidDiagram.tsx
+++ b/web/src/components/MermaidDiagram.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import { loadMermaidModule, renderMermaidDiagram } from "../mermaidRender";
+
+type MermaidDiagramState =
+  | { kind: "loading" }
+  | { kind: "empty" }
+  | { kind: "error"; error: string }
+  | { kind: "svg"; svg: string };
+
+export function MermaidDiagram({
+  code,
+  className = "",
+}: {
+  code: string;
+  className?: string;
+}) {
+  const [state, setState] = useState<MermaidDiagramState>({ kind: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!code.trim()) {
+      setState({ kind: "empty" });
+      return () => {
+        cancelled = true;
+      };
+    }
+    setState({ kind: "loading" });
+    void loadMermaidModule().then(
+      (mermaid) => {
+        if (cancelled) return;
+        const rendered = renderMermaidDiagram(mermaid, code);
+        setState(
+          rendered.ok
+            ? { kind: "svg", svg: rendered.svg }
+            : { kind: "error", error: rendered.error },
+        );
+      },
+      (error) => {
+        if (cancelled) return;
+        setState({
+          kind: "error",
+          error: error instanceof Error ? error.message : String(error),
+        });
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [code]);
+
+  if (state.kind === "loading") {
+    return (
+      <div
+        className={`mermaid-diagram is-loading ${className}`.trim()}
+        role="status"
+        aria-live="polite"
+      >
+        <span className="file-loading-spinner" />
+        Rendering diagram
+      </div>
+    );
+  }
+  if (state.kind === "empty") {
+    return (
+      <div className={`mermaid-diagram is-empty ${className}`.trim()}>
+        Empty diagram
+      </div>
+    );
+  }
+  if (state.kind === "error") {
+    return (
+      <div className={`mermaid-diagram-error ${className}`.trim()} role="alert">
+        Mermaid render failed: {state.error}
+      </div>
+    );
+  }
+  return (
+    <div
+      className={`mermaid-diagram ${className}`.trim()}
+      role="img"
+      aria-label="Mermaid diagram"
+      // SVG produced by beautiful-mermaid from escaped labels; the shared
+      // module promise keeps it identical to the Markdown preview output.
+      dangerouslySetInnerHTML={{ __html: state.svg }}
+    />
+  );
+}

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -65,6 +65,7 @@ import {
   TerminalImeTextareaFallbackTracker,
 } from "../terminalIme";
 import { terminalPageScroll, terminalWheelScroll } from "../terminalScroll";
+import { terminalFocusBlockedByOverlay } from "../terminalFocus";
 import {
   TerminalAttachFrameWatchdog,
   TerminalResizeSync,
@@ -579,6 +580,9 @@ export function TerminalView({
         const activeIsTerminalInput = !!activeElement?.closest(".xterm");
         if (!term || (isEditableElement(active) && !activeIsTerminalInput))
           return;
+        // Streaming frames must not steal focus from an open popover, dialog,
+        // or menu: moving focus out of an overlay dismisses it.
+        if (terminalFocusBlockedByOverlay(activeElement, document)) return;
         term.focus();
       }, 0);
     });

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -486,6 +486,7 @@ export function TerminalView({
     (el: HTMLDivElement | null) => setContainer(el),
     [],
   );
+  const pasteFromClipboardRef = useRef<(() => void) | null>(null);
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const attachedRef = useRef<string | null>(null);
@@ -1149,6 +1150,11 @@ export function TerminalView({
         clipboardPasteInFlight = false;
       }
     };
+    pasteFromClipboardRef.current = () => {
+      void pasteFromBrowserClipboard().catch((error) => {
+        setUploadError(`Paste failed: ${(error as Error).message}`);
+      });
+    };
     const applePlatform = isApplePlatform();
     const appleTouchPlatform = applePlatform && navigator.maxTouchPoints > 0;
     const shouldHandleCtrlVPaste = !applePlatform;
@@ -1683,6 +1689,7 @@ export function TerminalView({
       document.removeEventListener("pointerdown", onDocumentPointerDown, {
         capture: true,
       });
+      pasteFromClipboardRef.current = null;
       imeFallback.dispose();
       linkProvider.dispose();
       const terminalId = attachedRef.current ?? desiredTerminalRef.current;
@@ -1866,6 +1873,9 @@ export function TerminalView({
     if (!execution) return;
     if (execution.type === "scroll") {
       scrollPage(execution.direction, execution.amount);
+    } else if (execution.type === "paste") {
+      if (shouldAvoidVirtualKeyboard()) blurTerminalInput();
+      pasteFromClipboardRef.current?.();
     } else {
       sendControl(execution.bytes);
     }

--- a/web/src/components/markdown.tsx
+++ b/web/src/components/markdown.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { marked } from "marked";
+import { loadMermaidModule, renderMermaidDiagram } from "../mermaidRender";
 
 const MARKDOWN_ALLOWED_TAGS = new Set([
   "a",
@@ -86,6 +87,15 @@ export function sanitizeMarkdownHtml(html: string) {
     for (const attr of Array.from(element.attributes)) {
       const name = attr.name.toLowerCase();
       if (
+        name === "class" &&
+        tag === "code" &&
+        /^language-[a-z0-9#+.-]{1,40}$/i.test(attr.value.trim())
+      ) {
+        // Keep the fenced-code language hint so mermaid blocks can be found
+        // and replaced with rendered diagrams after sanitization.
+        continue;
+      }
+      if (
         name.startsWith("on") ||
         name === "style" ||
         !MARKDOWN_ALLOWED_ATTRS.has(name)
@@ -135,8 +145,49 @@ export function MarkdownPreview({
   breaks?: boolean;
 }) {
   const html = useMemo(() => renderMarkdown(text, { breaks }), [text, breaks]);
+  const articleRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const root = articleRef.current;
+    if (!root) return;
+    const blocks = Array.from(
+      root.querySelectorAll("pre > code.language-mermaid"),
+    );
+    if (blocks.length === 0) return;
+    let cancelled = false;
+    loadMermaidModule()
+      .then((mermaid) => {
+        if (cancelled) return;
+        for (const codeElement of blocks) {
+          const pre = codeElement.parentElement;
+          if (!pre || pre.tagName !== "PRE" || !pre.isConnected) continue;
+          const code = codeElement.textContent ?? "";
+          if (!code.trim()) continue;
+          const rendered = renderMermaidDiagram(mermaid, code);
+          if (rendered.ok) {
+            const figure = document.createElement("div");
+            figure.className = "mermaid-diagram";
+            figure.setAttribute("role", "img");
+            figure.setAttribute("aria-label", "Mermaid diagram");
+            figure.innerHTML = rendered.svg;
+            pre.replaceWith(figure);
+          } else {
+            const note = document.createElement("div");
+            note.className = "mermaid-diagram-error";
+            note.textContent = `Mermaid render failed: ${rendered.error}`;
+            pre.before(note);
+          }
+        }
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [html]);
+
   return (
     <article
+      ref={articleRef}
       className={`file-preview-markdown ${className}`.trim()}
       dangerouslySetInnerHTML={{ __html: html }}
     />

--- a/web/src/connectionProfiles.test.ts
+++ b/web/src/connectionProfiles.test.ts
@@ -92,8 +92,8 @@ describe("local connection profile presentation", () => {
       id: "remote-dev",
       label: "Remote Dev",
       sshDestination: " operator@dev-box ",
-      remoteControlSocketPath: "/home/operator/.config/herdr/herdr.sock",
-      remoteClientSocketPath: "/home/operator/.config/herdr/herdr-client.sock",
+      remoteControlSocketPath: "/remote/herdr.sock",
+      remoteClientSocketPath: "/remote/herdr-client.sock",
       autoConnect: false,
     };
     expect(sshConnectionProfilePayload(input)).toEqual({
@@ -101,9 +101,8 @@ describe("local connection profile presentation", () => {
       label: "Remote Dev",
       type: "ssh",
       ssh_destination: "operator@dev-box",
-      remote_control_socket_path: "/home/operator/.config/herdr/herdr.sock",
-      remote_client_socket_path:
-        "/home/operator/.config/herdr/herdr-client.sock",
+      remote_control_socket_path: "/remote/herdr.sock",
+      remote_client_socket_path: "/remote/herdr-client.sock",
       auto_connect: false,
     });
     for (const sshDestination of [
@@ -130,6 +129,35 @@ describe("local connection profile presentation", () => {
         remoteClientSocketPath: input.remoteControlSocketPath,
       }),
     ).toThrow("must differ");
+  });
+
+  test("allows empty SSH socket paths so the bridge infers them", () => {
+    const input = {
+      id: "remote-dev",
+      label: "Remote Dev",
+      sshDestination: "operator@dev-box",
+      remoteControlSocketPath: " ",
+      remoteClientSocketPath: "",
+      autoConnect: true,
+    };
+    expect(sshConnectionProfilePayload(input)).toEqual({
+      id: "remote-dev",
+      label: "Remote Dev",
+      type: "ssh",
+      ssh_destination: "operator@dev-box",
+      remote_control_socket_path: "",
+      remote_client_socket_path: "",
+      auto_connect: true,
+    });
+    expect(
+      sshConnectionProfilePayload({
+        ...input,
+        remoteControlSocketPath: "/remote/herdr.sock",
+      }),
+    ).toMatchObject({
+      remote_control_socket_path: "/remote/herdr.sock",
+      remote_client_socket_path: "",
+    });
   });
 
   test("protects read-only and default profiles from destructive controls", () => {

--- a/web/src/connectionProfiles.ts
+++ b/web/src/connectionProfiles.ts
@@ -180,7 +180,11 @@ export function sshConnectionProfilePayload(value: {
   validateSshDestination(sshDestination);
   validateRemoteSocketPath(remoteControlSocketPath, "Remote control socket");
   validateRemoteSocketPath(remoteClientSocketPath, "Remote render socket");
-  if (remoteControlSocketPath === remoteClientSocketPath) {
+  if (
+    remoteControlSocketPath &&
+    remoteClientSocketPath &&
+    remoteControlSocketPath === remoteClientSocketPath
+  ) {
     throw new Error("Remote control and render socket paths must differ.");
   }
   return {

--- a/web/src/mermaidRender.test.ts
+++ b/web/src/mermaidRender.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import type { RenderOptions } from "beautiful-mermaid";
+import { prepareMermaidSvg, renderMermaidDiagram } from "./mermaidRender";
+
+const SAMPLE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50" width="100" height="50" style="--bg:#000;--fg:#fff">
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400&amp;display=swap');
+  text { font-family: 'Inter', system-ui, sans-serif; }
+  svg { --_text: var(--fg); }
+</style>
+<defs>
+  <marker id="arrowhead" markerWidth="8" markerHeight="5" refX="7" refY="2.5" orient="auto">
+    <polygon points="0 0, 8 2.5, 0 5" fill="var(--_arrow)" />
+  </marker>
+</defs>
+<polyline class="edge" data-from="A" data-to="B" points="1,2 3,4" fill="none" stroke="var(--_line)" marker-end="url(#arrowhead)" />
+<g class="node" data-id="A" id="A"><text>A</text></g>
+<g class="node" data-id="B" id="B"><text>&lt;img src=x onerror=alert(1)&gt;</text></g>
+<style type="text/css">
+  svg { --_chart-grid: var(--_inner-stroke); }
+</style>
+</svg>`;
+
+describe("prepareMermaidSvg", () => {
+  test("strips the document-global style block", () => {
+    const prepared = prepareMermaidSvg(SAMPLE_SVG, "mmd-7");
+    expect(prepared).not.toContain("<style");
+    expect(prepared).not.toContain("fonts.googleapis.com");
+  });
+
+  test("namespaces ids and marker references so diagrams cannot collide", () => {
+    const prepared = prepareMermaidSvg(SAMPLE_SVG, "mmd-7");
+    expect(prepared).toContain('id="mmd-7-arrowhead"');
+    expect(prepared).toContain("url(#mmd-7-arrowhead)");
+    expect(prepared).toContain('id="mmd-7-A"');
+    expect(prepared).toContain('id="mmd-7-B"');
+    expect(prepared).not.toContain(' id="A"');
+    // Attribute-only lookalikes stay untouched.
+    expect(prepared).toContain('data-id="A"');
+  });
+});
+
+describe("renderMermaidDiagram", () => {
+  test("renders with theme variables and a unique token", () => {
+    let seenOptions: RenderOptions | undefined;
+    const mermaid = {
+      renderMermaidSVG(_code: string, options?: RenderOptions) {
+        seenOptions = options;
+        return SAMPLE_SVG;
+      },
+    };
+    const first = renderMermaidDiagram(mermaid, "graph LR\n  A --> B");
+    const second = renderMermaidDiagram(mermaid, "graph LR\n  A --> B");
+    expect(seenOptions).toMatchObject({
+      bg: "var(--viewer-code-bg)",
+      fg: "var(--text)",
+      line: "var(--accent)",
+      transparent: true,
+    });
+    if (!first.ok || !second.ok) throw new Error("expected rendered svgs");
+    expect(first.svg).toContain("<svg");
+    const firstToken = first.svg.match(/id="(mmd-\d+)-arrowhead"/)?.[1];
+    const secondToken = second.svg.match(/id="(mmd-\d+)-arrowhead"/)?.[1];
+    expect(firstToken).toBeTruthy();
+    expect(secondToken).toBeTruthy();
+    expect(firstToken).not.toBe(secondToken);
+  });
+
+  test("reports renderer failures without throwing", () => {
+    const mermaid = {
+      renderMermaidSVG() {
+        throw new Error('Invalid mermaid header: "junk"');
+      },
+    };
+    const result = renderMermaidDiagram(mermaid, "junk");
+    expect(result).toEqual({
+      ok: false,
+      error: 'Invalid mermaid header: "junk"',
+    });
+  });
+});

--- a/web/src/mermaidRender.ts
+++ b/web/src/mermaidRender.ts
@@ -1,0 +1,69 @@
+/**
+ * Mermaid diagram rendering backed by beautiful-mermaid. The renderer and its
+ * layout engine are lazily code-split so the main bundle stays small; both
+ * file previews and Markdown code fences share the cached module promise.
+ */
+
+export type MermaidRenderResult =
+  | { ok: true; svg: string }
+  | { ok: false; error: string };
+
+type MermaidModule = typeof import("beautiful-mermaid");
+
+let mermaidModulePromise: Promise<MermaidModule> | null = null;
+
+export function loadMermaidModule(): Promise<MermaidModule> {
+  mermaidModulePromise ??= import("beautiful-mermaid");
+  return mermaidModulePromise;
+}
+
+let mermaidDiagramCounter = 0;
+
+/**
+ * Rewrites renderer output for safe inline embedding:
+ * - drops the bundled <style> block, whose bare `svg`/`text` selectors and
+ *   Google Fonts @import would leak into the whole document (the scoped
+ *   replacement lives in styles.css under .mermaid-diagram);
+ * - prefixes svg-internal ids so multiple diagrams on one page cannot share
+ *   `arrowhead`/node ids and cross-reference each other's markers.
+ */
+export function prepareMermaidSvg(svg: string, token: string): string {
+  let result = svg.replace(/<style[^>]*>[\s\S]*?<\/style>/g, "");
+  const ids = new Set(
+    Array.from(result.matchAll(/\sid="([^"]+)"/g), (match) => match[1]),
+  );
+  for (const id of ids) {
+    const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    result = result
+      .replace(new RegExp(`(\\s)id="${escaped}"`, "g"), `$1id="${token}-${id}"`)
+      .split(`url(#${id})`)
+      .join(`url(#${token}-${id})`);
+  }
+  return result;
+}
+
+export function renderMermaidDiagram(
+  mermaid: Pick<MermaidModule, "renderMermaidSVG">,
+  code: string,
+): MermaidRenderResult {
+  try {
+    const svg = mermaid.renderMermaidSVG(code, {
+      // Reference app theme variables so light/dark switches apply without a
+      // re-render. Diagram labels are XML-escaped by the renderer.
+      bg: "var(--viewer-code-bg)",
+      fg: "var(--text)",
+      line: "var(--accent)",
+      transparent: true,
+    });
+    mermaidDiagramCounter += 1;
+    return {
+      ok: true,
+      svg: prepareMermaidSvg(svg, `mmd-${mermaidDiagramCounter}`),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/web/src/mobileTerminalShortcutAction.test.ts
+++ b/web/src/mobileTerminalShortcutAction.test.ts
@@ -13,6 +13,12 @@ describe("mobile terminal shortcut execution", () => {
     });
   });
 
+  test("routes the paste action to the browser clipboard", () => {
+    expect(mobileTerminalShortcutExecution("paste")).toEqual({
+      type: "paste",
+    });
+  });
+
   test("routes page actions to full or half scrollback", () => {
     expect(mobileTerminalShortcutExecution("page-up")).toEqual({
       type: "scroll",

--- a/web/src/mobileTerminalShortcutAction.ts
+++ b/web/src/mobileTerminalShortcutAction.ts
@@ -1,5 +1,6 @@
 import {
   mobileTerminalShortcutBytes,
+  mobileTerminalShortcutClipboard,
   mobileTerminalShortcutScroll,
   type MobileTerminalShortcutAction,
 } from "./mobileTerminalShortcuts";
@@ -13,11 +14,17 @@ export type MobileTerminalShortcutExecution =
       type: "scroll";
       direction: "up" | "down";
       amount: "full" | "half";
+    }
+  | {
+      type: "paste";
     };
 
 export function mobileTerminalShortcutExecution(
   action: MobileTerminalShortcutAction,
 ): MobileTerminalShortcutExecution | null {
+  if (mobileTerminalShortcutClipboard(action) === "paste") {
+    return { type: "paste" };
+  }
   const scroll = mobileTerminalShortcutScroll(action);
   if (scroll) return { type: "scroll", ...scroll };
   const bytes = mobileTerminalShortcutBytes(action);

--- a/web/src/mobileTerminalShortcuts.test.ts
+++ b/web/src/mobileTerminalShortcuts.test.ts
@@ -23,7 +23,7 @@ describe("mobile terminal shortcuts", () => {
       rows.map((row) => row.map((shortcut) => shortcut?.action ?? null)),
     ).toEqual([
       ["ctrl-c", "ctrl-d", "ctrl-r", "escape", "page-up", null, null, null],
-      ["tab", "enter", "alt-up", "page-down", null, null, null, null],
+      ["tab", "enter", "alt-up", "page-down", "paste", null, null, null],
     ]);
     expect(
       rows.every((row) => row.length <= MAX_MOBILE_TERMINAL_SHORTCUTS_PER_ROW),
@@ -160,7 +160,7 @@ describe("mobile terminal shortcuts", () => {
     const encoded = serializeMobileTerminalShortcutRows(first);
     const parsed = parseMobileTerminalShortcutRows(encoded);
     expect(parsed[0][0]?.label).toBe("Changed");
-    expect(mobileTerminalShortcutCount(parsed)).toBe(9);
+    expect(mobileTerminalShortcutCount(parsed)).toBe(10);
   });
 
   test("encodes control, navigation, and modified keys", () => {

--- a/web/src/mobileTerminalShortcuts.ts
+++ b/web/src/mobileTerminalShortcuts.ts
@@ -19,6 +19,7 @@ type MobileTerminalShortcutOptionDefinition = {
     direction: "up" | "down";
     amount: "full" | "half";
   };
+  clipboard?: "paste";
 };
 
 export const MOBILE_TERMINAL_SHORTCUT_OPTIONS = [
@@ -147,6 +148,13 @@ export const MOBILE_TERMINAL_SHORTCUT_OPTIONS = [
     defaultButtonLabel: "Bksp",
     group: "Basic",
     bytes: [0x7f],
+  },
+  {
+    id: "paste",
+    label: "Paste (text or image)",
+    defaultButtonLabel: "Paste",
+    group: "Basic",
+    clipboard: "paste",
   },
   {
     id: "delete",
@@ -308,7 +316,7 @@ const defaultRows: MobileTerminalShortcutRows = [
     { id: "default-enter", label: "Enter", action: "enter" },
     { id: "default-alt-up", label: "A-Up", action: "alt-up" },
     { id: "default-page-down", label: "PgDn", action: "page-down" },
-    null,
+    { id: "default-paste", label: "Paste", action: "paste" },
     null,
     null,
     null,
@@ -331,6 +339,12 @@ export function mobileTerminalShortcutOption(
   action: MobileTerminalShortcutAction,
 ) {
   return optionById.get(action) ?? null;
+}
+
+export function mobileTerminalShortcutClipboard(
+  action: MobileTerminalShortcutAction,
+): "paste" | null {
+  return optionById.get(action)?.clipboard ?? null;
 }
 
 export function mobileTerminalShortcutBytes(

--- a/web/src/sshProfileValidation.ts
+++ b/web/src/sshProfileValidation.ts
@@ -40,6 +40,9 @@ export function validateRemoteSocketPath(
   value: unknown,
   field: string,
 ): string {
+  // An empty path asks the bridge to infer the default Herdr socket location
+  // under the remote home directory at connect time.
+  if (value === "") return "";
   if (
     typeof value !== "string" ||
     value.length < 2 ||

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4188,6 +4188,67 @@ textarea:focus {
   border: 0;
   background: var(--border-soft);
 }
+.mermaid-diagram {
+  display: flex;
+  justify-content: center;
+  overflow: auto;
+  padding: 12px 8px;
+}
+.mermaid-diagram > svg {
+  max-width: 100%;
+  height: auto;
+  /* Scoped replacement for the beautiful-mermaid <style> block that is
+     stripped before injection; values derive from the per-diagram --bg/--fg
+     (and optional --line/--muted overrides) set inline by the renderer. */
+  --_text: var(--fg);
+  --_text-sec: var(--muted, color-mix(in srgb, var(--fg) 60%, var(--bg)));
+  --_text-muted: var(--muted, color-mix(in srgb, var(--fg) 40%, var(--bg)));
+  --_text-faint: color-mix(in srgb, var(--fg) 25%, var(--bg));
+  --_line: var(--line, color-mix(in srgb, var(--fg) 50%, var(--bg)));
+  --_arrow: var(--accent, color-mix(in srgb, var(--fg) 85%, var(--bg)));
+  --_node-fill: var(--surface, color-mix(in srgb, var(--fg) 3%, var(--bg)));
+  --_node-stroke: var(--border, color-mix(in srgb, var(--fg) 20%, var(--bg)));
+  --_group-fill: var(--bg);
+  --_group-hdr: color-mix(in srgb, var(--fg) 5%, var(--bg));
+  --_inner-stroke: color-mix(in srgb, var(--fg) 12%, var(--bg));
+  --_key-badge: color-mix(in srgb, var(--fg) 10%, var(--bg));
+}
+.mermaid-diagram text {
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
+    sans-serif;
+}
+.mermaid-diagram.is-loading,
+.mermaid-diagram.is-empty {
+  justify-content: flex-start;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 13px;
+}
+.mermaid-diagram.is-empty {
+  justify-content: center;
+  padding: 24px 12px;
+}
+.mermaid-diagram-error {
+  margin: 0.85em 0;
+  padding: 8px 12px;
+  border: 1px solid var(--danger-border);
+  border-radius: 7px;
+  background: var(--danger-soft);
+  color: var(--danger-text);
+  font-size: 12.5px;
+}
+.file-preview-mermaid {
+  flex: 1 1 auto;
+  min-height: 0;
+  align-items: flex-start;
+  padding: 24px 16px;
+}
+.file-preview-mermaid.mermaid-diagram-error {
+  display: block;
+  margin: 16px;
+}
 .terminal-preview-modal {
   width: min(1120px, calc(100vw - 48px));
   height: min(760px, calc(100vh - 64px));

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4147,7 +4147,7 @@ textarea:focus {
   padding: 12px 14px;
   border: 1px solid var(--border-soft);
   border-radius: 7px;
-  background: var(--terminal-bg);
+  background: var(--viewer-code-bg);
   color: var(--text-code);
 }
 .file-preview-markdown pre code {

--- a/web/src/terminalFocus.test.ts
+++ b/web/src/terminalFocus.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { terminalFocusBlockedByOverlay } from "./terminalFocus";
+
+function docWithOpenPopper(open: boolean) {
+  return {
+    querySelector: (selector: string) =>
+      open && selector === "[data-radix-popper-content-wrapper]"
+        ? ({} as Element)
+        : null,
+  } as Pick<Document, "querySelector">;
+}
+
+function elementMatching(matching: string[] | null) {
+  return {
+    closest: (selector: string) =>
+      matching?.includes(selector) ? ({} as Element) : null,
+  } as Pick<Element, "closest">;
+}
+
+describe("terminalFocusBlockedByOverlay", () => {
+  test("blocks refocusing whenever a Radix popover is mounted", () => {
+    const doc = docWithOpenPopper(true);
+    expect(terminalFocusBlockedByOverlay(null, doc)).toBe(true);
+    // Covers the open-animation frame where focus still sits on the trigger.
+    expect(terminalFocusBlockedByOverlay(elementMatching(null), doc)).toBe(
+      true,
+    );
+  });
+
+  test("blocks when focus is inside a modal or menu without any popover", () => {
+    const doc = docWithOpenPopper(false);
+    expect(
+      terminalFocusBlockedByOverlay(
+        elementMatching([
+          '[data-radix-popper-content-wrapper], .modal-backdrop, [role="dialog"], [role="menu"]',
+        ]),
+        doc,
+      ),
+    ).toBe(true);
+  });
+
+  test("allows refocusing with no overlay and no focused element", () => {
+    expect(terminalFocusBlockedByOverlay(null, docWithOpenPopper(false))).toBe(
+      false,
+    );
+  });
+
+  test("allows refocusing ordinary page elements", () => {
+    expect(
+      terminalFocusBlockedByOverlay(
+        elementMatching(null),
+        docWithOpenPopper(false),
+      ),
+    ).toBe(false);
+  });
+});

--- a/web/src/terminalFocus.ts
+++ b/web/src/terminalFocus.ts
@@ -1,0 +1,27 @@
+/**
+ * Guards the terminal's frame-driven refocusing. Terminal frames refocus the
+ * xterm textarea so keyboard input keeps working, but doing so while an
+ * overlay owns focus dismisses it: Radix's DismissableLayer treats focusin
+ * outside its content as an outside interaction and closes the popover. That
+ * is why streaming output (e.g. a working agent) collapsed the connection
+ * menu the moment it opened.
+ */
+const TERMINAL_FOCUS_OVERLAY_SELECTOR =
+  '[data-radix-popper-content-wrapper], .modal-backdrop, [role="dialog"], [role="menu"]';
+const RADIX_POPPER_CONTENT_WRAPPER = "[data-radix-popper-content-wrapper]";
+
+type FocusableLike = Pick<Element, "closest">;
+type DocumentLike = Pick<Document, "querySelector">;
+
+export function terminalFocusBlockedByOverlay(
+  activeElement: FocusableLike | null,
+  doc: DocumentLike,
+): boolean {
+  // An open Radix popover mounts its content in a portal wrapper. Block even
+  // before focus lands inside the content (the open-animation frame), so a
+  // terminal frame cannot win that race and dismiss the popover. Closed
+  // popovers unmount their content, so a mounted wrapper means "open".
+  if (doc.querySelector(RADIX_POPPER_CONTENT_WRAPPER)) return true;
+  if (!activeElement) return false;
+  return Boolean(activeElement.closest(TERMINAL_FOCUS_OVERLAY_SELECTOR));
+}


### PR DESCRIPTION
## Summary

Ten focused commits improving everyday UX and automating the release flow:

- **Mobile paste**: the Basic shortcut group gains a configurable Paste action (default second row) using the same upload-and-paste-path flow as desktop paste, so text and images can be pasted into the terminal on mobile.
- **Overlay focus fix**: streaming frames no longer steal focus from open popovers/menus/dialogs - the connection menu previously collapsed the moment a working agent produced output.
- **SSH profiles**: remote control/render socket paths are now optional; the bridge infers the default Herdr sockets under the remote home directory at connect time.
- **Mermaid**: `.mmd`/`.mermaid` files get a Raw/Rendered toggle, and mermaid fences in Markdown previews render inline as theme-aware SVG (lazy-loaded beautiful-mermaid).
- **Local profile seed**: creating the first connection profile no longer drops the default local server; it is persisted as a writable `Local` profile with auto-connect.
- **Connection removal**: the browser-native `window.confirm` is replaced with the in-app ConfirmDialog.
- **Light mode**: Markdown fenced code blocks use the theme-aware code surface instead of the always-dark terminal background.
- **System theme**: new option follows `prefers-color-scheme`, switches live with the OS, and applies before first paint to avoid a theme flash.
- **Release automation**: the **Cut Release** workflow (workflow_dispatch) bumps versions, finalizes the changelog, lands the commit on main through an automated self-merging PR, tags it, and dispatches the Release workflow - no manual version-bump PRs anymore. Release notes now come from the version's CHANGELOG section. `bun run release:cut` wraps the same script locally.

## Verification

- `bun run format:check`, `bun run lint`, `bun run typecheck`, `bun run test` all pass (589 tests, including 16 new for the release scripts, 3 for theme preferences, 4 for the focus guard, plus mermaid/profile/paste coverage)
- `bun run build` verified locally; the built app was deployed and smoke-tested (connection manager, light/dark/system theme, markdown preview, connection seeding)
- Release script verified end-to-end in a scratch clone: failure guards leave the tree clean, cut + notes extraction + duplicate rejection behave correctly

## Notes

- The Cut Release workflow becomes dispatchable once this PR lands on main (workflow_dispatch requires the workflow file on the default branch). It works with the existing branch protection: the bot opens and merges its own release PR, so no protection changes or extra secrets are needed.