### PR TITLE
Add Copilot code review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,9 +25,9 @@ When reviewing pull requests, focus on:
 - React state management: prefer the existing store and bridge helpers in
   `web/src` over new abstractions; watch for missing effect cleanup and stale
   closures over socket state.
-- Security: the server binds locally and executes local processes; flag any
-  path traversal, unvalidated message payloads, or injection-prone command
-  construction.
+- Security: the server runs locally by default but can bind to a non-loopback
+  address; it also executes local processes. Flag any path traversal,
+  unvalidated message payloads, or injection-prone command construction.
 - Cross-platform behavior: releases target linux-x64, linux-arm64,
   darwin-x64, and darwin-arm64; avoid OS-specific assumptions in shared code.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,55 @@
+# Copilot Instructions
+
+## Project overview
+
+herdr-gui is a web GUI client for Herdr. It has two parts:
+
+- `server/src`: Bun-powered local bridge server (HTTP + WebSocket) that talks
+  to the local Herdr socket.
+- `web/src`: React + Vite frontend dashboard. Reusable UI lives in
+  `web/src/components`, assets in `web/src/assets`, global styling in
+  `web/src/styles.css`.
+- `scripts/`: release and packaging helpers.
+
+Generated build output lives in `server/public`,
+`server/src/public-files.gen.ts`, `server/herdr-gui*`, and `dist/`. These are
+build artifacts; they must not be edited or committed.
+
+## Review priorities
+
+When reviewing pull requests, focus on:
+
+- Correctness of the Bun bridge: HTTP/WebSocket message handling, socket
+  lifecycle, reconnection and error paths, and cleanup of listeners, timers,
+  and subprocesses.
+- React state management: prefer the existing store and bridge helpers in
+  `web/src` over new abstractions; watch for missing effect cleanup and stale
+  closures over socket state.
+- Security: the server binds locally and executes local processes; flag any
+  path traversal, unvalidated message payloads, or injection-prone command
+  construction.
+- Cross-platform behavior: releases target linux-x64, linux-arm64,
+  darwin-x64, and darwin-arm64; avoid OS-specific assumptions in shared code.
+
+## Style and conventions
+
+- TypeScript everywhere; React function components; keep components small and
+  focused under `web/src/components`.
+- Formatting is enforced by the root `biome.json` (2-space indent, LF, double
+  quotes, semicolons, trailing commas). Do not suggest style changes that
+  conflict with it.
+- Keep edits ASCII unless the file already contains non-ASCII text.
+- Use the existing CSS class naming style; no CSS-in-JS or new styling
+  systems.
+
+## Verification
+
+Changes are expected to pass, from the repo root:
+
+- `bun run format:check`
+- `bun run lint`
+- `bun run test`
+- `cd web && bun run typecheck` and `cd server && bun run typecheck`
+- For frontend-facing changes: `cd web && bun run build`
+
+Call out missing verification when a PR touches these areas without it.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,8 +33,8 @@ When reviewing pull requests, focus on:
 
 ## Style and conventions
 
-- TypeScript everywhere; React function components; keep components small and
-  focused under `web/src/components`.
+- Use TypeScript for application code; use React function components; keep components
+  small and focused under `web/src/components`.
 - Formatting is enforced by the root `biome.json` (2-space indent, LF, double
   quotes, semicolons, trailing commas). Do not suggest style changes that
   conflict with it.


### PR DESCRIPTION
## Summary

- Adds `.github/copilot-instructions.md` so Copilot code review (and the Copilot coding agent) reviews PRs against this project's structure, style, and verification gates.
- Companion repo-side setup (already applied via API): branch ruleset **Copilot code review** (https://github.com/powerfooI/herdr-gui/rules/21199119) automatically requests a Copilot review on PRs targeting `main`, including on new pushes. Draft PRs are not reviewed.

## Verification

- `bun run format:check` passes locally.
- This PR itself should receive an automatic Copilot review request, which validates the ruleset end to end.