### PR TITLE
Fix terminal attach against Herdr 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix terminal attach against Herdr 0.8.2 (protocol 20), which renumbered the
+  `TerminalAttach` launch-mode wire value and rejected direct attaches with
+  "connection is not pending terminal attach".
+
 ## 0.4.3 - 2026-08-22
 
 ### Added

--- a/server/src/bridge/protocol-compat.ts
+++ b/server/src/bridge/protocol-compat.ts
@@ -14,6 +14,16 @@ export function isSupportedHerdrProtocol(protocol: number): boolean {
   );
 }
 
+// Herdr 0.8.2 (protocol 20) inserted ClientLaunchMode::AppDirectGraphics at
+// wire index 1, moving ClientLaunchMode::TerminalAttach from 1 to 2. Map the
+// semantic terminal-attach launch mode onto the negotiated protocol's wire
+// value; App stays 0 on every protocol.
+export const APP_DIRECT_GRAPHICS_LAUNCH_MODE_PROTOCOL = 20;
+
+export function terminalAttachLaunchModeWireValue(protocol: number): number {
+  return protocol >= APP_DIRECT_GRAPHICS_LAUNCH_MODE_PROTOCOL ? 2 : 1;
+}
+
 export function assertSupportedHerdrProtocol(protocol: number): void {
   if (
     !Number.isSafeInteger(protocol) ||

--- a/server/src/bridge/terminal-bridge.ts
+++ b/server/src/bridge/terminal-bridge.ts
@@ -248,7 +248,7 @@ export function createTerminalBridge(args: {
     // receive them, so keep one lightweight app connection while terminals are
     // being viewed and route its clipboard messages back to the input owner.
     const connecting = relay
-      .connect(cols, rows, { launchMode: 0, encoding: 1 })
+      .connect(cols, rows, { launchMode: "app", encoding: 1 })
       .then(() => {
         if (disposed) {
           relay.close();
@@ -512,7 +512,7 @@ export function createTerminalBridge(args: {
       }
     });
     const terminalReady = thin
-      .connect(cols, rows, { launchMode: 1, encoding: 1 })
+      .connect(cols, rows, { launchMode: "terminal-attach", encoding: 1 })
       .then(() => {
         if (!isCurrent(creationRevision)) {
           thin.close();

--- a/server/src/bridge/thin-client.test.ts
+++ b/server/src/bridge/thin-client.test.ts
@@ -25,6 +25,8 @@ afterEach(async () => {
 async function startHandshakeServer(
   welcome: (protocol: number) => { version: number; error?: string },
   onConnection: () => void = () => undefined,
+  onHello: (hello: { protocol: number; launchMode: number }) => void = () =>
+    undefined,
 ) {
   const socketPath = path.join(
     tmpdir(),
@@ -44,6 +46,14 @@ async function startHandshakeServer(
       const reader = new BinReader(input.subarray(4, length + 4));
       expect(reader.variant()).toBe(0);
       const protocol = reader.varint();
+      reader.varint(); // cols
+      reader.varint(); // rows
+      reader.varint(); // cell_width_px
+      reader.varint(); // cell_height_px
+      reader.varint(); // requested_encoding
+      reader.varint(); // keybindings
+      const launchMode = reader.varint();
+      onHello({ protocol, launchMode });
       const response = welcome(protocol);
       const writer = new BinWriter();
       writer.variant(0);
@@ -132,12 +142,56 @@ describe("Herdr thin-client protocol compatibility", () => {
       });
       const client = new ThinClient(socketPath, async () => protocol);
 
-      await client.connect(100, 30, { launchMode: 1, encoding: 1 });
+      await client.connect(100, 30, {
+        launchMode: "terminal-attach",
+        encoding: 1,
+      });
 
       expect(seen).toEqual([protocol]);
       client.close();
     });
   }
+
+  test("maps the terminal-attach launch mode onto the negotiated protocol", async () => {
+    // Herdr 0.8.2 (protocol 20) renumbered ClientLaunchMode::TerminalAttach
+    // from 1 to 2 when AppDirectGraphics was inserted at index 1.
+    for (const [protocol, expectedLaunchMode] of [
+      [19, 1],
+      [20, 2],
+      [21, 2],
+    ] as const) {
+      const seen: Array<{ protocol: number; launchMode: number }> = [];
+      const socketPath = await startHandshakeServer(
+        (requestedProtocol) => ({ version: requestedProtocol }),
+        () => undefined,
+        (hello) => seen.push(hello),
+      );
+      const client = new ThinClient(socketPath, async () => protocol);
+
+      await client.connect(100, 30, {
+        launchMode: "terminal-attach",
+        encoding: 1,
+      });
+
+      expect(seen).toEqual([{ protocol, launchMode: expectedLaunchMode }]);
+      client.close();
+    }
+  });
+
+  test("keeps the app launch mode at wire value 0 on newer protocols", async () => {
+    const seen: Array<{ protocol: number; launchMode: number }> = [];
+    const socketPath = await startHandshakeServer(
+      (requestedProtocol) => ({ version: requestedProtocol }),
+      () => undefined,
+      (hello) => seen.push(hello),
+    );
+    const client = new ThinClient(socketPath, async () => 20);
+
+    await client.connect(100, 30, { launchMode: "app", encoding: 1 });
+
+    expect(seen).toEqual([{ protocol: 20, launchMode: 0 }]);
+    client.close();
+  });
 
   test("rejects a welcome error instead of treating the socket as attached", async () => {
     const socketPath = await startHandshakeServer((protocol) => ({
@@ -197,7 +251,10 @@ describe("Herdr thin-client protocol compatibility", () => {
     });
     const client = new ThinClient(socketPath, async () => 16);
 
-    await client.connect(100, 30, { launchMode: 1, encoding: 1 });
+    await client.connect(100, 30, {
+      launchMode: "terminal-attach",
+      encoding: 1,
+    });
     client.attach("term_1", true);
     client.attach("term_1", true);
     await Bun.sleep(10);
@@ -234,7 +291,10 @@ describe("Herdr thin-client protocol compatibility", () => {
     });
     const client = new ThinClient(socketPath, async () => 17);
 
-    await client.connect(100, 30, { launchMode: 1, encoding: 1 });
+    await client.connect(100, 30, {
+      launchMode: "terminal-attach",
+      encoding: 1,
+    });
     client.scroll("up", 28, null, null, "page-key");
     client.scroll("down", 17, null, null, "page-key");
     await receivedScrolls;
@@ -270,7 +330,10 @@ describe("Herdr thin-client protocol compatibility", () => {
       client.once("clipboard", resolve),
     );
 
-    await client.connect(100, 30, { launchMode: 1, encoding: 1 });
+    await client.connect(100, 30, {
+      launchMode: "terminal-attach",
+      encoding: 1,
+    });
     client.attach("term_1", true);
 
     expect(await clipboard).toEqual({ data: clipboardData });

--- a/server/src/bridge/thin-client.ts
+++ b/server/src/bridge/thin-client.ts
@@ -1,7 +1,10 @@
 import { EventEmitter } from "node:events";
 import * as net from "node:net";
 import { BinReader, BinWriter, encodeFrame } from "./bincode";
-import { assertSupportedHerdrProtocol } from "./protocol-compat";
+import {
+  assertSupportedHerdrProtocol,
+  terminalAttachLaunchModeWireValue,
+} from "./protocol-compat";
 
 const HANDSHAKE_TIMEOUT_MS = 8_000;
 
@@ -23,6 +26,13 @@ const SM = {
   Clipboard: 6,
   MouseCapture: 9,
 } as const;
+
+/**
+ * Semantic launch mode requested in the Hello handshake. The wire value is
+ * derived from the negotiated protocol version because Herdr 0.8.2 renumbered
+ * the ClientLaunchMode enum.
+ */
+export type ThinClientLaunchMode = "app" | "terminal-attach";
 
 export interface CellData {
   symbol: string;
@@ -84,7 +94,7 @@ export class ThinClient extends EventEmitter {
   async connect(
     cols: number,
     rows: number,
-    opts: { launchMode?: number; encoding?: number } = {},
+    opts: { launchMode?: ThinClientLaunchMode; encoding?: number } = {},
   ): Promise<void> {
     if (this.sock) throw new Error("thin client is already connected");
     if (this.closed) throw new Error("thin client is closed");
@@ -108,7 +118,7 @@ export class ThinClient extends EventEmitter {
         this.sendHello(
           cols,
           rows,
-          opts.launchMode ?? 0,
+          opts.launchMode ?? "app",
           opts.encoding ?? 0,
           protocolVersion,
         );
@@ -222,7 +232,7 @@ export class ThinClient extends EventEmitter {
   private sendHello(
     cols: number,
     rows: number,
-    launchMode: number,
+    launchMode: ThinClientLaunchMode,
     encoding: number,
     protocolVersion: number,
   ) {
@@ -235,7 +245,13 @@ export class ThinClient extends EventEmitter {
     w.varint(0); // cell_height_px
     w.varint(encoding); // requested_encoding: 0=SemanticFrame, 1=TerminalAnsi
     w.varint(0); // keybindings = Server
-    w.varint(launchMode); // launch_mode: 0=App, 1=TerminalAttach
+    // launch_mode: App is always 0; TerminalAttach moved from 1 to 2 in
+    // protocol 20 (Herdr 0.8.2) when AppDirectGraphics was inserted.
+    w.varint(
+      launchMode === "terminal-attach"
+        ? terminalAttachLaunchModeWireValue(protocolVersion)
+        : 0,
+    );
     this.write(w.toBuffer());
   }
 

--- a/server/src/probe-thin.ts
+++ b/server/src/probe-thin.ts
@@ -25,7 +25,7 @@ c.on("terminal", (t) => {
 });
 c.on("frame", (f) => console.log(`FRAME ${f.width}x${f.height}`));
 
-await c.connect(cols, rows, { launchMode: 1, encoding: 1 }); // TerminalAttach + TerminalAnsi
+await c.connect(cols, rows, { launchMode: "terminal-attach", encoding: 1 }); // TerminalAttach + TerminalAnsi
 setTimeout(() => {
   console.log("attaching to", termId);
   c.attach(termId);


### PR DESCRIPTION
## Summary

- Herdr 0.8.2 (protocol 20) inserted `ClientLaunchMode::AppDirectGraphics` at wire index 1 in the client handshake, moving `ClientLaunchMode::TerminalAttach` from 1 to 2. The bridge hardcoded the old value, so on protocol 20 the server treats direct-attach connections as full app clients and rejects `AttachTerminal` with `terminal attach failed: connection is not pending terminal attach`, leaving terminal views broken.
- `ThinClient` now takes a semantic launch mode (`"app"` / `"terminal-attach"`) and maps it onto the negotiated protocol version: 1 for protocol 19 and older, 2 for protocol 20 and newer. Wire bytes for older servers are unchanged, so backward compatibility is preserved for every released Herdr version in the supported range (protocol 14+).
- Added handshake regression tests asserting the launch-mode wire value on protocols 19/20/21 and that the app launch mode stays 0.

Fixes #29

## Verification

- `bun run format:check`
- `bun run lint`
- `cd server && bun run typecheck` and `cd web && bun run typecheck`
- `bun run test` (625 pass)
- Verified against a live Herdr 0.8.2 server: before the change the server rejected the attach with the exact error from #29; after the change the attach succeeds and pane frames stream normally.