### PR TITLE
Fix dialog Enter handling, compact diff wrap, and badge truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@
 
 ### Fixed
 
+- Keep worktree dirty/ahead/behind count badges fully visible in the
+  workspace tree; only the branch badge shrinks with an ellipsis, and the row
+  tooltip still shows the full status.
+- Restore Enter-to-confirm in confirmation dialogs such as Remove Worktree
+  and Close Workspace, and let Enter dismiss message dialogs; Enter confirms
+  unless a dialog button has focus, so a focused Cancel button still
+  activates natively.
+- Fix the Wrap/No wrap toggle doing nothing in narrow Inspector Changes
+  panes on desktop; compact diff styles now follow the pane layout instead of
+  a mobile-only viewport media query.
 - Upgrade release builds to Bun 1.4.0; the x64 binary built by Bun 1.3.14 can
   crash during `service install` under Windows ARM64 emulation.
 

--- a/web/src/components/DiffContentView.tsx
+++ b/web/src/components/DiffContentView.tsx
@@ -652,10 +652,10 @@ export function DiffContentView({
         <div
           ref={diffRef}
           className={`diff2html-wrapper syntax-highlighted ${
-            mobile && wrapEnabled ? "is-wrapped" : ""
-          } ${!mobile && !wrapEnabled ? "is-nowrap" : ""} ${
-            !mobile ? `is-${effectiveViewMode}` : ""
-          }`}
+            mobile ? "is-compact" : ""
+          } ${mobile && wrapEnabled ? "is-wrapped" : ""} ${
+            !mobile && !wrapEnabled ? "is-nowrap" : ""
+          } ${!mobile ? `is-${effectiveViewMode}` : ""}`}
         >
           {renderedSections.map((section) => {
             const sectionLoading =

--- a/web/src/components/ModalDialogs.tsx
+++ b/web/src/components/ModalDialogs.tsx
@@ -115,10 +115,18 @@ export function ConfirmDialog({
     const onKey = (e: KeyboardEvent) => {
       const target = e.target instanceof Node ? e.target : null;
       const isInsideDialog = !!target && !!dialogRef.current?.contains(target);
-      const action = dialogKeyAction(e.key, isInsideDialog);
+      const focusOnButton = target instanceof HTMLButtonElement;
+      const action = dialogKeyAction(e.key, isInsideDialog, focusOnButton);
       if (action === "close") {
         e.preventDefault();
         e.stopPropagation();
+        onCloseRef.current();
+        return;
+      }
+      if (action === "confirm") {
+        e.preventDefault();
+        e.stopPropagation();
+        onConfirmRef.current();
         onCloseRef.current();
         return;
       }
@@ -186,6 +194,9 @@ export function MessageDialog({
   onClose: () => void;
 }) {
   const dialogRef = useRef<HTMLDivElement>(null);
+  const onCloseRef = useRef(onClose);
+
+  onCloseRef.current = onClose;
 
   useEffect(() => {
     if (!open) return;
@@ -193,13 +204,16 @@ export function MessageDialog({
     const onKey = (e: KeyboardEvent) => {
       const target = e.target instanceof Node ? e.target : null;
       const isInsideDialog = !!target && !!dialogRef.current?.contains(target);
-      if (e.key === "Escape") {
+      const focusOnButton = target instanceof HTMLButtonElement;
+      const action = dialogKeyAction(e.key, isInsideDialog, focusOnButton);
+      // The OK button is the only action; both Escape and Enter dismiss.
+      if (action === "close" || action === "confirm") {
         e.preventDefault();
         e.stopPropagation();
-        onClose();
+        onCloseRef.current();
         return;
       }
-      if (!isInsideDialog) {
+      if (action === "contain") {
         e.preventDefault();
         e.stopPropagation();
       }
@@ -209,7 +223,7 @@ export function MessageDialog({
       cancelFocus();
       window.removeEventListener("keydown", onKey, { capture: true });
     };
-  }, [open, onClose]);
+  }, [open]);
 
   if (!open) return null;
 

--- a/web/src/components/dialogKeyboard.test.ts
+++ b/web/src/components/dialogKeyboard.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { dialogKeyAction } from "./dialogKeyboard";
 
 describe("dialog keyboard containment", () => {
+  test("confirms on Enter when focus is inside the dialog but not on a button", () => {
+    expect(dialogKeyAction("Enter", true)).toBe("confirm");
+    expect(dialogKeyAction("Enter", true, false)).toBe("confirm");
+  });
+
   test("leaves Enter to the focused button inside a confirmation dialog", () => {
-    expect(dialogKeyAction("Enter", true)).toBe("native");
+    expect(dialogKeyAction("Enter", true, true)).toBe("native");
   });
 
   test("closes on Escape and contains keys arriving from outside", () => {

--- a/web/src/components/dialogKeyboard.ts
+++ b/web/src/components/dialogKeyboard.ts
@@ -1,9 +1,14 @@
-export type DialogKeyAction = "close" | "contain" | "native";
+export type DialogKeyAction = "close" | "confirm" | "contain" | "native";
 
 export function dialogKeyAction(
   key: string,
   focusInsideDialog: boolean,
+  focusOnButton = false,
 ): DialogKeyAction {
   if (key === "Escape") return "close";
-  return focusInsideDialog ? "native" : "contain";
+  if (!focusInsideDialog) return "contain";
+  // Confirm on Enter unless a button is focused; focused buttons keep their
+  // native activation so Enter on Cancel never confirms.
+  if (key === "Enter" && !focusOnButton) return "confirm";
+  return "native";
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2277,11 +2277,12 @@ textarea:focus {
 }
 .git-status {
   min-width: 0;
-  max-width: min(45%, 142px);
+  max-width: min(55%, 168px);
   display: inline-flex;
   align-items: center;
   gap: 3px;
   flex: 0 1 auto;
+  overflow: hidden;
 }
 .git-badge {
   max-width: 84px;
@@ -2299,6 +2300,13 @@ textarea:focus {
 .git-branch {
   max-width: 92px;
   color: var(--text);
+}
+/* Count badges are inherently short; never shrink them. Only the branch
+   badge ellipsizes, and its full text stays available via the row tooltip. */
+.git-dirty,
+.git-ahead,
+.git-behind {
+  flex: 0 0 auto;
 }
 .git-dirty {
   color: var(--yellow);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2301,12 +2301,14 @@ textarea:focus {
   max-width: 92px;
   color: var(--text);
 }
-/* Count badges are inherently short; never shrink them. Only the branch
-   badge ellipsizes, and its full text stays available via the row tooltip. */
+/* Count badges are sized purely by their content: never shrink or cap them,
+   so counts stay fully visible. Only the branch badge ellipsizes, and its
+   full text stays available via the row tooltip. */
 .git-dirty,
 .git-ahead,
 .git-behind {
   flex: 0 0 auto;
+  max-width: none;
 }
 .git-dirty {
   color: var(--yellow);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5498,6 +5498,75 @@ textarea:focus {
   overflow-wrap: normal;
   white-space: pre;
 }
+/* Compact layout (narrow inspector panes and small screens) defaults to
+   horizontally scrolled long lines; the wrap toggle opts into wrapping.
+   These rules follow the component's is-compact class rather than a viewport
+   media query so they also apply inside narrow desktop inspector panes. */
+.diff2html-wrapper.is-compact {
+  box-sizing: border-box;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+.diff2html-wrapper.is-compact .d2h-wrapper,
+.diff2html-wrapper.is-compact .d2h-files-diff,
+.diff2html-wrapper.is-compact .d2h-file-diff,
+.diff2html-wrapper.is-compact .d2h-file-wrapper {
+  width: max-content;
+  min-width: 100%;
+}
+.diff2html-wrapper.is-compact .d2h-file-diff {
+  overflow-x: visible;
+}
+.diff2html-wrapper.is-compact .d2h-diff-table {
+  table-layout: auto;
+  width: max-content;
+  min-width: 100%;
+}
+.diff2html-wrapper.is-compact .d2h-code-line,
+.diff2html-wrapper.is-compact .d2h-code-side-line {
+  min-width: max-content;
+  width: max-content;
+  white-space: nowrap;
+}
+/* Unified rows carry two line-number cells; 7.5em each would consume half
+   of a narrow pane before any code is visible. */
+.diff2html-wrapper.is-compact .d2h-code-linenumber {
+  width: 3.4em;
+  min-width: 3.4em;
+  padding: 0 0.25em;
+}
+.diff2html-wrapper.is-compact .d2h-code-line-ctn {
+  flex: 0 0 auto;
+  min-width: max-content;
+  overflow-wrap: normal;
+  white-space: pre;
+}
+.diff2html-wrapper.is-wrapped .d2h-wrapper,
+.diff2html-wrapper.is-wrapped .d2h-files-diff,
+.diff2html-wrapper.is-wrapped .d2h-file-diff,
+.diff2html-wrapper.is-wrapped .d2h-file-wrapper {
+  width: 100%;
+  min-width: 0;
+}
+.diff2html-wrapper.is-wrapped .d2h-file-diff {
+  overflow-x: hidden;
+}
+.diff2html-wrapper.is-wrapped .d2h-diff-table {
+  table-layout: fixed;
+  width: 100%;
+  min-width: 0;
+}
+.diff2html-wrapper.is-wrapped .d2h-code-line,
+.diff2html-wrapper.is-wrapped .d2h-code-side-line {
+  min-width: 0;
+  width: 100%;
+  white-space: normal;
+}
+.diff2html-wrapper.is-wrapped .d2h-code-line-ctn {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
 .syntax-highlighted .hljs {
   background: transparent;
   color: inherit;
@@ -7802,71 +7871,6 @@ textarea:focus {
   }
   .diff-view-toggle {
     display: none;
-  }
-  .diff2html-wrapper {
-    box-sizing: border-box;
-    padding-bottom: env(safe-area-inset-bottom, 0px);
-  }
-  .diff2html-wrapper .d2h-wrapper,
-  .diff2html-wrapper .d2h-files-diff,
-  .diff2html-wrapper .d2h-file-diff,
-  .diff2html-wrapper .d2h-file-wrapper {
-    width: max-content;
-    min-width: 100%;
-  }
-  .diff2html-wrapper .d2h-file-diff {
-    overflow-x: visible;
-  }
-  .diff2html-wrapper .d2h-diff-table {
-    table-layout: auto;
-    width: max-content;
-    min-width: 100%;
-  }
-  .diff2html-wrapper .d2h-code-line,
-  .diff2html-wrapper .d2h-code-side-line {
-    min-width: max-content;
-    width: max-content;
-    white-space: nowrap;
-  }
-  /* Unified rows carry two line-number cells; 7.5em each would consume half
-     of a phone screen before any code is visible. */
-  .diff2html-wrapper .d2h-code-linenumber {
-    width: 3.4em;
-    min-width: 3.4em;
-    padding: 0 0.25em;
-  }
-  .diff2html-wrapper .d2h-code-line-ctn {
-    flex: 0 0 auto;
-    min-width: max-content;
-    overflow-wrap: normal;
-    white-space: pre;
-  }
-  .diff2html-wrapper.is-wrapped .d2h-wrapper,
-  .diff2html-wrapper.is-wrapped .d2h-files-diff,
-  .diff2html-wrapper.is-wrapped .d2h-file-diff,
-  .diff2html-wrapper.is-wrapped .d2h-file-wrapper {
-    width: 100%;
-    min-width: 0;
-  }
-  .diff2html-wrapper.is-wrapped .d2h-file-diff {
-    overflow-x: hidden;
-  }
-  .diff2html-wrapper.is-wrapped .d2h-diff-table {
-    table-layout: fixed;
-    width: 100%;
-    min-width: 0;
-  }
-  .diff2html-wrapper.is-wrapped .d2h-code-line,
-  .diff2html-wrapper.is-wrapped .d2h-code-side-line {
-    min-width: 0;
-    width: 100%;
-    white-space: normal;
-  }
-  .diff2html-wrapper.is-wrapped .d2h-code-line-ctn {
-    flex: 1 1 auto;
-    min-width: 0;
-    overflow-wrap: anywhere;
-    white-space: pre-wrap;
   }
   .main {
     padding: 0;


### PR DESCRIPTION
## Summary

- Restore Enter key handling in confirmation dialogs (Remove Worktree, Close Workspace, etc.): Enter confirms when focus is inside the dialog but not on a button, while a focused Cancel/close button still activates natively. Message dialogs now also dismiss on Enter.
- Fix the Wrap/No wrap toggle doing nothing in narrow Inspector Changes panes on desktop: compact diff styles now follow the pane layout (an `is-compact` class driven by pane width) instead of a mobile-only viewport media query.
- Keep worktree dirty/ahead/behind count badges fully visible in the workspace tree; only the branch badge shrinks with an ellipsis, and the row tooltip still shows the full status.

## Root causes

- The dialog keyboard refactor in #30 dropped the explicit Enter branch in `ConfirmDialog`; since initial focus lands on the dialog container (not a button), Enter fell through to a native no-op.
- The compact diff styles were scoped inside `@media (max-width: 768px)`, but compact mode is driven by Inspector pane width (<560px), so on desktop viewports the `is-wrapped` class had no styling effect.
- All `.git-status` badges were shrinkable flex items, so when branch + change + ahead/behind badges overflowed the container, every badge ellipsized — hiding the numbers.

## Verification

- `bun run format:check`, `bun run lint`, `bun run test` (660 tests), `cd web && bun run typecheck && bun run build`, `cd server && bun run typecheck`
- Added `dialogKeyboard` tests for the Enter action mapping.
- Render-verified with headless Chrome against the real stylesheet and diff2html markup: count badges stay fully visible at 260px and 200px row widths; compact diff panes toggle wrap/nowrap correctly (with per-file horizontal scroll); desktop non-compact diff behavior is unchanged.