### PR TITLE
Fix iOS/PWA downloads, stuck terminal selections, and docked inspector resizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@
   terminals that stayed blank after switching between desktop and mobile
   layouts or resuming the mobile app from the lock screen until the app was
   refreshed.
+- Keep file and session downloads inside the app on iOS/PWA instead of
+  navigating into the system document handler with no way back.
 - Fix terminal attach against Herdr 0.8.2 (protocol 20), which renumbered the
-  `TerminalAttach` launch-mode wire value and rejected direct attaches with
-  "connection is not pending terminal attach".
+  `TerminalAttach` launch-mode wire value.
 
 ## 0.4.3 - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Allow resizing the Files/Changes navigation list in docked Inspectors too.
+
 ### Fixed
 
 - Re-attach the terminal whenever the xterm instance is recreated, fixing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   refreshed.
 - Keep file and session downloads inside the app on iOS/PWA instead of
   navigating into the system document handler with no way back.
+- Stop terminal selections from growing on mouse moves after a lost mouseup.
 - Fix terminal attach against Herdr 0.8.2 (protocol 20), which renumbered the
   `TerminalAttach` launch-mode wire value.
 

--- a/web/src/components/FileExplorerDialog.tsx
+++ b/web/src/components/FileExplorerDialog.tsx
@@ -21,6 +21,7 @@ import {
 import type { ConnectionClient } from "../api";
 import { connectionHttpPath } from "../connectionHttp";
 import { connectionStorageKey } from "../connectionStorage";
+import { downloadFileFromUrl } from "../downloadFile";
 import { store, useStore } from "../store";
 import {
   connectionClientScopeKey,
@@ -1334,23 +1335,21 @@ function FileExplorerContent({
     );
     url.searchParams.set("workspace_id", workspace.workspace_id);
     url.searchParams.set("path", entry.path);
-    const link = document.createElement("a");
-    link.href = url.toString();
-    link.download =
+    const filename =
       entry.type === "directory"
         ? `${entry.name || "download"}.tar.gz`
         : entry.name || "download";
-    link.rel = "noopener";
-    document.body.appendChild(link);
-    link.click();
-    link.remove();
-    if (!connectionClient.isCurrent()) return;
-    store.notify({
-      kind: "info",
-      message: "Download started",
-      detail: entry.path,
-      autoDismissMs: 5000,
-    });
+    void downloadFileFromUrl({ url: url.toString(), filename }).then(
+      (result) => {
+        if (result === "shared" || !connectionClient.isCurrent()) return;
+        store.notify({
+          kind: "info",
+          message: "Download started",
+          detail: entry.path,
+          autoDismissMs: 5000,
+        });
+      },
+    );
   };
 
   const markDeletePath = (path: string, deleting: boolean) => {

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -61,6 +61,7 @@ import {
   TerminalImeTextareaFallbackTracker,
 } from "../terminalIme";
 import { terminalPageScroll, terminalWheelScroll } from "../terminalScroll";
+import { TerminalSelectionDragGuard } from "../terminalSelectionGuard";
 import { terminalFocusBlockedByOverlay } from "../terminalFocus";
 import {
   TerminalAttachFrameWatchdog,
@@ -1475,6 +1476,35 @@ export function TerminalView({
     };
     container.addEventListener("click", onClick);
 
+    // xterm only disarms its document-level drag listeners on mouseup. When
+    // the release is lost (released outside the window, or the browser drops
+    // the mouseup after the mousedown target was re-rendered mid-gesture),
+    // every later move keeps growing the selection without a button pressed.
+    // Detect the lost release on the first button-less move and force it.
+    const selectionDragGuard = new TerminalSelectionDragGuard();
+    const onTerminalMouseDown = (e: MouseEvent) =>
+      selectionDragGuard.mouseDown(e.button);
+    const onDocumentMouseUp = () => selectionDragGuard.mouseUp();
+    const onDocumentMouseMove = (e: MouseEvent) => {
+      if (!selectionDragGuard.mouseMoveNeedsRelease(e.buttons)) return;
+      container.ownerDocument.dispatchEvent(
+        new MouseEvent("mouseup", {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+          button: 0,
+          buttons: 0,
+          clientX: e.clientX,
+          clientY: e.clientY,
+          screenX: e.screenX,
+          screenY: e.screenY,
+        }),
+      );
+    };
+    container.addEventListener("mousedown", onTerminalMouseDown);
+    document.addEventListener("mouseup", onDocumentMouseUp, { capture: true });
+    document.addEventListener("mousemove", onDocumentMouseMove);
+
     const onWheel = (e: WheelEvent) => {
       const scroll = terminalWheelScroll(e.deltaY, e.deltaMode, term.rows);
       const terminalId = desiredTerminalRef.current;
@@ -1593,6 +1623,11 @@ export function TerminalView({
       document.removeEventListener("paste", onPaste, { capture: true });
       container.removeEventListener("copy", onCopy, { capture: true });
       container.removeEventListener("click", onClick);
+      container.removeEventListener("mousedown", onTerminalMouseDown);
+      document.removeEventListener("mouseup", onDocumentMouseUp, {
+        capture: true,
+      });
+      document.removeEventListener("mousemove", onDocumentMouseMove);
       container.removeEventListener("wheel", onWheel, { capture: true });
       container.removeEventListener("touchstart", onTouchStart, {
         capture: true,

--- a/web/src/components/WorkspaceInspectorHost.tsx
+++ b/web/src/components/WorkspaceInspectorHost.tsx
@@ -225,7 +225,10 @@ export function WorkspaceInspectorHost({
     };
   });
   const compact = hostWidth > 0 && hostWidth < 560;
-  const splitEnabled = state.expanded && hostWidth >= 600;
+  // The navigation/detail split is draggable whenever both panes fit side by
+  // side, not only in the expanded layout, so docked inspectors can resize
+  // the Files/Changes list too.
+  const splitEnabled = hostWidth >= 600;
   const navigationIds = {
     files: `${splitId}-files-navigation`,
     changes: `${splitId}-changes-navigation`,

--- a/web/src/components/agentSession.ts
+++ b/web/src/components/agentSession.ts
@@ -1,5 +1,6 @@
 import type { ConnectionClient } from "../api";
 import { connectionHttpPath } from "../connectionHttp";
+import { downloadFileFromUrl } from "../downloadFile";
 import { store } from "../store";
 import type { Pane } from "../types";
 
@@ -333,12 +334,8 @@ export function downloadSession(pane: Pane, client: ConnectionClient) {
   );
   url.searchParams.set("pane_id", pane.pane_id);
   if (pane.agent) url.searchParams.set("agent", pane.agent);
-  const link = document.createElement("a");
-  link.href = url.toString();
-  link.download = "";
-  document.body.appendChild(link);
-  link.click();
-  link.remove();
+  // Empty fallback keeps the server's Content-Disposition filename.
+  void downloadFileFromUrl({ url: url.toString(), filename: "" });
 }
 
 function sessionAtifFilename(path?: string) {
@@ -366,12 +363,10 @@ export function downloadSessionAtif(
   );
   url.searchParams.set("pane_id", pane.pane_id);
   if (pane.agent) url.searchParams.set("agent", pane.agent);
-  const link = document.createElement("a");
-  link.href = url.toString();
-  link.download = sessionAtifFilename(sessionName);
-  document.body.appendChild(link);
-  link.click();
-  link.remove();
+  void downloadFileFromUrl({
+    url: url.toString(),
+    filename: sessionAtifFilename(sessionName),
+  });
 }
 
 export async function exportSessionForConnection(

--- a/web/src/downloadFile.test.ts
+++ b/web/src/downloadFile.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import {
+  chooseFileDownloadStrategy,
+  filenameFromContentDisposition,
+  isIosDevice,
+  isStandaloneDisplay,
+} from "./downloadFile";
+
+describe("isIosDevice", () => {
+  test("detects iPhones, iPads, and iPads reporting as Macintosh", () => {
+    expect(
+      isIosDevice({
+        userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X)",
+        maxTouchPoints: 5,
+      }),
+    ).toBe(true);
+    expect(
+      isIosDevice({
+        userAgent: "Mozilla/5.0 (iPad; CPU OS 18_0 like Mac OS X)",
+        maxTouchPoints: 5,
+      }),
+    ).toBe(true);
+    expect(
+      isIosDevice({
+        userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+        maxTouchPoints: 5,
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects desktop browsers", () => {
+    expect(
+      isIosDevice({
+        userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+        maxTouchPoints: 0,
+      }),
+    ).toBe(false);
+    expect(
+      isIosDevice({
+        userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+        maxTouchPoints: 0,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("isStandaloneDisplay", () => {
+  test("accepts the media query or the iOS navigator flag", () => {
+    expect(isStandaloneDisplay(true, undefined)).toBe(true);
+    expect(isStandaloneDisplay(false, true)).toBe(true);
+    expect(isStandaloneDisplay(false, false)).toBe(false);
+    expect(isStandaloneDisplay(false, undefined)).toBe(false);
+  });
+});
+
+describe("filenameFromContentDisposition", () => {
+  test("prefers the extended UTF-8 filename", () => {
+    expect(
+      filenameFromContentDisposition(
+        `attachment; filename="fallback.jsonl"; filename*=UTF-8''${encodeURIComponent("会话 1.jsonl")}`,
+      ),
+    ).toBe("会话 1.jsonl");
+  });
+
+  test("falls back to the quoted filename and rejects junk", () => {
+    expect(
+      filenameFromContentDisposition('attachment; filename="a.jsonl"'),
+    ).toBe("a.jsonl");
+    expect(filenameFromContentDisposition("attachment")).toBeNull();
+    expect(filenameFromContentDisposition(null)).toBeNull();
+    expect(filenameFromContentDisposition(undefined)).toBeNull();
+    // Malformed percent-encoding falls through instead of throwing.
+    expect(
+      filenameFromContentDisposition("filename*=UTF-8''%E0%A4%A"),
+    ).toBeNull();
+  });
+});
+
+describe("chooseFileDownloadStrategy", () => {
+  test("prefers the native share sheet when files can be shared", () => {
+    expect(
+      chooseFileDownloadStrategy({
+        canShareFiles: true,
+        standalone: true,
+        ios: true,
+      }),
+    ).toBe("share");
+  });
+
+  test("opens a new browsing context on iOS or in a PWA without share", () => {
+    for (const env of [
+      { canShareFiles: false, standalone: true, ios: false },
+      { canShareFiles: false, standalone: false, ios: true },
+      { canShareFiles: false, standalone: true, ios: true },
+    ]) {
+      expect(chooseFileDownloadStrategy(env)).toBe("new-context");
+    }
+  });
+
+  test("keeps the anchor download for regular desktop browsers", () => {
+    expect(
+      chooseFileDownloadStrategy({
+        canShareFiles: false,
+        standalone: false,
+        ios: false,
+      }),
+    ).toBe("anchor");
+  });
+});

--- a/web/src/downloadFile.ts
+++ b/web/src/downloadFile.ts
@@ -1,0 +1,155 @@
+/**
+ * Download strategy for file URLs. Plain anchor downloads navigate the
+ * current browsing context, which iOS replaces with the system document
+ * handler; in a PWA there is no way back without force-quitting the app.
+ * Prefer the native share sheet when available, open a new browsing context
+ * on iOS/standalone (the in-app browser offers a way back), and keep the
+ * classic anchor download everywhere else.
+ */
+export type FileDownloadStrategy = "share" | "new-context" | "anchor";
+
+/** Share sheets need the whole blob in memory; open large files instead. */
+export const MAX_SHARE_FILE_BYTES = 64 * 1024 * 1024;
+
+export type FileDownloadEnvironment = {
+  canShareFiles: boolean;
+  standalone: boolean;
+  ios: boolean;
+};
+
+export function isIosDevice(
+  nav: Pick<Navigator, "userAgent" | "maxTouchPoints">,
+): boolean {
+  return (
+    /iP(hone|ad|od)/.test(nav.userAgent) ||
+    (nav.userAgent.includes("Macintosh") && nav.maxTouchPoints > 1)
+  );
+}
+
+export function isStandaloneDisplay(
+  matchesStandaloneMedia: boolean,
+  navigatorStandalone: boolean | undefined,
+): boolean {
+  return matchesStandaloneMedia || navigatorStandalone === true;
+}
+
+export function chooseFileDownloadStrategy(
+  env: FileDownloadEnvironment,
+): FileDownloadStrategy {
+  if (env.canShareFiles) return "share";
+  if (env.standalone || env.ios) return "new-context";
+  return "anchor";
+}
+
+/**
+ * The server is the filename authority: prefer its Content-Disposition name
+ * over client-side guesses. Handles both filename*=UTF-8'' and filename="".
+ */
+export function filenameFromContentDisposition(
+  header: string | null | undefined,
+): string | null {
+  if (!header) return null;
+  const extended = /filename\*=UTF-8''([^;]+)/i.exec(header);
+  if (extended) {
+    try {
+      const decoded = decodeURIComponent(extended[1].trim());
+      if (decoded) return decoded;
+    } catch {
+      // Fall through to the plain filename.
+    }
+  }
+  const plain = /filename="([^"]*)"/i.exec(header);
+  return plain?.[1] || null;
+}
+
+function probeCanShareFiles(): boolean {
+  try {
+    return (
+      typeof navigator.canShare === "function" &&
+      navigator.canShare({
+        files: [new File([""], "probe.txt", { type: "text/plain" })],
+      })
+    );
+  } catch {
+    return false;
+  }
+}
+
+function currentDownloadEnvironment(): FileDownloadEnvironment {
+  return {
+    canShareFiles: probeCanShareFiles(),
+    standalone: isStandaloneDisplay(
+      typeof window.matchMedia === "function" &&
+        window.matchMedia("(display-mode: standalone)").matches,
+      (navigator as { standalone?: boolean }).standalone,
+    ),
+    ios: isIosDevice(navigator),
+  };
+}
+
+function openInNewContext(url: string) {
+  window.open(url, "_blank", "noopener");
+}
+
+function anchorDownload(url: string, filename: string) {
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  link.rel = "noopener";
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+}
+
+/**
+ * Downloads a same-origin file URL without trapping the current context.
+ * Resolves to how the download was delivered: "shared" (native share sheet,
+ * including a dismissed sheet), "opened" (new browsing context), or
+ * "anchored" (classic browser download).
+ */
+export async function downloadFileFromUrl(args: {
+  url: string;
+  /** Fallback name; the server's Content-Disposition name wins when present. */
+  filename: string;
+}): Promise<"shared" | "opened" | "anchored"> {
+  const strategy = chooseFileDownloadStrategy(currentDownloadEnvironment());
+  if (strategy === "share") {
+    try {
+      const response = await fetch(args.url, { credentials: "same-origin" });
+      if (!response.ok) {
+        throw new Error(`download failed (${response.status})`);
+      }
+      const size = Number(response.headers.get("content-length") ?? 0);
+      if (size > MAX_SHARE_FILE_BYTES) {
+        openInNewContext(args.url);
+        return "opened";
+      }
+      const blob = await response.blob();
+      if (blob.size > MAX_SHARE_FILE_BYTES) {
+        openInNewContext(args.url);
+        return "opened";
+      }
+      const filename =
+        filenameFromContentDisposition(
+          response.headers.get("content-disposition"),
+        ) ||
+        args.filename ||
+        "download";
+      const file = new File([blob], filename, {
+        type: blob.type || "application/octet-stream",
+      });
+      await navigator.share({ files: [file], title: filename });
+      return "shared";
+    } catch (error) {
+      if ((error as Error).name === "AbortError") return "shared";
+      openInNewContext(args.url);
+      return "opened";
+    }
+  }
+  if (strategy === "new-context") {
+    openInNewContext(args.url);
+    return "opened";
+  }
+  anchorDownload(args.url, args.filename);
+  return "anchored";
+}

--- a/web/src/terminalSelectionGuard.test.ts
+++ b/web/src/terminalSelectionGuard.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { TerminalSelectionDragGuard } from "./terminalSelectionGuard";
+
+describe("TerminalSelectionDragGuard", () => {
+  test("requests a synthetic release when a button-less move follows a lost mouseup", () => {
+    const guard = new TerminalSelectionDragGuard();
+    guard.mouseDown(0);
+    expect(guard.mouseMoveNeedsRelease(1)).toBe(false); // real drag continues
+    expect(guard.mouseMoveNeedsRelease(0)).toBe(true); // lost release detected
+    expect(guard.mouseMoveNeedsRelease(0)).toBe(false); // reported only once
+  });
+
+  test("ignores non-left buttons and moves without a tracked press", () => {
+    const guard = new TerminalSelectionDragGuard();
+    guard.mouseDown(2);
+    expect(guard.mouseMoveNeedsRelease(0)).toBe(false);
+    guard.mouseDown(0);
+    guard.mouseUp();
+    expect(guard.mouseMoveNeedsRelease(0)).toBe(false);
+  });
+
+  test("reset clears a tracked gesture", () => {
+    const guard = new TerminalSelectionDragGuard();
+    guard.mouseDown(0);
+    guard.reset();
+    expect(guard.mouseMoveNeedsRelease(0)).toBe(false);
+  });
+});

--- a/web/src/terminalSelectionGuard.ts
+++ b/web/src/terminalSelectionGuard.ts
@@ -1,0 +1,39 @@
+/**
+ * xterm arms document-level mousemove/mouseup listeners on every left
+ * mousedown to track a selection drag, and only disarms them on mouseup. When
+ * the release is swallowed (released outside the window, or the browser drops
+ * the mouseup after the mousedown target was re-rendered mid-gesture), those
+ * listeners stay armed and every later move keeps extending the selection
+ * without a button pressed.
+ *
+ * This guard mirrors the gesture with its own tracking and reports when a
+ * button-less move means the release was lost, so the caller can dispatch a
+ * synthetic mouseup to finalize the drag.
+ */
+export class TerminalSelectionDragGuard {
+  private dragActive = false;
+
+  /** Left button pressed inside the terminal: start watching the gesture. */
+  mouseDown(button: number): void {
+    if (button === 0) this.dragActive = true;
+  }
+
+  /** Any real release ends the gesture. */
+  mouseUp(): void {
+    this.dragActive = false;
+  }
+
+  /**
+   * A move with no button held while the drag never saw its release means the
+   * mouseup was lost. Returns true once per lost release.
+   */
+  mouseMoveNeedsRelease(buttons: number): boolean {
+    if (!this.dragActive || buttons !== 0) return false;
+    this.dragActive = false;
+    return true;
+  }
+
+  reset(): void {
+    this.dragActive = false;
+  }
+}


### PR DESCRIPTION
## Summary

- Keep file and agent-session downloads inside the app on iOS/PWA: plain anchor downloads navigate the current browsing context, which iOS replaces with the system document handler, leaving PWA users with no way back without force-quitting. Downloads now prefer the native share sheet when available and otherwise open a new browsing context (the in-app browser offers a way back); desktop browsers keep the classic anchor download. The server's `Content-Disposition` filename stays authoritative, and very large files skip the in-memory share path.
- Stop stuck terminal selections: xterm only disarms its document-level drag listeners on `mouseup`, so when the release is lost (released outside the window, or dropped by the browser after the mousedown target was re-rendered mid-gesture) every later mouse move keeps growing the selection without a button pressed. A small drag guard detects the first button-less move and forces the release.
- Allow resizing the Files/Changes navigation list in docked (non-expanded) Inspectors too, not only in the expanded layout.

## Verification

- `bun run format:check`, `bun run lint`, `cd web && bun run typecheck`, `bun run test` (637 pass)
- Playwright against a live bridge: iPad emulation opens downloads in a new browsing context while the app stays put; desktop keeps anchor downloads with the original filename; button-less mouse moves after a lost mouseup no longer grow the selection (selection itself is preserved); the docked Inspector split resizer appears at >=600px and dragging it resizes the navigation list.
