### PR TITLE
Publish Windows release packages

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,7 +29,8 @@ When reviewing pull requests, focus on:
   address; it also executes local processes. Flag any path traversal,
   unvalidated message payloads, or injection-prone command construction.
 - Cross-platform behavior: releases target linux-x64, linux-arm64,
-  darwin-x64, and darwin-arm64; avoid OS-specific assumptions in shared code.
+  darwin-x64, darwin-arm64, and windows-x64; avoid OS-specific assumptions in
+  shared code.
 
 ## Style and conventions
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
           - linux-arm64
           - darwin-x64
           - darwin-arm64
+          - windows-x64
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -101,7 +102,11 @@ jobs:
           mkdir -p "$extract_dir"
           tar -xJf "dist/$versioned_archive" -C "$extract_dir"
           grep -Fx "herdr-gui $version $platform" "$extract_dir/$package_dir/VERSION"
-          binary="$extract_dir/$package_dir/herdr-gui"
+          binary_name="herdr-gui"
+          if [ "$platform" = "windows-x64" ]; then
+            binary_name="herdr-gui.exe"
+          fi
+          binary="$extract_dir/$package_dir/$binary_name"
           case "$platform" in
             linux-x64)
               test "$("$binary" --version)" = "herdr-gui $version"
@@ -114,6 +119,9 @@ jobs:
               ;;
             darwin-arm64)
               file "$binary" | grep -Eq 'Mach-O 64-bit.*arm64'
+              ;;
+            windows-x64)
+              file "$binary" | grep -Eq 'PE32\+ executable.*x86-64.*MS Windows'
               ;;
           esac
       - uses: actions/upload-artifact@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,9 @@ committed.
 - `bun run build:darwin-arm64`: build the macOS Apple Silicon binary.
 - `bun run package:linux-x64`: build and emit both versioned and latest `tar.xz`
   archives and checksums in `dist/`.
-- `bun run package:linux-arm64`, `package:darwin-x64`, and
-  `package:darwin-arm64`: package the other supported release targets.
+- `bun run package:linux-arm64`, `package:darwin-x64`,
+  `package:darwin-arm64`, and `package:windows-x64`: package the other
+  supported release targets.
 - `bun run format`: format supported files with the pinned root Biome config.
 - `bun run format:check`: verify that all supported files are formatted.
 - `bun run lint`: lint all TypeScript and React code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 ### Added
 
 - Add Windows support: the bridge maps local Herdr `%APPDATA%\herdr` socket
-  names to native named pipes, gains a Windows x64 build target, and manages an
-  isolated per-user startup task through Windows Task Scheduler.
+  names to native named pipes, gains Windows x64 build and release packages,
+  and manages an isolated per-user startup task through Windows Task
+  Scheduler.
 
 ### Performance
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ curl -fsSL \
   | sh
 ```
 
+Windows x64 releases are published as a checksummed archive containing
+`herdr-gui.exe`. Download `herdr-gui-windows-x64.tar.xz` and its matching
+`.sha256` file from the [latest release](https://github.com/powerfooI/herdr-gui/releases/latest),
+verify it with `Get-FileHash`, then extract it with Windows 11's built-in
+`tar.exe`.
+
 Make sure `~/.local/bin` is in `PATH`, then start the application:
 
 ```bash
@@ -335,6 +341,7 @@ bun run build:darwin-x64  # → server/herdr-gui-darwin-x64  (Intel macOS)
 bun run build:darwin-arm64 # → server/herdr-gui-darwin-arm64 (Apple Silicon)
 bun run build:windows-x64 # → server/herdr-gui-windows-x64.exe (Windows x64)
 bun run build:all
+bun run package:windows-x64 # → dist/herdr-gui-windows-x64.tar.xz
 ```
 
 > **Linux x86-64 note:** use the **glibc** build (`herdr-gui-linux-x64`) for

--- a/USAGE.md
+++ b/USAGE.md
@@ -12,7 +12,7 @@ herdr-gui 是 Herdr 的 Web 图形界面。它启动一个本地 bridge 服务�
 
 ## 安装和更新
 
-当前 Linux 和 macOS 的 x86-64、arm64 版本通过 GitHub Releases 发布：
+当前 Linux、macOS 和 Windows x64 版本通过 GitHub Releases 发布：
 
 ```text
 https://github.com/powerfooI/herdr-gui/releases
@@ -24,6 +24,12 @@ https://github.com/powerfooI/herdr-gui/releases
 ```bash
 curl -fsSL "https://github.com/powerfooI/herdr-gui/releases/latest/download/install-herdr-gui.sh" | bash
 ```
+
+Windows x64 用户从 latest release 下载
+`herdr-gui-windows-x64.tar.xz` 及同名 `.sha256` 文件，用
+`Get-FileHash -Algorithm SHA256` 校验后，通过 Windows 11 自带的
+`tar.exe` 解压；可执行文件位于
+`herdr-gui-windows-x64\herdr-gui.exe`。
 
 确认 `~/.local/bin` 在 `PATH` 里：
 
@@ -516,6 +522,8 @@ bun run build:linux-x64
 bun run build:linux-arm64
 bun run build:darwin-x64
 bun run build:darwin-arm64
+bun run build:windows-x64
+bun run package:windows-x64
 ```
 
 构建多个平台：

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "package:linux-arm64": "scripts/package-release.sh linux-arm64",
     "package:darwin-x64": "scripts/package-release.sh darwin-x64",
     "package:darwin-arm64": "scripts/package-release.sh darwin-arm64",
+    "package:windows-x64": "scripts/package-release.sh windows-x64",
     "release:cut": "bun scripts/cut-release.ts",
     "changelog:notes": "bun scripts/changelog-notes.ts",
     "format": "biome format --write .",

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -8,6 +8,7 @@ version="$(
   bun -e 'console.log(require("./package.json").version)'
 )"
 
+binary_name="herdr-gui"
 case "$platform" in
   darwin-arm64)
     build_script="build:darwin-arm64"
@@ -25,9 +26,14 @@ case "$platform" in
     build_script="build:linux-arm64"
     binary="$root_dir/server/herdr-gui-linux-arm64"
     ;;
+  windows-x64)
+    build_script="build:windows-x64"
+    binary="$root_dir/server/herdr-gui-windows-x64.exe"
+    binary_name="herdr-gui.exe"
+    ;;
   *)
     echo "unsupported platform: $platform" >&2
-    echo "supported platforms: darwin-arm64, darwin-x64, linux-arm64, linux-x64" >&2
+    echo "supported platforms: darwin-arm64, darwin-x64, linux-arm64, linux-x64, windows-x64" >&2
     exit 2
     ;;
 esac
@@ -45,8 +51,8 @@ bun run "$build_script"
 
 rm -rf "$package_dir"
 mkdir -p "$package_dir"
-cp "$binary" "$package_dir/herdr-gui"
-chmod 755 "$package_dir/herdr-gui"
+cp "$binary" "$package_dir/$binary_name"
+chmod 755 "$package_dir/$binary_name"
 printf 'herdr-gui %s %s\n' "$version" "$platform" > "$package_dir/VERSION"
 
 rm -f \


### PR DESCRIPTION
## Summary
- package the Windows x64 standalone binary with checksums and update metadata
- include Windows x64 in the Release workflow matrix and validate its PE header
- document the Windows release archive

## Verification
- `TMPDIR=/tmp bun run precommit`
- `bun run package:windows-x64`
- verified both archive checksums, VERSION metadata, manifest, and PE32+ x86-64 executable
- transferred the archive to Windows 11 ARM64, verified SHA-256, extracted it with built-in `tar.exe`, and ran `herdr-gui.exe --version` successfully