### PR TITLE
Organize menus and update preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@
 
 ### Added
 
+- Add a preference to disable automatic update checks while keeping manual
+  update checks available from the application menu.
 - Add a native Windows ARM64 release package.
+
+### Changed
+
+- Group the application, workspace, and agent menus into clearer sections;
+  workspace and agent context menus now identify their target and isolate
+  destructive actions.
 
 ### Fixed
 

--- a/web/src/components/ConfigMenu.tsx
+++ b/web/src/components/ConfigMenu.tsx
@@ -83,6 +83,7 @@ export function ConfigMenu({
       status: state.status,
       taskNotificationPermission: state.taskNotificationPermission,
       taskNotificationsEnabled: state.taskNotificationsEnabled,
+      automaticUpdateChecksEnabled: state.automaticUpdateChecksEnabled,
       updateInfo: state.updateInfo,
       updateInstalling: state.updateInstalling,
     }),
@@ -209,7 +210,7 @@ export function ConfigMenu({
             </div>
 
             <div className="config-section">
-              <div className="config-title">Preferences</div>
+              <div className="config-title">Appearance</div>
               <div className="config-preference-row">
                 <span className="config-item-icon">
                   {theme === "system" ? (
@@ -314,6 +315,38 @@ export function ConfigMenu({
                     />
                   ))}
                 </div>
+              </div>
+            </div>
+
+            <div className="config-section">
+              <div className="config-title">Behavior & automation</div>
+              <div className="config-preference-row">
+                <span className="config-item-icon">
+                  <Download size={15} />
+                </span>
+                <div className="config-item-copy">
+                  <strong>Automatic update checks</strong>
+                  <span>
+                    {s.automaticUpdateChecksEnabled ? "Enabled" : "Disabled"}
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-label="Automatic update checks"
+                  aria-checked={s.automaticUpdateChecksEnabled}
+                  className={
+                    "settings-switch" +
+                    (s.automaticUpdateChecksEnabled ? " is-on" : "")
+                  }
+                  onClick={() => {
+                    store.setAutomaticUpdateChecksEnabled(
+                      !s.automaticUpdateChecksEnabled,
+                    );
+                  }}
+                >
+                  <span />
+                </button>
               </div>
               <div className="config-preference-row">
                 <span className="config-item-icon">

--- a/web/src/components/ContextMenu.tsx
+++ b/web/src/components/ContextMenu.tsx
@@ -9,8 +9,9 @@ import { WorkspaceAutoSyncDialog } from "./WorkspaceAutoSyncDialog";
 import { worktreeCreationSource } from "../worktree";
 import { WorktreeLifecycleDialog } from "./WorktreeLifecycleDialog";
 import { isWorkspacePinned } from "../workspacePins";
+import { workspaceDisplayName } from "../workspaceTreeBadges";
 import { copyTextFromUserGesture } from "../terminalClipboard";
-import { clampContextMenuPosition } from "./contextMenuPosition";
+import { observeClampedContextMenu } from "./contextMenuPosition";
 
 export interface ContextMenuState {
   x: number;
@@ -113,14 +114,10 @@ export function ContextMenu({
   useLayoutEffect(() => {
     const menu = ref.current;
     if (!state || !menu) return;
-    const rect = menu.getBoundingClientRect();
-    const position = clampContextMenuPosition(
-      { left: state.x, top: state.y },
-      { width: rect.width, height: rect.height },
-      { width: window.innerWidth, height: window.innerHeight },
-    );
-    menu.style.left = `${position.left}px`;
-    menu.style.top = `${position.top}px`;
+    return observeClampedContextMenu(menu, {
+      left: state.x,
+      top: state.y,
+    });
   }, [state]);
 
   const dialogs = (
@@ -239,6 +236,7 @@ export function ContextMenu({
       (workspace) => workspace.workspace_id === state.workspace.workspace_id,
     ) ?? state.workspace;
   const isLinked = !!w.worktree?.is_linked_worktree;
+  const displayName = workspaceDisplayName(w);
   const pinned = isWorkspacePinned(pinnedWorkspaceKeys, w);
   const creationSource = worktreeCreationSource(workspaces, w);
 
@@ -380,7 +378,7 @@ export function ContextMenu({
       >
         <div className="context-menu-header">
           <span>Workspace</span>
-          <strong title={w.label}>{w.label}</strong>
+          <strong title={displayName}>{displayName}</strong>
           <small>
             {isLinked
               ? "Linked worktree"

--- a/web/src/components/ContextMenu.tsx
+++ b/web/src/components/ContextMenu.tsx
@@ -23,6 +23,12 @@ interface Item {
   action: () => void;
 }
 
+interface ItemGroup {
+  label: string;
+  items: Item[];
+  danger?: boolean;
+}
+
 type DialogState =
   | {
       type: "new-worktree";
@@ -217,22 +223,35 @@ export function ContextMenu({
   const pinned = isWorkspacePinned(pinnedWorkspaceKeys, w);
   const creationSource = worktreeCreationSource(workspaces, w);
 
-  const items: Item[] = [
+  const inspectItems: Item[] = [
     {
-      label: "Open Files in Inspector",
+      label: "Browse files",
       action: () => onBrowseFiles?.(w),
     },
     {
-      label: "Open Changes in Inspector",
+      label: "Review changes",
       action: () => onReviewChanges?.(w),
     },
+  ];
+  const organizeItems: Item[] = [
     {
       label: `${pinned ? "Unpin" : "Pin"} ${isLinked ? "worktree" : "workspace"}`,
       action: () => onPinnedChange(w, !pinned),
     },
+    {
+      label: "Rename workspace…",
+      action: () => {
+        setDialog({
+          type: "rename-workspace",
+          workspaceId: w.workspace_id,
+          label: w.label,
+        });
+      },
+    },
   ];
+  const worktreeItems: Item[] = [];
   if (w.worktree) {
-    items.push({
+    organizeItems.push({
       label: "Copy checkout path",
       action: () => {
         const path = w.worktree?.checkout_path;
@@ -254,27 +273,23 @@ export function ContextMenu({
         );
       },
     });
-    items.push({
-      label: "Worktree lifecycle…",
-      action: () => {
-        setLifecycleWorkspaceId(w.workspace_id);
+    worktreeItems.push(
+      {
+        label: "Open worktree…",
+        action: () => setOpenWorktreeWorkspaceId(w.workspace_id),
       },
-    });
-    items.push({
-      label: "Open worktree…",
-      action: () => {
-        setOpenWorktreeWorkspaceId(w.workspace_id);
+      {
+        label: "Worktree lifecycle…",
+        action: () => setLifecycleWorkspaceId(w.workspace_id),
       },
-    });
-    items.push({
-      label: "Worktree hooks…",
-      action: () => {
-        setWorktreeHooksWorkspaceId(w.workspace_id);
+      {
+        label: "Configure worktree hooks…",
+        action: () => setWorktreeHooksWorkspaceId(w.workspace_id),
       },
-    });
+    );
   }
   if (creationSource) {
-    items.push({
+    worktreeItems.unshift({
       label: "New worktree…",
       action: () => {
         setDialog({
@@ -285,30 +300,21 @@ export function ContextMenu({
       },
     });
   }
-  items.push({
-    label: "Git pull",
-    action: () => {
-      void store.gitPullWorkspace(w.workspace_id);
+  const sourceControlItems: Item[] = [
+    {
+      label: "Pull from Git",
+      action: () => {
+        void store.gitPullWorkspace(w.workspace_id);
+      },
     },
-  });
-  items.push({
-    label: "Auto-update branch…",
-    action: () => {
-      setAutoSyncWorkspaceId(w.workspace_id);
+    {
+      label: "Configure branch auto-update…",
+      action: () => setAutoSyncWorkspaceId(w.workspace_id),
     },
-  });
-  items.push({
-    label: "Rename workspace…",
-    action: () => {
-      setDialog({
-        type: "rename-workspace",
-        workspaceId: w.workspace_id,
-        label: w.label,
-      });
-    },
-  });
+  ];
+  const closeItems: Item[] = [];
   if (isLinked) {
-    items.push({
+    closeItems.push({
       label: "Remove worktree",
       danger: true,
       action: () => {
@@ -320,7 +326,7 @@ export function ContextMenu({
       },
     });
   }
-  items.push({
+  closeItems.push({
     label: "Close workspace",
     danger: true,
     action: () => {
@@ -331,10 +337,25 @@ export function ContextMenu({
       });
     },
   });
+  const groups: ItemGroup[] = [
+    { label: "Inspect", items: inspectItems },
+    { label: "Organize", items: organizeItems },
+    { label: "Worktrees", items: worktreeItems },
+    { label: "Source control", items: sourceControlItems },
+    { label: "Close", items: closeItems, danger: true },
+  ].filter((group) => group.items.length > 0);
 
-  // Keep the menu on-screen, including narrow mobile viewports.
+  // Keep the grouped menu on-screen, including narrow mobile viewports.
   const menuMargin = 8;
-  const menuWidth = 200;
+  const menuWidth = 244;
+  const itemCount = groups.reduce(
+    (total, group) => total + group.items.length,
+    0,
+  );
+  const estimatedHeight = Math.min(
+    window.innerHeight - menuMargin * 2,
+    58 + groups.length * 25 + itemCount * 34,
+  );
   const style: React.CSSProperties = {
     position: "fixed",
     left: Math.max(
@@ -343,25 +364,53 @@ export function ContextMenu({
     ),
     top: Math.max(
       menuMargin,
-      Math.min(state.y, window.innerHeight - items.length * 34 - menuMargin),
+      Math.min(state.y, window.innerHeight - estimatedHeight - menuMargin),
     ),
     zIndex: 1000,
   };
 
   return (
     <>
-      <div ref={ref} className="context-menu" style={style}>
-        {items.map((it, i) => (
-          <button
-            key={i}
-            className={`context-menu-item ${it.danger ? "is-danger" : ""}`}
-            onClick={() => {
-              onClose();
-              it.action();
-            }}
+      <div
+        ref={ref}
+        className="context-menu context-menu--grouped"
+        style={style}
+        role="menu"
+        aria-label={`Workspace actions for ${w.label}`}
+      >
+        <div className="context-menu-header">
+          <span>Workspace</span>
+          <strong title={w.label}>{w.label}</strong>
+          <small>
+            {isLinked
+              ? "Linked worktree"
+              : w.worktree
+                ? "Git workspace"
+                : "Workspace"}
+          </small>
+        </div>
+        {groups.map((group) => (
+          <div
+            key={group.label}
+            className={`context-menu-group ${group.danger ? "is-danger" : ""}`}
+            role="group"
+            aria-label={group.label}
           >
-            {it.label}
-          </button>
+            <div className="context-menu-group-title">{group.label}</div>
+            {group.items.map((item) => (
+              <button
+                key={item.label}
+                role="menuitem"
+                className={`context-menu-item ${item.danger ? "is-danger" : ""}`}
+                onClick={() => {
+                  onClose();
+                  item.action();
+                }}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
         ))}
       </div>
       {dialogs}

--- a/web/src/components/ContextMenu.tsx
+++ b/web/src/components/ContextMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { Workspace } from "../types";
 import { store, useStoreSelector } from "../store";
 import { luckyWorktreeBranchName } from "../luckyName";
@@ -10,6 +10,7 @@ import { worktreeCreationSource } from "../worktree";
 import { WorktreeLifecycleDialog } from "./WorktreeLifecycleDialog";
 import { isWorkspacePinned } from "../workspacePins";
 import { copyTextFromUserGesture } from "../terminalClipboard";
+import { clampContextMenuPosition } from "./contextMenuPosition";
 
 export interface ContextMenuState {
   x: number;
@@ -90,19 +91,37 @@ export function ContextMenu({
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
     };
+    const onScroll = (e: Event) => {
+      const target = e.target;
+      if (target instanceof Node && ref.current?.contains(target)) return;
+      onClose();
+    };
     // Defer so the triggering contextmenu event doesn't immediately close it.
     const t = setTimeout(() => {
       window.addEventListener("mousedown", onDown);
       window.addEventListener("keydown", onKey);
-      window.addEventListener("scroll", onClose, true);
+      window.addEventListener("scroll", onScroll, true);
     }, 0);
     return () => {
       clearTimeout(t);
       window.removeEventListener("mousedown", onDown);
       window.removeEventListener("keydown", onKey);
-      window.removeEventListener("scroll", onClose, true);
+      window.removeEventListener("scroll", onScroll, true);
     };
   }, [state, onClose]);
+
+  useLayoutEffect(() => {
+    const menu = ref.current;
+    if (!state || !menu) return;
+    const rect = menu.getBoundingClientRect();
+    const position = clampContextMenuPosition(
+      { left: state.x, top: state.y },
+      { width: rect.width, height: rect.height },
+      { width: window.innerWidth, height: window.innerHeight },
+    );
+    menu.style.left = `${position.left}px`;
+    menu.style.top = `${position.top}px`;
+  }, [state]);
 
   const dialogs = (
     <>
@@ -345,27 +364,10 @@ export function ContextMenu({
     { label: "Close", items: closeItems, danger: true },
   ].filter((group) => group.items.length > 0);
 
-  // Keep the grouped menu on-screen, including narrow mobile viewports.
-  const menuMargin = 8;
-  const menuWidth = 244;
-  const itemCount = groups.reduce(
-    (total, group) => total + group.items.length,
-    0,
-  );
-  const estimatedHeight = Math.min(
-    window.innerHeight - menuMargin * 2,
-    58 + groups.length * 25 + itemCount * 34,
-  );
   const style: React.CSSProperties = {
     position: "fixed",
-    left: Math.max(
-      menuMargin,
-      Math.min(state.x, window.innerWidth - menuWidth - menuMargin),
-    ),
-    top: Math.max(
-      menuMargin,
-      Math.min(state.y, window.innerHeight - estimatedHeight - menuMargin),
-    ),
+    left: state.x,
+    top: state.y,
     zIndex: 1000,
   };
 
@@ -375,8 +377,6 @@ export function ContextMenu({
         ref={ref}
         className="context-menu context-menu--grouped"
         style={style}
-        role="menu"
-        aria-label={`Workspace actions for ${w.label}`}
       >
         <div className="context-menu-header">
           <span>Workspace</span>
@@ -393,14 +393,11 @@ export function ContextMenu({
           <div
             key={group.label}
             className={`context-menu-group ${group.danger ? "is-danger" : ""}`}
-            role="group"
-            aria-label={group.label}
           >
             <div className="context-menu-group-title">{group.label}</div>
             {group.items.map((item) => (
               <button
                 key={item.label}
-                role="menuitem"
                 className={`context-menu-item ${item.danger ? "is-danger" : ""}`}
                 onClick={() => {
                   onClose();

--- a/web/src/components/WorkspaceAgentRows.tsx
+++ b/web/src/components/WorkspaceAgentRows.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import {
   focusTreeItem,
   keyboardContextMenuPoint,
@@ -9,6 +9,7 @@ import type { Pane } from "../types";
 import { agentClass, basename, shortId } from "../utils";
 import { shouldShowAgentStatusLabel } from "./agentSession";
 import { AgentStatusIcon } from "./AgentStatusIcon";
+import { clampContextMenuPosition } from "./contextMenuPosition";
 
 const LONG_PRESS_MS = 550;
 const LONG_PRESS_MOVE_PX = 10;
@@ -221,18 +222,36 @@ export function AgentContextMenu({
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
     };
+    const onScroll = (e: Event) => {
+      const target = e.target;
+      if (target instanceof Node && ref.current?.contains(target)) return;
+      onClose();
+    };
     const t = setTimeout(() => {
       window.addEventListener("mousedown", onDown);
       window.addEventListener("keydown", onKey);
-      window.addEventListener("scroll", onClose, true);
+      window.addEventListener("scroll", onScroll, true);
     }, 0);
     return () => {
       clearTimeout(t);
       window.removeEventListener("mousedown", onDown);
       window.removeEventListener("keydown", onKey);
-      window.removeEventListener("scroll", onClose, true);
+      window.removeEventListener("scroll", onScroll, true);
     };
   }, [state, onClose]);
+
+  useLayoutEffect(() => {
+    const menu = ref.current;
+    if (!state || !menu) return;
+    const rect = menu.getBoundingClientRect();
+    const position = clampContextMenuPosition(
+      { left: state.x, top: state.y },
+      { width: rect.width, height: rect.height },
+      { width: window.innerWidth, height: window.innerHeight },
+    );
+    menu.style.left = `${position.left}px`;
+    menu.style.top = `${position.top}px`;
+  }, [state]);
 
   if (!state) return null;
 
@@ -276,59 +295,37 @@ export function AgentContextMenu({
       ],
     },
   ];
-  const menuMargin = 8;
-  const menuWidth = 244;
-  const itemCount = groups.reduce(
-    (total, group) => total + group.items.length,
-    0,
-  );
-  const estimatedHeight = Math.min(
-    window.innerHeight - menuMargin * 2,
-    58 + groups.length * 25 + itemCount * 34,
-  );
   const style: React.CSSProperties = {
     position: "fixed",
-    left: Math.max(
-      menuMargin,
-      Math.min(state.x, window.innerWidth - menuWidth - menuMargin),
-    ),
-    top: Math.max(
-      menuMargin,
-      Math.min(state.y, window.innerHeight - estimatedHeight - menuMargin),
-    ),
+    left: state.x,
+    top: state.y,
     zIndex: 1000,
   };
   const agentName = state.pane.agent ?? "Agent";
   const agentLocation = state.pane.foreground_cwd ?? state.pane.cwd;
+  const agentLocationName = agentLocation
+    ? basename(agentLocation.replace(/\\/g, "/"))
+    : "";
 
   return (
-    <div
-      ref={ref}
-      className="context-menu context-menu--grouped"
-      style={style}
-      role="menu"
-      aria-label={`Actions for ${agentName}`}
-    >
+    <div ref={ref} className="context-menu context-menu--grouped" style={style}>
       <div className="context-menu-header">
         <span>Agent</span>
         <strong title={agentName}>{agentName}</strong>
         <small>
           {state.pane.agent_status}
-          {agentLocation ? ` · ${basename(agentLocation)}` : ""}
+          {agentLocationName ? ` · ${agentLocationName}` : ""}
         </small>
       </div>
       {groups.map((group) => (
         <div
           key={group.label}
           className={`context-menu-group ${group.danger ? "is-danger" : ""}`}
-          role="group"
-          aria-label={group.label}
         >
           <div className="context-menu-group-title">{group.label}</div>
           {group.items.map((item) => (
             <button
               key={item.label}
-              role="menuitem"
               className={`context-menu-item ${item.danger ? "is-danger" : ""}`}
               onClick={() => {
                 onClose();

--- a/web/src/components/WorkspaceAgentRows.tsx
+++ b/web/src/components/WorkspaceAgentRows.tsx
@@ -19,6 +19,18 @@ export interface AgentMenuState {
   y: number;
 }
 
+type AgentContextMenuItem = {
+  label: string;
+  danger?: boolean;
+  action: () => void;
+};
+
+type AgentContextMenuGroup = {
+  label: string;
+  items: AgentContextMenuItem[];
+  danger?: boolean;
+};
+
 export function AgentRow({
   pane,
   selected,
@@ -224,29 +236,56 @@ export function AgentContextMenu({
 
   if (!state) return null;
 
-  const items = [
-    { label: "Open Terminal", action: () => onFocus(state.pane) },
+  const groups: AgentContextMenuGroup[] = [
     {
-      label: "Browse Files at Agent CWD",
-      action: () => onBrowseFiles?.(state.pane),
+      label: "Open",
+      items: [
+        { label: "Open terminal", action: () => onFocus(state.pane) },
+        {
+          label: "Browse files at agent CWD",
+          action: () => onBrowseFiles?.(state.pane),
+        },
+        {
+          label: "Review workspace changes",
+          action: () => onReviewChanges?.(state.pane),
+        },
+      ],
     },
     {
-      label: "Review Workspace Changes",
-      action: () => onReviewChanges?.(state.pane),
+      label: "Session",
+      items: [
+        {
+          label: "View agent history",
+          action: () => onViewHistory?.(state.pane),
+        },
+        {
+          label: "Export session",
+          action: () => onExportSession(state.pane),
+        },
+      ],
     },
     {
-      label: "View Agent History",
-      action: () => onViewHistory?.(state.pane),
-    },
-    { label: "Export session", action: () => onExportSession(state.pane) },
-    {
-      label: "Close pane",
+      label: "Pane",
       danger: true,
-      action: () => onClosePane(state.pane),
+      items: [
+        {
+          label: "Close pane",
+          danger: true,
+          action: () => onClosePane(state.pane),
+        },
+      ],
     },
   ];
   const menuMargin = 8;
-  const menuWidth = 200;
+  const menuWidth = 244;
+  const itemCount = groups.reduce(
+    (total, group) => total + group.items.length,
+    0,
+  );
+  const estimatedHeight = Math.min(
+    window.innerHeight - menuMargin * 2,
+    58 + groups.length * 25 + itemCount * 34,
+  );
   const style: React.CSSProperties = {
     position: "fixed",
     left: Math.max(
@@ -255,24 +294,51 @@ export function AgentContextMenu({
     ),
     top: Math.max(
       menuMargin,
-      Math.min(state.y, window.innerHeight - items.length * 34 - menuMargin),
+      Math.min(state.y, window.innerHeight - estimatedHeight - menuMargin),
     ),
     zIndex: 1000,
   };
+  const agentName = state.pane.agent ?? "Agent";
+  const agentLocation = state.pane.foreground_cwd ?? state.pane.cwd;
 
   return (
-    <div ref={ref} className="context-menu" style={style}>
-      {items.map((item) => (
-        <button
-          key={item.label}
-          className={`context-menu-item ${item.danger ? "is-danger" : ""}`}
-          onClick={() => {
-            onClose();
-            item.action();
-          }}
+    <div
+      ref={ref}
+      className="context-menu context-menu--grouped"
+      style={style}
+      role="menu"
+      aria-label={`Actions for ${agentName}`}
+    >
+      <div className="context-menu-header">
+        <span>Agent</span>
+        <strong title={agentName}>{agentName}</strong>
+        <small>
+          {state.pane.agent_status}
+          {agentLocation ? ` · ${basename(agentLocation)}` : ""}
+        </small>
+      </div>
+      {groups.map((group) => (
+        <div
+          key={group.label}
+          className={`context-menu-group ${group.danger ? "is-danger" : ""}`}
+          role="group"
+          aria-label={group.label}
         >
-          {item.label}
-        </button>
+          <div className="context-menu-group-title">{group.label}</div>
+          {group.items.map((item) => (
+            <button
+              key={item.label}
+              role="menuitem"
+              className={`context-menu-item ${item.danger ? "is-danger" : ""}`}
+              onClick={() => {
+                onClose();
+                item.action();
+              }}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
       ))}
     </div>
   );

--- a/web/src/components/WorkspaceAgentRows.tsx
+++ b/web/src/components/WorkspaceAgentRows.tsx
@@ -9,7 +9,7 @@ import type { Pane } from "../types";
 import { agentClass, basename, shortId } from "../utils";
 import { shouldShowAgentStatusLabel } from "./agentSession";
 import { AgentStatusIcon } from "./AgentStatusIcon";
-import { clampContextMenuPosition } from "./contextMenuPosition";
+import { observeClampedContextMenu } from "./contextMenuPosition";
 
 const LONG_PRESS_MS = 550;
 const LONG_PRESS_MOVE_PX = 10;
@@ -243,14 +243,10 @@ export function AgentContextMenu({
   useLayoutEffect(() => {
     const menu = ref.current;
     if (!state || !menu) return;
-    const rect = menu.getBoundingClientRect();
-    const position = clampContextMenuPosition(
-      { left: state.x, top: state.y },
-      { width: rect.width, height: rect.height },
-      { width: window.innerWidth, height: window.innerHeight },
-    );
-    menu.style.left = `${position.left}px`;
-    menu.style.top = `${position.top}px`;
+    return observeClampedContextMenu(menu, {
+      left: state.x,
+      top: state.y,
+    });
   }, [state]);
 
   if (!state) return null;

--- a/web/src/components/contextMenuPosition.test.ts
+++ b/web/src/components/contextMenuPosition.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { clampContextMenuPosition } from "./contextMenuPosition";
+
+describe("context menu positioning", () => {
+  test("keeps an anchor position when the rendered menu fits", () => {
+    expect(
+      clampContextMenuPosition(
+        { left: 120, top: 80 },
+        { width: 244, height: 320 },
+        { width: 1280, height: 800 },
+      ),
+    ).toEqual({ left: 120, top: 80 });
+  });
+
+  test("clamps the rendered dimensions against the viewport edges", () => {
+    expect(
+      clampContextMenuPosition(
+        { left: 1200, top: 740 },
+        { width: 244, height: 625 },
+        { width: 1280, height: 768 },
+      ),
+    ).toEqual({ left: 1028, top: 135 });
+  });
+
+  test("keeps the margin when the menu is as large as the viewport", () => {
+    expect(
+      clampContextMenuPosition(
+        { left: -20, top: -30 },
+        { width: 400, height: 600 },
+        { width: 390, height: 590 },
+      ),
+    ).toEqual({ left: 8, top: 8 });
+  });
+});

--- a/web/src/components/contextMenuPosition.ts
+++ b/web/src/components/contextMenuPosition.ts
@@ -17,3 +17,40 @@ export function clampContextMenuPosition(
     top: Math.max(margin, Math.min(anchor.top, maxTop)),
   };
 }
+
+/** Re-clamp after menu-content, window, or mobile visual-viewport changes. */
+export function observeClampedContextMenu(
+  menu: HTMLElement,
+  anchor: FloatingMenuPosition,
+): () => void {
+  const updatePosition = () => {
+    const rect = menu.getBoundingClientRect();
+    const visualViewport = window.visualViewport;
+    const position = clampContextMenuPosition(
+      anchor,
+      { width: rect.width, height: rect.height },
+      {
+        width: visualViewport?.width ?? window.innerWidth,
+        height: visualViewport?.height ?? window.innerHeight,
+      },
+    );
+    menu.style.left = `${position.left}px`;
+    menu.style.top = `${position.top}px`;
+  };
+
+  updatePosition();
+  const resizeObserver =
+    typeof ResizeObserver === "undefined"
+      ? null
+      : new ResizeObserver(updatePosition);
+  resizeObserver?.observe(menu);
+  window.addEventListener("resize", updatePosition);
+  window.visualViewport?.addEventListener("resize", updatePosition);
+  window.visualViewport?.addEventListener("scroll", updatePosition);
+  return () => {
+    resizeObserver?.disconnect();
+    window.removeEventListener("resize", updatePosition);
+    window.visualViewport?.removeEventListener("resize", updatePosition);
+    window.visualViewport?.removeEventListener("scroll", updatePosition);
+  };
+}

--- a/web/src/components/contextMenuPosition.ts
+++ b/web/src/components/contextMenuPosition.ts
@@ -1,0 +1,19 @@
+export interface FloatingMenuPosition {
+  left: number;
+  top: number;
+}
+
+/** Keep a rendered floating menu inside the viewport around its anchor point. */
+export function clampContextMenuPosition(
+  anchor: FloatingMenuPosition,
+  menu: { width: number; height: number },
+  viewport: { width: number; height: number },
+  margin = 8,
+): FloatingMenuPosition {
+  const maxLeft = Math.max(margin, viewport.width - menu.width - margin);
+  const maxTop = Math.max(margin, viewport.height - menu.height - margin);
+  return {
+    left: Math.max(margin, Math.min(anchor.left, maxLeft)),
+    top: Math.max(margin, Math.min(anchor.top, maxTop)),
+  };
+}

--- a/web/src/store.test.ts
+++ b/web/src/store.test.ts
@@ -3,6 +3,7 @@ import { bridge, type ConnectionClient } from "./api";
 import {
   __storeTesting,
   activateConnectionState,
+  automaticUpdateChecksEnabledFromStorage,
   bindTaskNotificationActivation,
   connectionEventIsActive,
   DEFAULT_NOTICE_AUTO_DISMISS_MS,
@@ -27,6 +28,32 @@ import {
   worktreeRemovalCompletionNotice,
 } from "./store";
 import type { Pane } from "./types";
+
+describe("automatic update check preference", () => {
+  test("defaults to enabled and honors an explicit disabled value", () => {
+    expect(automaticUpdateChecksEnabledFromStorage(undefined)).toBe(true);
+    expect(
+      automaticUpdateChecksEnabledFromStorage({
+        getItem: () => "false",
+      }),
+    ).toBe(false);
+    expect(
+      automaticUpdateChecksEnabledFromStorage({
+        getItem: () => "true",
+      }),
+    ).toBe(true);
+  });
+
+  test("falls back to enabled when browser storage is unavailable", () => {
+    expect(
+      automaticUpdateChecksEnabledFromStorage({
+        getItem: () => {
+          throw new Error("storage denied");
+        },
+      }),
+    ).toBe(true);
+  });
+});
 
 describe("task notification activation", () => {
   test("closes the system notification, focuses the window, and dispatches its pane target", () => {
@@ -197,6 +224,7 @@ function partitionState(): State {
     notice: null,
     taskNotificationsEnabled: false,
     taskNotificationPermission: "unsupported",
+    automaticUpdateChecksEnabled: true,
     updateInfo: null,
     updateInstalling: false,
     pendingRestartVersion: null,

--- a/web/src/store.test.ts
+++ b/web/src/store.test.ts
@@ -53,6 +53,101 @@ describe("automatic update check preference", () => {
       }),
     ).toBe(true);
   });
+
+  test("cancels polling and ignores an in-flight automatic result when disabled", async () => {
+    const previousState = store.get();
+    const previousFetch = globalThis.fetch;
+    const previousLocalStorage = globalThis.localStorage;
+    let resolveFetch!: (response: Response) => void;
+    globalThis.fetch = (() =>
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      })) as unknown as typeof fetch;
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: { setItem: () => undefined },
+    });
+    try {
+      __storeTesting.replaceState(partitionState());
+      const automaticCheck = __storeTesting.startUpdatePolling();
+      expect(__storeTesting.updatePollingActive()).toBe(true);
+
+      store.setAutomaticUpdateChecksEnabled(false);
+      expect(__storeTesting.updatePollingActive()).toBe(false);
+      expect(store.get().automaticUpdateChecksEnabled).toBe(false);
+
+      resolveFetch(
+        Response.json({
+          current_version: "0.4.5",
+          latest_version: "0.5.0",
+          update_available: true,
+          can_auto_update: true,
+          platform: "darwin-arm64",
+        }),
+      );
+      await automaticCheck;
+      expect(store.get().updateInfo).toBeNull();
+    } finally {
+      __storeTesting.replaceState(previousState);
+      globalThis.fetch = previousFetch;
+      if (previousLocalStorage === undefined) {
+        delete (globalThis as { localStorage?: Storage }).localStorage;
+      } else {
+        Object.defineProperty(globalThis, "localStorage", {
+          configurable: true,
+          value: previousLocalStorage,
+        });
+      }
+    }
+  });
+
+  test("restarts polling when enabled while manual checks bypass the preference", async () => {
+    const previousState = store.get();
+    const previousFetch = globalThis.fetch;
+    const previousLocalStorage = globalThis.localStorage;
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls += 1;
+      return Response.json({
+        current_version: "0.4.5",
+        latest_version: "0.4.5",
+        update_available: false,
+        can_auto_update: true,
+        platform: "darwin-arm64",
+      });
+    }) as unknown as typeof fetch;
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: { setItem: () => undefined },
+    });
+    try {
+      __storeTesting.replaceState({
+        ...partitionState(),
+        automaticUpdateChecksEnabled: false,
+      });
+
+      store.setAutomaticUpdateChecksEnabled(true);
+      expect(fetchCalls).toBe(1);
+      expect(__storeTesting.updatePollingActive()).toBe(true);
+      store.setAutomaticUpdateChecksEnabled(false);
+      expect(__storeTesting.updatePollingActive()).toBe(false);
+
+      await store.checkForUpdate();
+      expect(fetchCalls).toBe(2);
+      expect(store.get().notice?.message).toBe("herdr-gui is up to date");
+    } finally {
+      __storeTesting.replaceState(previousState);
+      globalThis.fetch = previousFetch;
+      if (previousLocalStorage === undefined) {
+        delete (globalThis as { localStorage?: Storage }).localStorage;
+      } else {
+        Object.defineProperty(globalThis, "localStorage", {
+          configurable: true,
+          value: previousLocalStorage,
+        });
+      }
+    }
+  });
 });
 
 describe("task notification activation", () => {

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -1202,15 +1202,18 @@ async function checkForUpdate(showErrors = false) {
   }
 }
 
-function startUpdatePolling() {
-  if (updateTimer || !state.automaticUpdateChecksEnabled) return;
-  void checkForUpdate(false);
+function startUpdatePolling(): Promise<void> {
+  if (updateTimer || !state.automaticUpdateChecksEnabled) {
+    return Promise.resolve();
+  }
+  const initialCheck = checkForUpdate(false);
   updateTimer = setInterval(
     () => {
       void checkForUpdate(false);
     },
     30 * 60 * 1000,
   );
+  return initialCheck;
 }
 
 function stopPolling() {
@@ -2639,6 +2642,8 @@ export const store = {
 
 /** Test-only singleton seam for deterministic deferred production-store tests. */
 export const __storeTesting = {
+  startUpdatePolling,
+  updatePollingActive: () => updateTimer !== null,
   replaceState(snapshot: State) {
     stopPolling();
     refreshingConnectionKeys.clear();

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -46,6 +46,7 @@ export interface State extends ServerSessionState {
   notice: Notice | null;
   taskNotificationsEnabled: boolean;
   taskNotificationPermission: NotificationPermission | "unsupported";
+  automaticUpdateChecksEnabled: boolean;
   updateInfo: UpdateInfo | null;
   updateInstalling: boolean;
   pendingRestartVersion: string | null;
@@ -111,6 +112,7 @@ type WorktreeRemovalCleanup = {
 };
 
 const TASK_NOTIFICATIONS_KEY = "taskNotificationsEnabled";
+const AUTOMATIC_UPDATE_CHECKS_KEY = "automaticUpdateChecksEnabled";
 const PENDING_UPDATE_RELOAD_KEY = "pendingUpdateReloadVersion";
 export const DEFAULT_NOTICE_AUTO_DISMISS_MS = 15 * 1000;
 const TASK_COMPLETED_TOAST_DISMISS_MS = DEFAULT_NOTICE_AUTO_DISMISS_MS;
@@ -229,6 +231,22 @@ function storedTaskNotificationsEnabled() {
   );
 }
 
+export function automaticUpdateChecksEnabledFromStorage(
+  storage: Pick<Storage, "getItem"> | undefined,
+): boolean {
+  try {
+    return storage?.getItem(AUTOMATIC_UPDATE_CHECKS_KEY) !== "false";
+  } catch {
+    return true;
+  }
+}
+
+function storedAutomaticUpdateChecksEnabled(): boolean {
+  return automaticUpdateChecksEnabledFromStorage(
+    typeof localStorage === "undefined" ? undefined : localStorage,
+  );
+}
+
 function storedPendingRestartVersion(): string | null {
   if (typeof sessionStorage === "undefined") return null;
   try {
@@ -281,6 +299,7 @@ const initial: State = {
   notice: null,
   taskNotificationsEnabled: storedTaskNotificationsEnabled(),
   taskNotificationPermission: notificationPermission(),
+  automaticUpdateChecksEnabled: storedAutomaticUpdateChecksEnabled(),
   updateInfo: null,
   updateInstalling: false,
   pendingRestartVersion: storedPendingRestartVersion(),
@@ -1117,6 +1136,7 @@ function startMetadataPolling() {
 }
 
 async function checkForUpdate(showErrors = false) {
+  if (!showErrors && !state.automaticUpdateChecksEnabled) return;
   if (state.connectionPaused) {
     if (showErrors) {
       set({
@@ -1148,6 +1168,7 @@ async function checkForUpdate(showErrors = false) {
       return;
     }
     const info = (await r.json()) as UpdateInfo;
+    if (!showErrors && !state.automaticUpdateChecksEnabled) return;
     if (
       info.update_available &&
       info.latest_version &&
@@ -1182,7 +1203,7 @@ async function checkForUpdate(showErrors = false) {
 }
 
 function startUpdatePolling() {
-  if (updateTimer) return;
+  if (updateTimer || !state.automaticUpdateChecksEnabled) return;
   void checkForUpdate(false);
   updateTimer = setInterval(
     () => {
@@ -2401,6 +2422,23 @@ export const store = {
 
   checkForUpdate() {
     return checkForUpdate(true);
+  },
+
+  setAutomaticUpdateChecksEnabled(enabled: boolean) {
+    try {
+      localStorage.setItem(AUTOMATIC_UPDATE_CHECKS_KEY, String(enabled));
+    } catch {
+      // The in-memory preference still applies when storage is unavailable.
+    }
+    if (!enabled && updateTimer) {
+      clearInterval(updateTimer);
+      updateTimer = null;
+    }
+    set({
+      automaticUpdateChecksEnabled: enabled,
+      updateInfo: enabled ? state.updateInfo : null,
+    });
+    if (enabled && !state.connectionPaused) startUpdatePolling();
   },
 
   updateOrCheck() {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2655,7 +2655,8 @@ textarea:focus {
 }
 .context-menu--grouped {
   width: min(244px, calc(100vw - 16px));
-  max-height: calc(100vh - 16px);
+  min-width: 0;
+  max-height: calc(var(--app-viewport-height, 100vh) - 16px);
   overflow-y: auto;
   padding: 6px;
   gap: 0;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2653,6 +2653,60 @@ textarea:focus {
   flex-direction: column;
   gap: 2px;
 }
+.context-menu--grouped {
+  width: min(244px, calc(100vw - 16px));
+  max-height: calc(100vh - 16px);
+  overflow-y: auto;
+  padding: 6px;
+  gap: 0;
+}
+.context-menu-header {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  padding: 7px 9px 9px;
+  border-bottom: 1px solid var(--border-soft);
+}
+.context-menu-header > span,
+.context-menu-group-title {
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.55px;
+  text-transform: uppercase;
+}
+.context-menu-header > strong,
+.context-menu-header > small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.context-menu-header > strong {
+  color: var(--text-strong);
+  font-size: 13px;
+}
+.context-menu-header > small {
+  color: var(--muted);
+  font-size: 11px;
+}
+.context-menu-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border-soft);
+}
+.context-menu-group:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+.context-menu-group-title {
+  padding: 2px 9px 3px;
+}
+.context-menu-group.is-danger .context-menu-group-title {
+  color: var(--danger-text);
+  opacity: 0.72;
+}
 .context-menu-item {
   display: block;
   width: 100%;


### PR DESCRIPTION
## Summary

- add a browser-persisted preference to disable automatic update checks while keeping manual checks available
- split the application menu into clearer appearance, behavior, help, and runtime sections
- group workspace and agent context-menu actions by purpose, identify the current target, and isolate destructive actions
- keep grouped context menus usable in narrow or short viewports

## Verification

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test` (660 passed, 1 skipped)
- `cd web && bun run build`