### PR TITLE
Eliminate idle render churn and recover terminals from stream takeovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+### Performance
+
+- Stop the idle-state render churn that made the UI hitch every second:
+  removed a leftover background poll that read 200 lines of scrollback per
+  visible pane every 1.5s without any consumer, skip broadcasting store
+  updates when a refresh returns unchanged data, slow the metadata fallback
+  poll to 5s and suspend it while the page is hidden.
+- Subscribe components to just the state slices they read via a new
+  `useStoreSelector` hook, so a store update no longer re-renders the whole
+  app.
+
+### Fixed
+
+- Re-attach the terminal when Herdr closes its stream after another herdr-gui
+  client takes the terminal over (e.g. a second GUI instance viewing the same
+  pane): the bridge now tells viewers when the stream closes and the frontend
+  re-attaches with a bounded retry instead of leaving a blank terminal until
+  the page was refreshed; sustained takeover wars surface an explicit error.
+- Re-arm the metadata and update polls when the connection settles: they were
+  stopped by the initial switch from the legacy placeholder connection and
+  never restarted, leaving status updates and update checks without their
+  fallback poll until the next manual action.
+
 ## 0.4.4 - 2026-08-22
 
 ### Added

--- a/server/src/bridge/terminal-bridge.test.ts
+++ b/server/src/bridge/terminal-bridge.test.ts
@@ -49,7 +49,7 @@ async function startThinServer(
     directClipboardOnResize?: string;
     directFrameDelayMs?: number;
     skipDirectFrame?: boolean;
-    onDirectAttach?: () => void;
+    onDirectAttach?: (socket: net.Socket) => void;
     tracker?: {
       appConnects: number;
       appCloses: number;
@@ -143,7 +143,7 @@ async function startThinServer(
           } else {
             options.tracker?.events.push("attach");
             options.tracker?.events.push("terminalFrame");
-            options.onDirectAttach?.();
+            options.onDirectAttach?.(socket);
           }
           const sendTerminalFrame = () => {
             if (!socket.destroyed) {
@@ -273,6 +273,65 @@ describe("terminal bridge sharing", () => {
 
     bridge.cleanupWs(firstBrowser);
     bridge.cleanupWs(secondBrowser);
+  });
+
+  test("notifies viewers to re-attach when Herdr closes the terminal stream", async () => {
+    const direct: { socket: net.Socket | null } = { socket: null };
+    const socketPath = await startThinServer({
+      onDirectAttach: (socket) => {
+        direct.socket = socket;
+      },
+    });
+    const browser = {} as ServerWebSocket<unknown>;
+    const messages: string[] = [];
+    const bridge = createTerminalBridge({
+      clientSocketPath: socketPath,
+      herdrProtocol: async () => 17,
+      safeSend: (ws, payload) => {
+        messages.push(payload);
+        return true;
+      },
+      clientLabel: () => "browser",
+      markRpcError: () => undefined,
+    });
+
+    await bridge.handleTerminalRpc(browser, "attach", "terminal.attach", {
+      terminal_id: "term_1",
+      cols: 100,
+      rows: 30,
+    });
+    await waitForTerminalFrame(messages);
+
+    // Herdr closes the direct attach when another client takes the terminal
+    // over; the viewer must be told so its UI can re-attach.
+    expect(direct.socket).not.toBeNull();
+    (direct.socket as net.Socket).destroy();
+    await waitForCondition(
+      () =>
+        messages
+          .map((message) => JSON.parse(message))
+          .some((message) => message.terminal_closed?.terminal_id === "term_1"),
+      "timed out waiting for terminal_closed",
+    );
+    const closed = messages
+      .map((message) => JSON.parse(message))
+      .find((message) => message.terminal_closed);
+    expect(closed.terminal_closed).toMatchObject({
+      terminal_id: "term_1",
+      reason: "stream_closed",
+    });
+
+    // A re-attach after the close must build a fresh stream.
+    messages.length = 0;
+    await bridge.handleTerminalRpc(browser, "reattach", "terminal.attach", {
+      terminal_id: "term_1",
+      cols: 100,
+      rows: 30,
+    });
+    const frame = await waitForTerminalFrame(messages);
+    expect(frame).toMatchObject({ terminal_id: "term_1", full: true });
+
+    bridge.cleanupWs(browser);
   });
 
   test("routes Herdr clipboard messages from the app relay to the input owner", async () => {

--- a/server/src/bridge/terminal-bridge.ts
+++ b/server/src/bridge/terminal-bridge.ts
@@ -24,6 +24,8 @@ type SharedTerminalSession = {
   bytes: number;
   firstFrameLogged: boolean;
   lastFrameLogAt: number;
+  /** Last error Herdr reported on the stream, e.g. a takeover notice. */
+  lastError: string | null;
 };
 
 type ClipboardTarget = {
@@ -421,6 +423,7 @@ export function createTerminalBridge(args: {
       bytes: 0,
       firstFrameLogged: false,
       lastFrameLogAt: 0,
+      lastError: null,
     };
     sharedTerminals.set(terminalId, shared);
     console.log(
@@ -486,14 +489,15 @@ export function createTerminalBridge(args: {
       if (w.error) parts.push(`error=${formatError(w.error)}`);
       console.log(...parts);
     });
-    thin.on("error", (error) =>
+    thin.on("error", (error) => {
+      shared.lastError = formatError(error);
       console.error(
         "[thin]",
         connectionDetail,
         formatError(terminalId),
         formatError(error),
-      ),
-    );
+      );
+    });
     thin.on("close", () => {
       const resolve = shared.resolveFirstFrame;
       if (resolve) {
@@ -509,6 +513,27 @@ export function createTerminalBridge(args: {
       );
       if (sharedTerminals.get(terminalId)?.thin === thin) {
         sharedTerminals.delete(terminalId);
+      }
+      // Herdr closes a direct attach whose terminal another client takes
+      // over, and the stream can also die with the server. Viewers only see
+      // silence otherwise, so tell them to re-attach instead of leaving a
+      // blank terminal behind.
+      if (isCurrent(creationRevision) && shared.viewers.size > 0) {
+        console.log(
+          "[bridge] terminal stream closed with live viewers",
+          connectionDetail,
+          `terminal=${terminalId}`,
+          `viewers=${shared.viewers.size}`,
+        );
+        const closedPayload = serialize({
+          terminal_closed: {
+            terminal_id: terminalId,
+            reason: shared.lastError ?? "stream_closed",
+          },
+        });
+        for (const viewer of Array.from(shared.viewers)) {
+          args.safeSend(viewer, closedPayload, "terminal-closed");
+        }
       }
     });
     const terminalReady = thin

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -78,11 +78,12 @@ import {
   isTaskNotificationTarget,
   type Notice,
   noticeAutoDismissDelay,
+  shallowEqual,
   store,
   TASK_NOTIFICATION_ACTIVATE_EVENT,
   type TaskNotificationTarget,
   taskNotificationTargetFromNotice,
-  useStore,
+  useStoreSelector,
   WORKTREE_REMOVED_EVENT,
   type WorktreeRemovedTarget,
 } from "./store";
@@ -608,7 +609,16 @@ function TerminalPaneLayout({
   onAgentHistoryOpenChange: (open: boolean) => void;
   onOpenWorkspaceFile: (request: TerminalWorkspaceFileRequest) => void;
 }) {
-  const s = useStore();
+  const s = useStoreSelector(
+    (state) => ({
+      activeConnectionId: state.activeConnectionId,
+      connectionGeneration: state.connectionGeneration,
+      layout: state.layout,
+      panes: state.panes,
+      selectedPaneId: state.selectedPaneId,
+    }),
+    shallowEqual,
+  );
   const mobile = useMobileLayout();
   const layoutRef = useRef<HTMLDivElement | null>(null);
   const layout = s.layout;
@@ -839,7 +849,24 @@ function TerminalPaneLayout({
 }
 
 export default function App() {
-  const s = useStore();
+  const s = useStoreSelector(
+    (state) => ({
+      connectionPaused: state.connectionPaused,
+      lastRefresh: state.lastRefresh,
+      layout: state.layout,
+      notice: state.notice,
+      panes: state.panes,
+      pendingFocusWorkspaceId: state.pendingFocusWorkspaceId,
+      recentPaneIds: state.recentPaneIds,
+      selectedPaneId: state.selectedPaneId,
+      status: state.status,
+      tabs: state.tabs,
+      updateInfo: state.updateInfo,
+      updateInstalling: state.updateInstalling,
+      workspaces: state.workspaces,
+    }),
+    shallowEqual,
+  );
   const connectionClient = useConnectionClient();
   useVisualViewportCssVars();
   const mobile = useMobileLayout();

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -341,6 +341,46 @@ describe("bridge connection lifecycle", () => {
     ]);
   });
 
+  test("routes terminal_closed pushes to closed listeners", async () => {
+    class ManualWebSocket extends HangingWebSocket {
+      static instance: ManualWebSocket;
+
+      constructor() {
+        super();
+        ManualWebSocket.instance = this;
+        queueMicrotask(() => {
+          this.readyState = ManualWebSocket.OPEN;
+          this.onopen?.();
+        });
+      }
+    }
+    installBrowserGlobals(ManualWebSocket as unknown as typeof WebSocket);
+    const bridge = createTestBridge();
+    const closed: unknown[] = [];
+    const terminals: unknown[] = [];
+    bridge.onTerminalClosed((push) => closed.push(push));
+    bridge.onTerminal((terminal) => terminals.push(terminal));
+    bridge.connect();
+    await Bun.sleep(1);
+    sendHello(ManualWebSocket.instance);
+
+    ManualWebSocket.instance.onmessage?.({
+      data: JSON.stringify({
+        connection_id: "legacy-default",
+        terminal_closed: { terminal_id: "term_1", reason: "stream_closed" },
+      }),
+    } as MessageEvent);
+
+    expect(closed).toEqual([
+      {
+        connection_id: "legacy-default",
+        terminal_id: "term_1",
+        reason: "stream_closed",
+      },
+    ]);
+    expect(terminals).toEqual([]);
+  });
+
   test("keeps event and terminal listeners compatible with scoped pushes", async () => {
     class ManualWebSocket extends HangingWebSocket {
       static instance: ManualWebSocket;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -189,6 +189,13 @@ export interface TerminalClipboardPush {
   data: string;
 }
 
+export interface TerminalClosedPush {
+  connection_id: string;
+  connection_generation?: number;
+  terminal_id: string;
+  reason?: string;
+}
+
 export interface BridgeControlMsg {
   type: "pause_connection";
   reason?: string;
@@ -307,6 +314,9 @@ export class Bridge {
   private terminalHandlers = new Set<(t: TerminalPush) => void>();
   private terminalClipboardHandlers = new Set<
     (clipboard: TerminalClipboardPush) => void
+  >();
+  private terminalClosedHandlers = new Set<
+    (closed: TerminalClosedPush) => void
   >();
   private statusHandlers = new Set<(s: ConnectionStatus) => void>();
   private controlHandlers = new Set<(c: BridgeControlMsg) => void>();
@@ -606,6 +616,7 @@ export class Bridge {
     const hasEvent = owns("event");
     const hasTerminal = owns("terminal");
     const hasClipboard = owns("terminal_clipboard");
+    const hasTerminalClosed = owns("terminal_closed");
     const hasControl = owns("control");
     const kindCount = [
       hasHello,
@@ -613,6 +624,7 @@ export class Bridge {
       hasEvent,
       hasTerminal,
       hasClipboard,
+      hasTerminalClosed,
       hasControl,
     ].filter(Boolean).length;
     if (kindCount !== 1) return;
@@ -768,6 +780,31 @@ export class Bridge {
       );
       if (clipboard) {
         this.terminalClipboardHandlers.forEach((handler) => handler(clipboard));
+      }
+      return;
+    }
+
+    if (hasTerminalClosed) {
+      if (
+        !msg.terminal_closed ||
+        typeof msg.terminal_closed !== "object" ||
+        typeof msg.terminal_closed.terminal_id !== "string" ||
+        msg.terminal_closed.terminal_id.length === 0 ||
+        !this.pushGenerationMatches(
+          msg.connection_id,
+          msg.connection_generation,
+        )
+      ) {
+        return;
+      }
+      const closed = scopedPayload(
+        msg.connection_id,
+        msg.connection_generation,
+        msg.terminal_closed,
+        this._hello?.capabilities?.connection_runtime_generation === true,
+      );
+      if (closed) {
+        this.terminalClosedHandlers.forEach((handler) => handler(closed));
       }
       return;
     }
@@ -930,6 +967,11 @@ export class Bridge {
   ): () => void {
     this.terminalClipboardHandlers.add(cb);
     return () => this.terminalClipboardHandlers.delete(cb);
+  }
+
+  onTerminalClosed(cb: (closed: TerminalClosedPush) => void): () => void {
+    this.terminalClosedHandlers.add(cb);
+    return () => this.terminalClosedHandlers.delete(cb);
   }
 
   onStatus(cb: (status: ConnectionStatus) => void): () => void {

--- a/web/src/components/AgentHistoryDrawer.tsx
+++ b/web/src/components/AgentHistoryDrawer.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Bot, Copy, Download, Eye, RefreshCw, X } from "lucide-react";
-import { useStore } from "../store";
+import { useStoreSelector } from "../store";
 import { useConnectionClient } from "../useConnectionClient";
 import type { Pane } from "../types";
 import { formatUiRelativeTime, UI_LOCALE } from "../uiLocale";
@@ -163,12 +163,11 @@ export function AgentHistoryDrawer({
   embedded?: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
-  const appState = useStore();
+  const workspaces = useStoreSelector((state) => state.workspaces);
   const connectionClient = useConnectionClient();
   const workspaceLabel =
-    appState.workspaces.find(
-      (workspace) => workspace.workspace_id === pane.workspace_id,
-    )?.label ?? pane.workspace_id;
+    workspaces.find((workspace) => workspace.workspace_id === pane.workspace_id)
+      ?.label ?? pane.workspace_id;
   const [history, setHistory] = useState<AgentHistory | null>(null);
   const [session, setSession] = useState<AgentSessionSummary | null>(null);
   const [drawerTab, setDrawerTab] = useState<"messages" | "details">(

--- a/web/src/components/AgentSessionPreviewDialog.tsx
+++ b/web/src/components/AgentSessionPreviewDialog.tsx
@@ -8,7 +8,7 @@ import {
   Info,
   Wrench,
 } from "lucide-react";
-import { useStore } from "../store";
+import { useStoreSelector } from "../store";
 import type { Pane } from "../types";
 import { UI_LOCALE } from "../uiLocale";
 import { useConnectionClient } from "../useConnectionClient";
@@ -100,7 +100,7 @@ export function AgentSessionPreviewDialog({
   error: string;
   onClose: () => void;
 }) {
-  const appState = useStore();
+  const workspaces = useStoreSelector((state) => state.workspaces);
   const connectionClient = useConnectionClient();
   const dialogRef = useRef<HTMLDivElement>(null);
   const [mode, setMode] = useState<"timeline" | "atif" | "raw">("timeline");
@@ -130,9 +130,8 @@ export function AgentSessionPreviewDialog({
   if (!pane) return null;
 
   const workspaceLabel =
-    appState.workspaces.find(
-      (workspace) => workspace.workspace_id === pane.workspace_id,
-    )?.label ?? pane.workspace_id;
+    workspaces.find((workspace) => workspace.workspace_id === pane.workspace_id)
+      ?.label ?? pane.workspace_id;
   const usage = summary?.stats.token_usage;
   const text = summary?.text ?? "";
   const atifText = summary?.trajectory

--- a/web/src/components/CommandCombobox.tsx
+++ b/web/src/components/CommandCombobox.tsx
@@ -18,7 +18,7 @@ import {
   SplitSquareVertical,
   X,
 } from "lucide-react";
-import { useStore, store } from "../store";
+import { shallowEqual, store, useStoreSelector } from "../store";
 import type { FileExplorerEntry, Pane, Tab, Workspace } from "../types";
 import { basename, shortId } from "../utils";
 import { luckyWorktreeBranchName } from "../luckyName";
@@ -234,7 +234,16 @@ export function CommandCombobox({
   onOpenFile?: (workspaceId: string, entry: FileExplorerEntry) => void;
   onOpenDiffViewer?: (workspaceId?: string) => void;
 }) {
-  const s = useStore();
+  const s = useStoreSelector(
+    (state) => ({
+      layout: state.layout,
+      panes: state.panes,
+      selectedPaneId: state.selectedPaneId,
+      tabs: state.tabs,
+      workspaces: state.workspaces,
+    }),
+    shallowEqual,
+  );
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [selectedActionValue, setSelectedActionValue] = useState("");

--- a/web/src/components/ConfigMenu.tsx
+++ b/web/src/components/ConfigMenu.tsx
@@ -23,7 +23,7 @@ import packageJson from "../../package.json";
 import type { Theme } from "../App";
 import { ACCENT_OPTIONS, type AccentColor } from "../appearance";
 import { connectionHttpPath } from "../connectionHttp";
-import { store, useStore } from "../store";
+import { shallowEqual, store, useStoreSelector } from "../store";
 import { useConnectionClient } from "../useConnectionClient";
 import {
   mobileTerminalShortcutCount,
@@ -76,7 +76,18 @@ export function ConfigMenu({
   onMobileTerminalShortcutsChange,
   onMobileTerminalSideShortcutsChange,
 }: ConfigMenuProps) {
-  const s = useStore();
+  const s = useStoreSelector(
+    (state) => ({
+      bridgeStatus: state.bridgeStatus,
+      connectionPaused: state.connectionPaused,
+      status: state.status,
+      taskNotificationPermission: state.taskNotificationPermission,
+      taskNotificationsEnabled: state.taskNotificationsEnabled,
+      updateInfo: state.updateInfo,
+      updateInstalling: state.updateInstalling,
+    }),
+    shallowEqual,
+  );
   const connectionClient = useConnectionClient();
   const updateAvailable = !!s.updateInfo?.update_available;
   const canInstallUpdate = updateAvailable && s.updateInfo?.can_auto_update;

--- a/web/src/components/ConnectionSwitcher.tsx
+++ b/web/src/components/ConnectionSwitcher.tsx
@@ -28,7 +28,7 @@ import {
   sshConnectionProfilePayload,
   suggestConnectionId,
 } from "../connectionProfiles";
-import { store, useStore } from "../store";
+import { shallowEqual, store, useStoreSelector } from "../store";
 import { CloseButton } from "./CloseButton";
 import { focusDialogElement } from "./dialogFocus";
 import { ConfirmDialog } from "./ModalDialogs";
@@ -150,7 +150,13 @@ function trapDialogTab(event: KeyboardEvent, dialog: HTMLElement | null) {
 }
 
 function BrowserTransportStatus() {
-  const state = useStore();
+  const state = useStoreSelector(
+    (snapshot) => ({
+      connectionPaused: snapshot.connectionPaused,
+      status: snapshot.status,
+    }),
+    shallowEqual,
+  );
   const label = state.connectionPaused
     ? "Browser sync paused"
     : state.status === "connected"
@@ -490,7 +496,7 @@ function SshProfileForm({
 }
 
 function ConnectionManagerDialog({ onClose }: { onClose: () => void }) {
-  const state = useStore();
+  const connections = useStoreSelector((snapshot) => snapshot.connections);
   const [editing, setEditing] = useState<
     ConnectionSummary | "new-local" | "new-ssh" | null
   >(null);
@@ -744,7 +750,7 @@ function ConnectionManagerDialog({ onClose }: { onClose: () => void }) {
           </div>
         ) : null}
         <div className="connection-manager-list">
-          {state.connections.map((connection) => {
+          {connections.map((connection) => {
             const capabilities = connectionProfileCapabilities(connection);
             const status = connectionLifecycleLabel(connection.state);
             return (
@@ -966,7 +972,14 @@ function ConnectionManagerDialog({ onClose }: { onClose: () => void }) {
 }
 
 export function ConnectionSwitcher() {
-  const state = useStore();
+  const state = useStoreSelector(
+    (snapshot) => ({
+      activeConnectionId: snapshot.activeConnectionId,
+      connections: snapshot.connections,
+      defaultConnectionId: snapshot.defaultConnectionId,
+    }),
+    shallowEqual,
+  );
   const [open, setOpen] = useState(false);
   const [manageOpen, setManageOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);

--- a/web/src/components/ContextMenu.tsx
+++ b/web/src/components/ContextMenu.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import type { Workspace } from "../types";
-import { store, useStore } from "../store";
+import { store, useStoreSelector } from "../store";
 import { luckyWorktreeBranchName } from "../luckyName";
 import { ConfirmDialog, TextInputDialog } from "./ModalDialogs";
 import { WorktreeHooksDialog } from "./WorktreeHooksDialog";
@@ -60,7 +60,7 @@ export function ContextMenu({
   onReviewChanges?: (workspace: Workspace) => void;
   onClose: () => void;
 }) {
-  const workspaces = useStore().workspaces;
+  const workspaces = useStoreSelector((state) => state.workspaces);
   const ref = useRef<HTMLDivElement>(null);
   const [dialog, setDialog] = useState<DialogState | null>(null);
   const [openWorktreeWorkspaceId, setOpenWorktreeWorkspaceId] = useState<

--- a/web/src/components/DiffViewerPanel.tsx
+++ b/web/src/components/DiffViewerPanel.tsx
@@ -22,7 +22,7 @@ import type {
   GitDiffKind,
   GitDiffSummary,
 } from "../types";
-import { useStore } from "../store";
+import { useStoreSelector } from "../store";
 import {
   connectionClientScopeKey,
   useConnectionClient,
@@ -610,11 +610,11 @@ export function DiffViewerPanel({
     meta?: DiffSelectionMeta,
   ) => void;
 }) {
-  const s = useStore();
+  const workspaces = useStoreSelector((state) => state.workspaces);
   const connectionClient = useConnectionClient();
-  const focusedWorkspace = s.workspaces.find((w) => w.focused);
+  const focusedWorkspace = workspaces.find((w) => w.focused);
   const workspace = workspaceId
-    ? s.workspaces.find((w) => w.workspace_id === workspaceId)
+    ? workspaces.find((w) => w.workspace_id === workspaceId)
     : focusedWorkspace;
   const cacheWorkspaceId = workspace?.workspace_id;
   const cacheResourceKey = resourceKey ?? cacheWorkspaceId;

--- a/web/src/components/FileExplorerDialog.tsx
+++ b/web/src/components/FileExplorerDialog.tsx
@@ -22,7 +22,7 @@ import type { ConnectionClient } from "../api";
 import { connectionHttpPath } from "../connectionHttp";
 import { connectionStorageKey } from "../connectionStorage";
 import { downloadFileFromUrl } from "../downloadFile";
-import { store, useStore } from "../store";
+import { store, useStoreSelector } from "../store";
 import {
   connectionClientScopeKey,
   useConnectionClient,
@@ -775,11 +775,11 @@ function FileExplorerContent({
     meta?: FilePreviewSelectionMeta,
   ) => void;
 }) {
-  const s = useStore();
+  const workspaces = useStoreSelector((state) => state.workspaces);
   const connectionClient = useConnectionClient();
-  const focusedWorkspace = s.workspaces.find((w) => w.focused);
+  const focusedWorkspace = workspaces.find((w) => w.focused);
   const workspace = workspaceId
-    ? s.workspaces.find((w) => w.workspace_id === workspaceId)
+    ? workspaces.find((w) => w.workspace_id === workspaceId)
     : focusedWorkspace;
   const cacheWorkspaceId = workspace?.workspace_id;
   const cacheResourceKey = resourceKey ?? cacheWorkspaceId;

--- a/web/src/components/TabBar.tsx
+++ b/web/src/components/TabBar.tsx
@@ -1,4 +1,4 @@
-import { useStore, store } from "../store";
+import { shallowEqual, store, useStoreSelector } from "../store";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { PanelRight } from "lucide-react";
@@ -48,7 +48,14 @@ export function TabBar({
   inspectorOpen?: boolean;
   onToggleInspector?: () => void;
 }) {
-  const s = useStore();
+  const s = useStoreSelector(
+    (state) => ({
+      panes: state.panes,
+      tabs: state.tabs,
+      workspaces: state.workspaces,
+    }),
+    shallowEqual,
+  );
   const [pendingCloseTabId, setPendingCloseTabId] = useState<string | null>(
     null,
   );

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -17,7 +17,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { UnicodeGraphemesAddon } from "@xterm/addon-unicode-graphemes";
 import { Columns2, Keyboard, Maximize2, Rows2, X } from "lucide-react";
 import "@xterm/xterm/css/xterm.css";
-import { store, useStore } from "../store";
+import { shallowEqual, store, useStoreSelector } from "../store";
 import { paneCanClose } from "../paneJump";
 import { bridge, type ConnectionClient } from "../api";
 import { connectionHttpPath } from "../connectionHttp";
@@ -150,6 +150,8 @@ const RESET_FOREGROUND = "\x1b[39m";
 const ANSI_SEQUENCE_RE =
   /\x1b\][\s\S]*?(?:\x07|\x1b\\)|\x1b\[[0-?]*[ -/]*[@-~]|\x1b[@-Z\\-_]/g;
 const CLIPBOARD_READ_TIMEOUT_MS = 2000;
+const TERMINAL_EVICTION_WINDOW_MS = 60_000;
+const TERMINAL_EVICTION_MAX_RETRIES = 3;
 
 function terminalDensity() {
   const compact =
@@ -429,7 +431,20 @@ export function TerminalView({
   onAgentHistoryOpenChange?: (open: boolean) => void;
   onOpenWorkspaceFile?: (request: TerminalWorkspaceFileRequest) => void;
 }) {
-  const s = useStore();
+  const s = useStoreSelector(
+    (state) => ({
+      activeConnectionId: state.activeConnectionId,
+      connectionGeneration: state.connectionGeneration,
+      connectionPaused: state.connectionPaused,
+      connections: state.connections,
+      layout: state.layout,
+      panes: state.panes,
+      selectedPaneId: state.selectedPaneId,
+      status: state.status,
+      terminalAttachEpoch: state.terminalAttachEpoch,
+    }),
+    shallowEqual,
+  );
   const terminalIdentity = useMemo<TerminalConnectionIdentity>(
     () => ({
       connectionId: s.activeConnectionId,
@@ -496,6 +511,7 @@ export function TerminalView({
   const attachingRef = useRef<string | null>(null);
   const desiredTerminalRef = useRef<string | null>(null);
   const renderedTerminalRef = useRef<string | null>(null);
+  const attachEvictionsRef = useRef<number[]>([]);
   const resizeSyncRef = useRef<TerminalResizeSync | null>(null);
   const terminalAttachEpochRef = useRef(s.terminalAttachEpoch);
   const attachWatchdogRef = useRef<TerminalAttachFrameWatchdog | null>(null);
@@ -871,6 +887,40 @@ export function TerminalView({
       if (text !== null && connectionClient.isCurrent()) {
         clipboardProvider.writeText(SYSTEM_CLIPBOARD, text);
       }
+    });
+    const offClosed = bridge.onTerminalClosed((closed) => {
+      if (
+        !terminalPushMatches(
+          terminalIdentity,
+          connectionClient,
+          desiredTerminalRef.current,
+          closed,
+        )
+      ) {
+        return;
+      }
+      // Herdr closes the direct attach when another client takes the
+      // terminal over (or its stream dies). Re-attach, but bound takeover
+      // wars between two clients so they cannot evict each other forever.
+      attachedRef.current = null;
+      attachingRef.current = null;
+      const now = Date.now();
+      attachEvictionsRef.current = attachEvictionsRef.current.filter(
+        (at) => now - at < TERMINAL_EVICTION_WINDOW_MS,
+      );
+      attachEvictionsRef.current.push(now);
+      if (attachEvictionsRef.current.length > TERMINAL_EVICTION_MAX_RETRIES) {
+        attachWatchdogRef.current?.cancel();
+        setTerminalLoading(false);
+        setTerminalAttachError(
+          typeof closed.reason === "string" &&
+            closed.reason.includes("taken over")
+            ? "Terminal stream was taken over by another herdr-gui client"
+            : "Terminal stream closed by the server",
+        );
+        return;
+      }
+      setAttachRetry((value) => value + 1);
     });
     let disposedByConnectionLease = false;
     const unregisterConnectionDisposer = registerTerminalConnectionDisposer(
@@ -1585,6 +1635,7 @@ export function TerminalView({
       terminalEffectDisposed = true;
       off();
       offClipboard();
+      offClosed();
       unregisterConnectionDisposer();
       densityQuery.removeEventListener("change", applyDensity);
       ro.disconnect();

--- a/web/src/components/WorkspaceTree.tsx
+++ b/web/src/components/WorkspaceTree.tsx
@@ -1,4 +1,4 @@
-import { useStore, store } from "../store";
+import { shallowEqual, store, useStoreSelector } from "../store";
 import type { GitStatusSummary, Pane, Workspace } from "../types";
 import { shortId } from "../utils";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -180,7 +180,18 @@ export function WorkspaceTree({
   onReviewChangesForAgent?: (pane: Pane) => void;
   onViewAgentHistory?: (pane: Pane) => void;
 }) {
-  const s = useStore();
+  const s = useStoreSelector(
+    (state) => ({
+      activeConnectionId: state.activeConnectionId,
+      lastRefresh: state.lastRefresh,
+      layout: state.layout,
+      panes: state.panes,
+      selectedPaneId: state.selectedPaneId,
+      status: state.status,
+      workspaces: state.workspaces,
+    }),
+    shallowEqual,
+  );
   const connectionClient = useConnectionClient();
   const [menu, setMenu] = useState<ContextMenuState | null>(null);
   const [agentMenu, setAgentMenu] = useState<AgentMenuState | null>(null);
@@ -548,7 +559,12 @@ function WorkspaceRow({
 }) {
   const children = childrenByParent.get(w.workspace_id) ?? [];
   const agents = agentsByWorkspace.get(w.workspace_id) ?? [];
-  const s = useStore();
+  const s = useStoreSelector(
+    (state) => ({
+      pendingFocusWorkspaceId: state.pendingFocusWorkspaceId,
+    }),
+    shallowEqual,
+  );
   const isChild = depth > 0;
   const hasChildren = children.length > 0;
   const hasNestedItems = hasChildren || agents.length > 0;

--- a/web/src/components/WorktreeLifecycleDialog.tsx
+++ b/web/src/components/WorktreeLifecycleDialog.tsx
@@ -3,7 +3,7 @@ import { createPortal } from "react-dom";
 import { FolderOpen, GitBranch, RefreshCw, Settings } from "lucide-react";
 import { luckyWorktreeBranchName } from "../luckyName";
 import { useConnectionClient } from "../useConnectionClient";
-import { store, useStore } from "../store";
+import { store, useStoreSelector } from "../store";
 import type { Workspace, WorktreeList } from "../types";
 import { resolveWorktreeOpenSource, worktreeCreationSource } from "../worktree";
 import {
@@ -86,13 +86,13 @@ export function WorktreeLifecycleDialog({
   workspaceId?: string | null;
   onClose: () => void;
 }) {
-  const s = useStore();
+  const workspaces = useStoreSelector((state) => state.workspaces);
   const connectionClient = useConnectionClient();
-  const selectedWorkspace = s.workspaces.find(
+  const selectedWorkspace = workspaces.find(
     (workspace) => workspace.workspace_id === workspaceId,
   );
   const actionSourceWorkspace = selectedWorkspace
-    ? worktreeCreationSource(s.workspaces, selectedWorkspace)
+    ? worktreeCreationSource(workspaces, selectedWorkspace)
     : undefined;
   // Listing and repository settings accept linked workspaces. Creating or
   // opening a worktree does not, so keep those two contexts independent.
@@ -259,8 +259,8 @@ export function WorktreeLifecycleDialog({
   }, [hooksOpen, newWorktreeOpen, onClose, open, openWorktreeOpen, removeRow]);
 
   const rows = useMemo(
-    () => (list ? buildWorktreeLifecycleRows(list, s.workspaces) : []),
-    [list, s.workspaces],
+    () => (list ? buildWorktreeLifecycleRows(list, workspaces) : []),
+    [list, workspaces],
   );
   const configuredHooks = hooks?.hooks
     ? Object.values(hooks.hooks).filter(Boolean).length

--- a/web/src/store.test.ts
+++ b/web/src/store.test.ts
@@ -14,6 +14,7 @@ import {
   noticeAutoDismissDelay,
   numberedCreatedTabRename,
   reconcileConnectionCatalogSessions,
+  stabilizeRefreshPatch,
   type ServerSessionState,
   type State,
   store,
@@ -156,7 +157,6 @@ function session(
       },
     ],
     panes: [pane(label, "idle")],
-    paneContents: { "same-pane": `${label} contents` },
     selectedPaneId: "same-pane",
     recentPaneIds: [`${label}-recent`, "same-pane"],
     pendingFocusWorkspaceId: `${label}-pending`,
@@ -333,13 +333,11 @@ describe("connection-partitioned store state", () => {
 
     expect(beta.activeConnectionId).toBe("beta");
     expect(beta.workspaces[0]?.label).toBe("beta");
-    expect(beta.paneContents["same-pane"]).toBe("beta contents");
     expect(beta.pendingFocusWorkspaceId).toBe("beta-pending");
     expect(beta.recentPaneIds).toEqual(["beta-recent", "same-pane"]);
 
     const restoredAlpha = activateConnectionState(beta, "alpha", 12);
     expect(restoredAlpha.workspaces[0]?.label).toBe("alpha");
-    expect(restoredAlpha.paneContents["same-pane"]).toBe("alpha contents");
     expect(restoredAlpha.pendingFocusWorkspaceId).toBe("alpha-pending");
     expect(restoredAlpha.recentPaneIds).toEqual(["alpha-recent", "same-pane"]);
   });
@@ -361,7 +359,6 @@ describe("connection-partitioned store state", () => {
       tabs: [],
       panes: [],
       layout: null,
-      paneContents: {},
       selectedPaneId: null,
       pendingFocusWorkspaceId: null,
     });
@@ -413,7 +410,6 @@ describe("connection-partitioned store state", () => {
         tabs: [],
         panes: [],
         layout: null,
-        paneContents: {},
         selectedPaneId: null,
       });
     } finally {
@@ -680,6 +676,111 @@ describe("connection-partitioned store state", () => {
     } finally {
       bridge.connection = originalConnection;
       bridge.setActiveConnection = originalSetActiveConnection;
+      __storeTesting.replaceState(partitionState());
+    }
+  });
+});
+
+describe("stabilizeRefreshPatch", () => {
+  test("returns null when a refresh reproduces the current state", () => {
+    const snapshot = partitionState();
+    expect(
+      stabilizeRefreshPatch(snapshot, {
+        workspaces: structuredClone(snapshot.workspaces),
+        tabs: structuredClone(snapshot.tabs),
+        panes: structuredClone(snapshot.panes),
+        layout: structuredClone(snapshot.layout),
+        error: null,
+        lastRefresh: Date.now(),
+      }),
+    ).toBeNull();
+  });
+
+  test("keeps unchanged slice references and adopts changed ones", () => {
+    const snapshot = partitionState();
+    const panes = [pane("alpha", "working")];
+    const patch = stabilizeRefreshPatch(snapshot, {
+      workspaces: structuredClone(snapshot.workspaces),
+      tabs: structuredClone(snapshot.tabs),
+      panes,
+      layout: null,
+      error: null,
+      lastRefresh: 123,
+    });
+
+    expect(patch?.workspaces).toBe(snapshot.workspaces);
+    expect(patch?.tabs).toBe(snapshot.tabs);
+    expect(patch?.layout).toBe(snapshot.layout);
+    expect(patch?.panes).toBe(panes);
+    expect(patch?.lastRefresh).toBe(123);
+    expect(patch).not.toHaveProperty("error");
+  });
+
+  test("publishes scalar-only transitions like selection or error moves", () => {
+    const snapshot = partitionState();
+    const cleared = stabilizeRefreshPatch(snapshot, {
+      selectedPaneId: null,
+      error: null,
+      lastRefresh: 5,
+    });
+    expect(cleared).toMatchObject({ selectedPaneId: null, lastRefresh: 5 });
+
+    const failed = stabilizeRefreshPatch(snapshot, {
+      error: "boom",
+      lastRefresh: 6,
+    });
+    expect(failed).toMatchObject({ error: "boom", lastRefresh: 6 });
+    expect(failed).not.toHaveProperty("selectedPaneId");
+  });
+
+  test("returns null when scalar values already match", () => {
+    const snapshot = partitionState();
+    expect(
+      stabilizeRefreshPatch(snapshot, {
+        selectedPaneId: snapshot.selectedPaneId,
+        error: snapshot.error,
+        lastRefresh: Date.now(),
+      }),
+    ).toBeNull();
+  });
+
+  test("keeps the store silent when an idle refresh changes nothing", async () => {
+    const originalConnection = bridge.connection;
+    const snapshot = partitionState();
+    bridge.connection = (() => ({
+      connectionId: "alpha",
+      generation: 10,
+      isCurrent: () => true,
+      call: (async (method: string) => {
+        if (method === "workspace.list") {
+          return { workspaces: structuredClone(snapshot.workspaces) };
+        }
+        if (method === "tab.list") {
+          return { tabs: structuredClone(snapshot.tabs) };
+        }
+        if (method === "pane.list") {
+          return { panes: structuredClone(snapshot.panes) };
+        }
+        if (method === "pane.layout") return { layout: null };
+        return {};
+      }) as ConnectionClient["call"],
+    })) as typeof bridge.connection;
+    try {
+      __storeTesting.replaceState(snapshot);
+      let emissions = 0;
+      const unsubscribe = store.subscribe(() => {
+        emissions += 1;
+      });
+      try {
+        const before = store.get();
+        await store.refresh();
+        expect(store.get()).toBe(before);
+        expect(emissions).toBe(0);
+      } finally {
+        unsubscribe();
+      }
+    } finally {
+      bridge.connection = originalConnection;
       __storeTesting.replaceState(partitionState());
     }
   });

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -1,4 +1,4 @@
-import { useSyncExternalStore } from "react";
+import { useRef, useSyncExternalStore } from "react";
 import {
   bridge,
   type ConnectionClient,
@@ -26,8 +26,6 @@ export interface ServerSessionState {
   tabs: Tab[];
   panes: Pane[];
   layout: PaneLayout | null;
-  /** Latest visible text of each pane currently shown in the layout. */
-  paneContents: Record<string, string>;
   selectedPaneId: string | null;
   recentPaneIds: string[];
   error: string | null;
@@ -135,7 +133,6 @@ export function emptyServerSessionState(
     tabs: [],
     panes: [],
     layout: null,
-    paneContents: {},
     selectedPaneId: null,
     recentPaneIds: [],
     error: null,
@@ -296,7 +293,6 @@ const SERVER_SESSION_KEYS: Array<keyof ServerSessionState> = [
   "tabs",
   "panes",
   "layout",
-  "paneContents",
   "selectedPaneId",
   "recentPaneIds",
   "error",
@@ -312,7 +308,6 @@ function serverSessionFromState(snapshot: State): ServerSessionState {
     tabs: snapshot.tabs,
     panes: snapshot.panes,
     layout: snapshot.layout,
-    paneContents: snapshot.paneContents,
     selectedPaneId: snapshot.selectedPaneId,
     recentPaneIds: snapshot.recentPaneIds,
     error: snapshot.error,
@@ -897,6 +892,77 @@ function enqueueFocusAction<T>(fn: () => Promise<T>): Promise<T> {
   return task;
 }
 
+/**
+ * Structural equality for JSON-shaped values. Fails open (reports unequal)
+ * when a value cannot be serialized, so callers fall back to publishing.
+ */
+function jsonDeepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+}
+
+function serverSessionEqual(
+  a: ServerSessionState,
+  b: ServerSessionState,
+): boolean {
+  for (const key of SERVER_SESSION_KEYS) {
+    if (a[key] === b[key]) continue;
+    if (!jsonDeepEqual(a[key], b[key])) return false;
+  }
+  return true;
+}
+
+const REFRESH_SLICE_KEYS = ["workspaces", "tabs", "panes", "layout"] as const;
+const REFRESH_SCALAR_KEYS = [
+  "error",
+  "pendingFocusWorkspaceId",
+  "selectedPaneId",
+] as const;
+
+/**
+ * Reuse the previous reference for every refresh slice whose content is
+ * unchanged so memoized consumers stay valid, and return null when nothing
+ * changed at all so the caller can skip broadcasting a no-op state. Scalars
+ * are only adopted when their value actually moved.
+ */
+export function stabilizeRefreshPatch(
+  snapshot: State,
+  next: Partial<State>,
+): Partial<State> | null {
+  const patch: Partial<State> = {};
+  let changed = false;
+  const adoptSlice = <K extends (typeof REFRESH_SLICE_KEYS)[number]>(
+    key: K,
+  ) => {
+    if (!(key in next)) return;
+    const incoming = next[key] as State[K];
+    const current = snapshot[key];
+    if (incoming === current || jsonDeepEqual(incoming, current)) {
+      patch[key] = current;
+    } else {
+      patch[key] = incoming;
+      changed = true;
+    }
+  };
+  for (const key of REFRESH_SLICE_KEYS) adoptSlice(key);
+  const adoptScalar = <K extends (typeof REFRESH_SCALAR_KEYS)[number]>(
+    key: K,
+  ) => {
+    if (!(key in next)) return;
+    if (next[key] === snapshot[key]) return;
+    patch[key] = next[key] as State[K];
+    changed = true;
+  };
+  for (const key of REFRESH_SCALAR_KEYS) adoptScalar(key);
+  if (!changed) return null;
+  patch.lastRefresh = next.lastRefresh ?? Date.now();
+  return patch;
+}
+
 async function refreshNow(lease = captureConnectionLease()) {
   if (
     state.connectionPaused ||
@@ -982,10 +1048,13 @@ async function refreshNow(lease = captureConnectionLease()) {
       next.layout = null;
     }
 
-    if (!setForConnection(lease, next)) return;
+    const patch = stabilizeRefreshPatch(state, next);
+    if (patch) {
+      if (!setForConnection(lease, patch)) return;
+    } else if (!leaseIsCurrent(lease)) {
+      return;
+    }
     notifyCompletedTasks(lease, completedPanes, workspaces, tabs);
-    // Fetch the visible text for every pane in the layout right away.
-    void refreshContents(lease);
   } catch (error) {
     setForConnection(lease, { error: (error as Error).message });
   } finally {
@@ -1012,72 +1081,39 @@ async function refreshBridgeStatus() {
     const r = await bridge.call("bridge.status");
     if (state.connectionPaused || state.status !== "connected") return;
     applyConnectionCatalog(r, requestSeq);
-    set({
-      bridgeStatus: {
-        clients: Number(r?.clients ?? 0),
-        terminals: Array.isArray(r?.terminals) ? r.terminals : [],
-      },
-    });
+    const nextBridgeStatus: BridgeStatus = {
+      clients: Number(r?.clients ?? 0),
+      terminals: Array.isArray(r?.terminals) ? r.terminals : [],
+    };
+    if (!jsonDeepEqual(state.bridgeStatus, nextBridgeStatus)) {
+      set({ bridgeStatus: nextBridgeStatus });
+    }
   } catch {
     // Keep the last good count; status polling should never interrupt the UI.
   }
 }
 
-/** Read recent scrollback of every pane in the current layout. */
-async function refreshContents(lease = captureConnectionLease()) {
-  if (
-    state.connectionPaused ||
-    state.status !== "connected" ||
-    !leaseIsCurrent(lease)
-  ) {
-    return;
-  }
-  const layout = state.layout;
-  if (!layout || layout.panes.length === 0) return;
-  const next: Record<string, string> = { ...state.paneContents };
-  await Promise.all(
-    layout.panes.map(async (layoutPane) => {
-      try {
-        const result = await lease.client.call("pane.read", {
-          pane_id: layoutPane.pane_id,
-          source: "visible",
-          lines: 200,
-          format: "ansi",
-        });
-        next[layoutPane.pane_id] = (result?.read?.text ?? "") as string;
-      } catch {
-        // Keep the last good content for this pane.
-      }
-      return undefined;
-    }),
-  );
-  setForConnection(lease, { paneContents: next });
-}
-
-let contentTimer: ReturnType<typeof setInterval> | null = null;
 let metadataTimer: ReturnType<typeof setInterval> | null = null;
 let updateTimer: ReturnType<typeof setInterval> | null = null;
-function startContentPolling() {
-  if (contentTimer) return;
-  contentTimer = setInterval(() => {
-    if (
-      state.status === "connected" &&
-      catalogReadyForConnection &&
-      state.layout
-    ) {
-      refreshContents();
-    }
-  }, 1500);
-}
+
+// Push events and post-action refreshes carry live updates; the metadata poll
+// is only a backstop, so it can run slowly and skip ticks while hidden.
+const METADATA_POLL_MS = 5000;
 
 function startMetadataPolling() {
   if (metadataTimer) return;
   metadataTimer = setInterval(() => {
+    if (
+      typeof document !== "undefined" &&
+      document.visibilityState === "hidden"
+    ) {
+      return;
+    }
     if (state.status === "connected") {
       if (catalogReadyForConnection) scheduleRefresh();
       void refreshBridgeStatus();
     }
-  }, 1000);
+  }, METADATA_POLL_MS);
 }
 
 async function checkForUpdate(showErrors = false) {
@@ -1161,10 +1197,6 @@ function stopPolling() {
     clearTimeout(refreshTimer);
     refreshTimer = null;
   }
-  if (contentTimer) {
-    clearInterval(contentTimer);
-    contentTimer = null;
-  }
   if (metadataTimer) {
     clearInterval(metadataTimer);
     metadataTimer = null;
@@ -1177,7 +1209,6 @@ function stopPolling() {
 }
 
 function startPolling() {
-  startContentPolling();
   startMetadataPolling();
   startUpdatePolling();
 }
@@ -1351,12 +1382,42 @@ function applyConnectionCatalog(result: unknown, requestSeq: number) {
     return;
   }
 
+  // Steady-state catalog polls rebuild identical DTOs every tick. Publish
+  // only real changes so unchanged slices keep their references and idle
+  // polls do not re-render every subscriber.
+  const stableConnections = jsonDeepEqual(state.connections, connections)
+    ? state.connections
+    : connections;
+  const previousSessions = state.sessionsByConnectionId;
+  const nextSessions = reconciliation.sessionsByConnectionId;
+  let sessionsChanged =
+    reconciliation.invalidatedConnectionIds.length > 0 ||
+    Object.keys(nextSessions).length !== Object.keys(previousSessions).length;
+  const stableSessions: Record<string, ServerSessionState> = {};
+  for (const [id, session] of Object.entries(nextSessions)) {
+    const previous = previousSessions[id];
+    if (previous && serverSessionEqual(previous, session)) {
+      stableSessions[id] = previous;
+    } else {
+      stableSessions[id] = session;
+      sessionsChanged = true;
+    }
+  }
+  if (
+    stableConnections === state.connections &&
+    !sessionsChanged &&
+    defaultConnectionId === state.defaultConnectionId
+  ) {
+    if (!nextActive) selectConnectionNow(defaultConnectionId);
+    return;
+  }
+
   state = {
     ...state,
     ...(reconciliation.activeSession ?? {}),
-    connections,
+    connections: stableConnections,
     defaultConnectionId,
-    sessionsByConnectionId: reconciliation.sessionsByConnectionId,
+    sessionsByConnectionId: stableSessions,
   };
   emit();
   if (!nextActive) selectConnectionNow(defaultConnectionId);
@@ -1621,6 +1682,9 @@ export const store = {
             },
       );
       if (s === "connected" && !state.connectionPaused) {
+        // Polling may have been stopped by the hello-driven initial
+        // connection switch; every settled connection must re-arm it.
+        startPolling();
         void refreshConnectionCatalog().then((catalogReady) => {
           if (
             !catalogReady ||
@@ -1663,6 +1727,7 @@ export const store = {
     const refreshOnReturn = () => {
       if (state.connectionPaused || state.status !== "connected") return;
       void refreshNow();
+      void refreshBridgeStatus();
     };
     if (typeof document !== "undefined") {
       document.addEventListener("visibilitychange", () => {
@@ -2557,4 +2622,66 @@ export const __storeTesting = {
 
 export function useStore(): State {
   return useSyncExternalStore(store.subscribe, store.get);
+}
+
+/** Shallowly compares own enumerable values; pair with useStoreSelector. */
+export function shallowEqual<T>(a: T, b: T): boolean {
+  if (Object.is(a, b)) return true;
+  if (
+    typeof a !== "object" ||
+    a === null ||
+    typeof b !== "object" ||
+    b === null
+  ) {
+    return false;
+  }
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const key of aKeys) {
+    if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
+    if (
+      !Object.is(
+        (a as Record<string, unknown>)[key],
+        (b as Record<string, unknown>)[key],
+      )
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Subscribe to a derived slice of the store. The selector result is cached
+ * and reused while `isEqual` reports equality, so inline selectors are safe
+ * as long as they keep stable semantics; object-returning selectors should
+ * pass a shallow equality to avoid re-rendering on every emit.
+ */
+export function useStoreSelector<T>(
+  selector: (state: State) => T,
+  isEqual: (a: T, b: T) => boolean = Object.is,
+): T {
+  const cacheRef = useRef<{
+    state: State;
+    selector: (state: State) => T;
+    value: T;
+  } | null>(null);
+
+  const getSnapshot = () => {
+    const snapshot = store.get();
+    const cache = cacheRef.current;
+    if (cache && cache.state === snapshot && cache.selector === selector) {
+      return cache.value;
+    }
+    const value = selector(snapshot);
+    if (cache && isEqual(cache.value, value)) {
+      cacheRef.current = { state: snapshot, selector, value: cache.value };
+      return cache.value;
+    }
+    cacheRef.current = { state: snapshot, selector, value };
+    return value;
+  };
+
+  return useSyncExternalStore(store.subscribe, getSnapshot);
 }

--- a/web/src/useConnectionClient.ts
+++ b/web/src/useConnectionClient.ts
@@ -1,11 +1,12 @@
 import { useMemo } from "react";
 import { bridge, type ConnectionClient } from "./api";
-import { useStore } from "./store";
+import { useStoreSelector } from "./store";
 
 /** Captures the active browser routing lease for component-owned work. */
 export function useConnectionClient(): ConnectionClient {
-  const state = useStore();
-  const { activeConnectionId, connectionGeneration, connections } = state;
+  const activeConnectionId = useStoreSelector((s) => s.activeConnectionId);
+  const connectionGeneration = useStoreSelector((s) => s.connectionGeneration);
+  const connections = useStoreSelector((s) => s.connections);
   const runtimeGeneration =
     connections.find((connection) => connection.id === activeConnectionId)
       ?.generation ?? null;


### PR DESCRIPTION
## Summary

**Performance** — eliminates the periodic one-second UI hitch while idle:

- Removed a leftover background poll that read 200 lines of scrollback per visible pane every 1.5s (`paneContents` chain) — it had no consumer; `pane.read` traffic is now zero.
- The store no longer broadcasts when a refresh returns unchanged data: unchanged slices keep their previous references (so memoized consumers stay valid) and fully-unchanged refreshes skip emitting entirely. The same change detection now covers the bridge-status and connection-catalog paths, which were emitting fresh objects every second as well.
- The metadata fallback poll runs at 5s instead of 1s (push events and post-action refreshes carry live updates) and is suspended while the page is hidden, with an immediate catch-up on return.
- New `useStoreSelector` hook: components subscribe to just the state slices they read instead of the whole store, so an emit no longer re-renders the entire app. All 18 whole-store subscription sites are migrated.

**Fixes:**

- Metadata/update polls were stopped by the initial switch away from the legacy placeholder connection and never re-armed, leaving the app without its fallback poll. They now restart whenever the connection settles.
- Terminal stream takeover recovery: when Herdr closes a terminal stream because another herdr-gui client took the terminal over (e.g. a second GUI instance viewing the same pane), the bridge now notifies viewers (`terminal_closed`, with the close reason) and the frontend re-attaches with a bounded retry instead of leaving a blank terminal until a page reload. Sustained takeover wars are capped and surface an explicit, reason-aware error.

## Verification

- `bun run format:check`, `bun run lint`, `bun run test` (645 pass), `cd web && bun run typecheck`, `cd server && bun run typecheck` (incl. web build) — all green.
- New tests: idle refresh produces zero store emissions (end-to-end through the store), `stabilizeRefreshPatch` unit tests, bridge notifies viewers on stream close + re-attach works, `terminal_closed` push dispatch.
- Automated browser verification (headless Chrome against a live Herdr): zero `pane.read` frames, zero idle emits in 12s, 5s poll cadence, polling suspended while hidden, terminal input/output round-trip, workspace switching, page reload and bridge restart re-attach, pause/resume, and takeover self-healing in ~1s after an external client steals the terminal.

## Notes

- `useStore()` remains exported for low-frequency cold paths but no longer has call sites.
- `pane.read` / `PaneRead` protocol support is untouched; only the dead consumer was removed.