### PR TITLE
Improve connection controls and responsive UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,21 @@
 - Group the application, workspace, and agent menus into clearer sections;
   workspace and agent context menus now identify their target and isolate
   destructive actions.
+- Consolidate browser pause and reconnect controls in the Connections menu,
+  surface paused/disconnected status on its trigger, and prevent compact and
+  mobile topbar overlap.
+- Place mobile notifications below the topbar instead of above the bottom
+  terminal controls.
 
 ### Fixed
 
+- Reattach terminal frames after resuming browser sync instead of requiring a
+  page reload to restore terminal content.
+- Use the compact drill-in Inspector layout below 640px so narrow panes do not
+  squeeze navigation and detail side by side; mobile view also hides dock and
+  expand actions while narrow desktop docks retain them.
+- Animate and disable the Diff Viewer refresh control while changes are being
+  reloaded so refresh progress is visible.
 - Keep worktree dirty/ahead/behind count badges fully visible in the
   workspace tree; only the branch badge shrinks with an ellipsis, and the row
   tooltip still shows the full status.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,7 +10,6 @@ import {
   LoaderCircle,
   MoreHorizontal,
   PanelTop,
-  Plug,
   SquareTerminal,
   X,
 } from "lucide-react";
@@ -851,7 +850,6 @@ function TerminalPaneLayout({
 export default function App() {
   const s = useStoreSelector(
     (state) => ({
-      connectionPaused: state.connectionPaused,
       lastRefresh: state.lastRefresh,
       layout: state.layout,
       notice: state.notice,
@@ -2212,20 +2210,6 @@ export default function App() {
           <ConnectionSwitcher />
         </div>
         <div className="topbar-actions">
-          {s.connectionPaused || s.status === "disconnected" ? (
-            <button
-              type="button"
-              className="topbar-button icon-button connection-toggle-button is-paused"
-              onClick={() => store.resumeConnection()}
-              title={
-                s.connectionPaused
-                  ? "Resume this client"
-                  : "Reconnect this client"
-              }
-            >
-              <Plug size={15} />
-            </button>
-          ) : null}
           <div className="topbar-command-group">
             <CommandCombobox
               key={`${resourceUiKey}:commands`}

--- a/web/src/components/ConfigMenu.tsx
+++ b/web/src/components/ConfigMenu.tsx
@@ -9,14 +9,11 @@ import {
   Keyboard,
   Moon,
   Palette,
-  Pause,
-  Play,
   RefreshCw,
   ScrollText,
   Server,
   Sun,
   SunMoon,
-  Users,
   Wifi,
 } from "lucide-react";
 import packageJson from "../../package.json";
@@ -97,8 +94,6 @@ export function ConfigMenu({
     !s.connectionPaused && s.status === "connected"
       ? s.bridgeStatus?.clients
       : null;
-  const otherClientCount =
-    typeof clientCount === "number" ? Math.max(0, clientCount - 1) : 0;
   const taskNotificationValue = taskNotificationStatus(
     s.taskNotificationsEnabled,
     s.taskNotificationPermission,
@@ -494,39 +489,6 @@ export function ConfigMenu({
                   <ConfigRow label="Socket" value={health?.socket ?? "-"} />
                 </div>
               ) : null}
-              <div className="config-inline-actions">
-                <button
-                  type="button"
-                  className={s.connectionPaused ? "is-primary" : ""}
-                  onClick={() => {
-                    setOpen(false);
-                    if (s.connectionPaused) {
-                      store.resumeConnection();
-                    } else {
-                      store.pauseConnection();
-                    }
-                  }}
-                >
-                  {s.connectionPaused ? (
-                    <Play size={14} />
-                  ) : (
-                    <Pause size={14} />
-                  )}
-                  {s.connectionPaused ? "Resume client" : "Pause client"}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setOpen(false);
-                    void store.pauseOtherClients();
-                  }}
-                  disabled={s.connectionPaused || otherClientCount === 0}
-                >
-                  <Users size={14} />
-                  Pause others
-                  {otherClientCount > 0 ? ` (${otherClientCount})` : ""}
-                </button>
-              </div>
             </div>
           </div>
         ) : null}

--- a/web/src/components/ConnectionSwitcher.tsx
+++ b/web/src/components/ConnectionSwitcher.tsx
@@ -2,10 +2,13 @@ import {
   Check,
   ChevronDown,
   CircleAlert,
+  Pause,
   Pencil,
+  Plug,
   Plus,
   Server,
   Star,
+  Users,
   X,
 } from "lucide-react";
 import {
@@ -29,6 +32,7 @@ import {
   suggestConnectionId,
 } from "../connectionProfiles";
 import { shallowEqual, store, useStoreSelector } from "../store";
+import { browserTransportPresentation } from "./browserTransport";
 import { CloseButton } from "./CloseButton";
 import { focusDialogElement } from "./dialogFocus";
 import { ConfirmDialog } from "./ModalDialogs";
@@ -149,29 +153,79 @@ function trapDialogTab(event: KeyboardEvent, dialog: HTMLElement | null) {
   }
 }
 
-function BrowserTransportStatus() {
+function BrowserTransportStatus({ onAction }: { onAction?: () => void }) {
   const state = useStoreSelector(
     (snapshot) => ({
+      bridgeStatus: snapshot.bridgeStatus,
       connectionPaused: snapshot.connectionPaused,
       status: snapshot.status,
     }),
     shallowEqual,
   );
-  const label = state.connectionPaused
-    ? "Browser sync paused"
-    : state.status === "connected"
-      ? "Browser connected to bridge"
-      : state.status === "connecting"
-        ? "Browser connecting to bridge"
-        : "Browser disconnected from bridge";
+  const { label, clientCount, pauseOthersLabel, needsResume, toggleLabel } =
+    browserTransportPresentation(
+      state.connectionPaused,
+      state.status,
+      state.bridgeStatus?.clients,
+    );
+  const statusLabel = `${label}${
+    typeof clientCount === "number"
+      ? ` · ${clientCount} browser${clientCount === 1 ? "" : "s"}`
+      : ""
+  }`;
   return (
-    <div className="connection-browser-status">
-      <span
-        className={`connection-browser-dot browser-${
-          state.connectionPaused ? "paused" : state.status
-        }`}
-      />
-      {label}
+    <div
+      className="connection-browser-section"
+      role={onAction ? "group" : undefined}
+      aria-label={onAction ? statusLabel : undefined}
+    >
+      <div
+        className="connection-browser-status"
+        role={onAction ? undefined : "status"}
+        aria-hidden={onAction ? true : undefined}
+      >
+        <span
+          className={`connection-browser-dot browser-${
+            state.connectionPaused ? "paused" : state.status
+          }`}
+        />
+        <span>{statusLabel}</span>
+      </div>
+      {onAction ? (
+        <div className="connection-browser-actions">
+          <button
+            type="button"
+            role="menuitem"
+            tabIndex={-1}
+            className={needsResume ? "is-warning" : ""}
+            onClick={() => {
+              onAction();
+              if (needsResume) {
+                store.resumeConnection();
+              } else {
+                store.pauseConnection();
+              }
+            }}
+          >
+            {needsResume ? <Plug size={14} /> : <Pause size={14} />}
+            {toggleLabel}
+          </button>
+          {pauseOthersLabel ? (
+            <button
+              type="button"
+              role="menuitem"
+              tabIndex={-1}
+              onClick={() => {
+                onAction();
+                void store.pauseOtherClients();
+              }}
+            >
+              <Users size={14} />
+              {pauseOthersLabel}
+            </button>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -975,8 +1029,10 @@ export function ConnectionSwitcher() {
   const state = useStoreSelector(
     (snapshot) => ({
       activeConnectionId: snapshot.activeConnectionId,
+      connectionPaused: snapshot.connectionPaused,
       connections: snapshot.connections,
       defaultConnectionId: snapshot.defaultConnectionId,
+      status: snapshot.status,
     }),
     shallowEqual,
   );
@@ -1008,10 +1064,16 @@ export function ConnectionSwitcher() {
       generation: 0,
     } satisfies ConnectionSummary);
 
+  const browserWarning = state.connectionPaused
+    ? "Browser sync paused"
+    : state.status === "disconnected"
+      ? "Browser disconnected from bridge"
+      : null;
+
   const menuItems = () =>
     Array.from(
       menuRef.current?.querySelectorAll<HTMLElement>(
-        '[role="menuitemradio"], [role="menuitem"]',
+        '[role="menuitemradio"]:not(:disabled), [role="menuitem"]:not(:disabled)',
       ) ?? [],
     );
   const focusInitialMenuItem = () => {
@@ -1074,7 +1136,9 @@ export function ConnectionSwitcher() {
             <button
               ref={triggerRef}
               type="button"
-              className={`connection-switcher-trigger ${open ? "is-active" : ""}`}
+              className={`connection-switcher-trigger ${open ? "is-active" : ""} ${browserWarning ? "has-browser-warning" : ""}`}
+              aria-label={`${active.label}, ${connectionTypeLabel(active)}, ${connectionLifecycleLabel(active.state)}${browserWarning ? `, ${browserWarning}` : ""}`}
+              title={browserWarning ?? undefined}
               aria-haspopup="menu"
               aria-expanded={open}
               onKeyDown={(event) => {
@@ -1091,6 +1155,13 @@ export function ConnectionSwitcher() {
                 className={`connection-runtime-dot ${runtimeStateClass(active)}`}
               />
               <span className="connection-switcher-label">{active.label}</span>
+              {browserWarning ? (
+                <CircleAlert
+                  className="connection-switcher-warning"
+                  size={13}
+                  aria-hidden="true"
+                />
+              ) : null}
               <span className="connection-switcher-meta">
                 {connectionTypeLabel(active)} /{" "}
                 {connectionLifecycleLabel(active.state)}
@@ -1104,6 +1175,7 @@ export function ConnectionSwitcher() {
             role="menu"
             aria-label="Connections"
             align="start"
+            collisionPadding={8}
             onKeyDown={onMenuKeyDown}
             onOpenAutoFocus={(event) => {
               event.preventDefault();
@@ -1135,7 +1207,7 @@ export function ConnectionSwitcher() {
               });
             }}
           >
-            <BrowserTransportStatus />
+            <BrowserTransportStatus onAction={() => setOpen(false)} />
             <div className="connection-switcher-list">
               {state.connections.map((connection) => (
                 <button

--- a/web/src/components/DiffViewerPanel.tsx
+++ b/web/src/components/DiffViewerPanel.tsx
@@ -1148,11 +1148,16 @@ export function DiffViewerPanel({
         <button
           type="button"
           className="diff-refresh"
-          title="Refresh"
-          aria-label="Refresh changes"
+          title={summaryLoading ? "Refreshing..." : "Refresh"}
+          aria-label={summaryLoading ? "Refreshing changes" : "Refresh changes"}
+          aria-busy={summaryLoading}
+          disabled={summaryLoading}
           onClick={() => void loadSummary()}
         >
-          <RefreshCw size={15} />
+          <RefreshCw
+            className={summaryLoading ? "is-spinning" : ""}
+            size={15}
+          />
         </button>
       </div>
 

--- a/web/src/components/WorkspaceInspectorHost.tsx
+++ b/web/src/components/WorkspaceInspectorHost.tsx
@@ -13,6 +13,7 @@ import {
 import {
   useEffect,
   useId,
+  useLayoutEffect,
   useRef,
   useState,
   type CSSProperties,
@@ -42,6 +43,7 @@ import {
   type ActiveFilePreviewSelection,
   FilePreviewContent,
 } from "./FilePreviewContent";
+import { workspaceInspectorLayout } from "./workspaceInspectorLayout";
 
 function changedCount(workspace?: Workspace) {
   const status = workspace?.worktree?.git_status;
@@ -224,11 +226,10 @@ export function WorkspaceInspectorHost({
       changes: preferences.changesNavigationRatio,
     };
   });
-  const compact = hostWidth > 0 && hostWidth < 560;
+  const { compact, splitEnabled } = workspaceInspectorLayout(hostWidth);
   // The navigation/detail split is draggable whenever both panes fit side by
   // side, not only in the expanded layout, so docked inspectors can resize
   // the Files/Changes list too.
-  const splitEnabled = hostWidth >= 600;
   const navigationIds = {
     files: `${splitId}-files-navigation`,
     changes: `${splitId}-changes-navigation`,
@@ -297,7 +298,7 @@ export function WorkspaceInspectorHost({
     });
   }, [contentResourceKey, state.scope]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const host = hostRef.current;
     if (!host) return;
     const update = () => setHostWidth(host.clientWidth);
@@ -312,7 +313,7 @@ export function WorkspaceInspectorHost({
       ref={hostRef}
       className={`workspace-inspector workspace-inspector-${state.dock} ${
         state.expanded ? "is-expanded" : ""
-      } ${hasDetail ? "has-detail" : ""}`}
+      } ${compact ? "is-compact" : ""} ${hasDetail ? "has-detail" : ""}`}
       aria-label="Workspace Inspector"
       data-view={state.view}
     >
@@ -390,6 +391,7 @@ export function WorkspaceInspectorHost({
         <div className="workspace-inspector-actions">
           <button
             type="button"
+            className="workspace-inspector-dock-action"
             title={state.dock === "right" ? "Dock at bottom" : "Dock at right"}
             aria-label={
               state.dock === "right"
@@ -408,6 +410,7 @@ export function WorkspaceInspectorHost({
           </button>
           <button
             type="button"
+            className="workspace-inspector-expand-action"
             title={state.expanded ? "Restore dock" : "Expand Inspector"}
             aria-label={
               state.expanded ? "Restore Inspector dock" : "Expand Inspector"

--- a/web/src/components/browserTransport.test.ts
+++ b/web/src/components/browserTransport.test.ts
@@ -6,7 +6,7 @@ describe("browser transport presentation", () => {
     expect(browserTransportPresentation(false, "connected", 3)).toEqual({
       label: "Browser connected to bridge",
       clientCount: 3,
-      pauseOthersLabel: "Pause others (2)",
+      pauseOthersLabel: "Pause other browsers (2)",
       needsResume: false,
       toggleLabel: "Pause browser sync",
     });

--- a/web/src/components/browserTransport.test.ts
+++ b/web/src/components/browserTransport.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { browserTransportPresentation } from "./browserTransport";
+
+describe("browser transport presentation", () => {
+  test("offers pause controls and counts only other connected browsers", () => {
+    expect(browserTransportPresentation(false, "connected", 3)).toEqual({
+      label: "Browser connected to bridge",
+      clientCount: 3,
+      pauseOthersLabel: "Pause others (2)",
+      needsResume: false,
+      toggleLabel: "Pause browser sync",
+    });
+  });
+
+  test("labels a single other browser and hides the action when alone", () => {
+    expect(
+      browserTransportPresentation(false, "connected", 2).pauseOthersLabel,
+    ).toBe("Pause other browser");
+    expect(
+      browserTransportPresentation(false, "connected", 1).pauseOthersLabel,
+    ).toBeNull();
+  });
+
+  test("offers resume while paused without exposing a stale client count", () => {
+    expect(browserTransportPresentation(true, "connected", 3)).toEqual({
+      label: "Browser sync paused",
+      clientCount: null,
+      pauseOthersLabel: null,
+      needsResume: true,
+      toggleLabel: "Resume browser sync",
+    });
+  });
+
+  test("offers reconnect after browser transport loss", () => {
+    expect(browserTransportPresentation(false, "disconnected", 3)).toEqual({
+      label: "Browser disconnected from bridge",
+      clientCount: null,
+      pauseOthersLabel: null,
+      needsResume: true,
+      toggleLabel: "Reconnect browser",
+    });
+  });
+
+  test("keeps connecting transport pausable", () => {
+    expect(browserTransportPresentation(false, "connecting", null)).toEqual({
+      label: "Browser connecting to bridge",
+      clientCount: null,
+      pauseOthersLabel: null,
+      needsResume: false,
+      toggleLabel: "Pause browser sync",
+    });
+  });
+});

--- a/web/src/components/browserTransport.ts
+++ b/web/src/components/browserTransport.ts
@@ -1,0 +1,51 @@
+import type { ConnectionStatus } from "../api";
+
+export interface BrowserTransportPresentation {
+  label: string;
+  clientCount: number | null;
+  pauseOthersLabel: string | null;
+  needsResume: boolean;
+  toggleLabel: string;
+}
+
+export function browserTransportPresentation(
+  connectionPaused: boolean,
+  status: ConnectionStatus,
+  reportedClientCount: number | null | undefined,
+): BrowserTransportPresentation {
+  let label = "Browser disconnected from bridge";
+  if (connectionPaused) {
+    label = "Browser sync paused";
+  } else if (status === "connected") {
+    label = "Browser connected to bridge";
+  } else if (status === "connecting") {
+    label = "Browser connecting to bridge";
+  }
+  const clientCount =
+    !connectionPaused && status === "connected"
+      ? (reportedClientCount ?? null)
+      : null;
+  const otherClientCount =
+    typeof clientCount === "number" ? Math.max(0, clientCount - 1) : 0;
+  let pauseOthersLabel: string | null = null;
+  if (otherClientCount === 1) {
+    pauseOthersLabel = "Pause other browser";
+  } else if (otherClientCount > 1) {
+    pauseOthersLabel = `Pause others (${otherClientCount})`;
+  }
+  const needsResume = connectionPaused || status === "disconnected";
+  let toggleLabel = "Pause browser sync";
+  if (connectionPaused) {
+    toggleLabel = "Resume browser sync";
+  } else if (status === "disconnected") {
+    toggleLabel = "Reconnect browser";
+  }
+
+  return {
+    label,
+    clientCount,
+    pauseOthersLabel,
+    needsResume,
+    toggleLabel,
+  };
+}

--- a/web/src/components/browserTransport.ts
+++ b/web/src/components/browserTransport.ts
@@ -31,7 +31,7 @@ export function browserTransportPresentation(
   if (otherClientCount === 1) {
     pauseOthersLabel = "Pause other browser";
   } else if (otherClientCount > 1) {
-    pauseOthersLabel = `Pause others (${otherClientCount})`;
+    pauseOthersLabel = `Pause other browsers (${otherClientCount})`;
   }
   const needsResume = connectionPaused || status === "disconnected";
   let toggleLabel = "Pause browser sync";

--- a/web/src/components/workspaceInspectorLayout.test.ts
+++ b/web/src/components/workspaceInspectorLayout.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { workspaceInspectorLayout } from "./workspaceInspectorLayout";
+
+describe("workspace Inspector responsive layout", () => {
+  test("uses compact drill-in navigation at 574px", () => {
+    expect(workspaceInspectorLayout(574)).toEqual({
+      compact: true,
+      splitEnabled: false,
+    });
+  });
+
+  test("enables the two-pane split only at 640px and above", () => {
+    expect(workspaceInspectorLayout(639)).toEqual({
+      compact: true,
+      splitEnabled: false,
+    });
+    expect(workspaceInspectorLayout(640)).toEqual({
+      compact: false,
+      splitEnabled: true,
+    });
+  });
+
+  test("does not assume compact layout before the host is measured", () => {
+    expect(workspaceInspectorLayout(0)).toEqual({
+      compact: false,
+      splitEnabled: false,
+    });
+  });
+});

--- a/web/src/components/workspaceInspectorLayout.ts
+++ b/web/src/components/workspaceInspectorLayout.ts
@@ -1,0 +1,11 @@
+export const WORKSPACE_INSPECTOR_COMPACT_WIDTH = 640;
+
+export function workspaceInspectorLayout(width: number): {
+  compact: boolean;
+  splitEnabled: boolean;
+} {
+  return {
+    compact: width > 0 && width < WORKSPACE_INSPECTOR_COMPACT_WIDTH,
+    splitEnabled: width >= WORKSPACE_INSPECTOR_COMPACT_WIDTH,
+  };
+}

--- a/web/src/store.test.ts
+++ b/web/src/store.test.ts
@@ -352,6 +352,46 @@ describe("connection-partitioned store state", () => {
     }
   });
 
+  test("uses distinct notices for reconnecting and resuming browser sync", () => {
+    const previousState = store.get();
+    const previousLocalStorage = globalThis.localStorage;
+    const originalConnect = bridge.connect;
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: { setItem: () => undefined },
+    });
+    bridge.connect = () => undefined;
+    try {
+      __storeTesting.replaceState({
+        ...partitionState(),
+        status: "disconnected",
+        automaticUpdateChecksEnabled: false,
+      });
+      store.resumeConnection();
+      expect(store.get().notice?.message).toBe("Reconnecting browser");
+
+      __storeTesting.replaceState({
+        ...partitionState(),
+        status: "disconnected",
+        connectionPaused: true,
+        automaticUpdateChecksEnabled: false,
+      });
+      store.resumeConnection();
+      expect(store.get().notice?.message).toBe("Resuming browser sync");
+    } finally {
+      bridge.connect = originalConnect;
+      __storeTesting.replaceState(previousState);
+      if (previousLocalStorage === undefined) {
+        delete (globalThis as { localStorage?: Storage }).localStorage;
+      } else {
+        Object.defineProperty(globalThis, "localStorage", {
+          configurable: true,
+          value: previousLocalStorage,
+        });
+      }
+    }
+  });
+
   test("rearms terminal attachment when status polling recovers a failed catalog", async () => {
     const previousState = store.get();
     const originalCall = bridge.call;

--- a/web/src/store.test.ts
+++ b/web/src/store.test.ts
@@ -352,6 +352,39 @@ describe("connection-partitioned store state", () => {
     }
   });
 
+  test("rearms terminal attachment when status polling recovers a failed catalog", async () => {
+    const previousState = store.get();
+    const originalCall = bridge.call;
+    const snapshot = {
+      ...partitionState(),
+      terminalAttachEpoch: 7,
+    };
+    bridge.call = (async (method: string) => {
+      expect(method).toBe("bridge.status");
+      return {
+        clients: 2,
+        terminals: [],
+        connections: snapshot.connections,
+        default_connection_id: snapshot.defaultConnectionId,
+      };
+    }) as typeof bridge.call;
+    try {
+      __storeTesting.replaceState(snapshot);
+      __storeTesting.markTerminalReattachPending();
+
+      await __storeTesting.refreshBridgeStatus();
+
+      expect(store.get().terminalAttachEpoch).toBe(8);
+      expect(store.get().bridgeStatus?.clients).toBe(2);
+      expect(__storeTesting.rearmTerminalAttachmentsAfterCatalog(true)).toBe(
+        false,
+      );
+    } finally {
+      bridge.call = originalCall;
+      __storeTesting.replaceState(previousState);
+    }
+  });
+
   test("preserves profile DTO fields across transition bridge-status catalogs", () => {
     const previous = [
       {

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -705,6 +705,7 @@ let initialized = false;
 let catalogRequestSeq = 0;
 let appliedCatalogRequestSeq = 0;
 let catalogReadyForConnection = false;
+let terminalReattachPending = false;
 let focusActionChain: Promise<unknown> = Promise.resolve();
 type PaneStatusTracker = {
   ready: boolean;
@@ -1100,6 +1101,9 @@ async function refreshBridgeStatus() {
     const r = await bridge.call("bridge.status");
     if (state.connectionPaused || state.status !== "connected") return;
     applyConnectionCatalog(r, requestSeq);
+    if (rearmTerminalAttachmentsAfterCatalog(catalogReadyForConnection)) {
+      scheduleRefresh();
+    }
     const nextBridgeStatus: BridgeStatus = {
       clients: Number(r?.clients ?? 0),
       terminals: Array.isArray(r?.terminals) ? r.terminals : [],
@@ -1459,6 +1463,20 @@ async function refreshConnectionCatalog(): Promise<boolean> {
   }
 }
 
+function rearmTerminalAttachmentsAfterCatalog(catalogReady: boolean): boolean {
+  if (
+    !terminalReattachPending ||
+    !catalogReady ||
+    state.status !== "connected" ||
+    state.connectionPaused
+  ) {
+    return false;
+  }
+  terminalReattachPending = false;
+  set({ terminalAttachEpoch: state.terminalAttachEpoch + 1 });
+  return true;
+}
+
 const RECONNECT_RETRY_WAIT_MS = 10_000;
 const RECONNECT_RETRY_POLL_MS = 100;
 
@@ -1675,6 +1693,7 @@ export const store = {
     bridge.onStatus((s) => {
       if (s === "disconnected") {
         catalogReadyForConnection = false;
+        terminalReattachPending = true;
         bridge.setConnectionRuntimeGenerations([]);
         clearTerminalRelayViewports();
         focusActionChain = Promise.resolve();
@@ -1717,6 +1736,7 @@ export const store = {
           ) {
             return;
           }
+          rearmTerminalAttachmentsAfterCatalog(true);
           void refreshNow();
           void refreshBridgeStatus();
         });
@@ -1828,8 +1848,8 @@ export const store = {
           kind: pausedClients > 0 ? "success" : "info",
           message:
             pausedClients === 1
-              ? "Paused 1 other client"
-              : `Paused ${pausedClients} other clients`,
+              ? "Paused 1 other browser"
+              : `Paused ${pausedClients} other browsers`,
           autoDismissMs: 5000,
         },
       });
@@ -2644,6 +2664,13 @@ export const store = {
 export const __storeTesting = {
   startUpdatePolling,
   updatePollingActive: () => updateTimer !== null,
+  refreshBridgeStatus,
+  markTerminalReattachPending() {
+    terminalReattachPending = true;
+    catalogReadyForConnection = false;
+    bridge.setConnectionRuntimeGenerations([]);
+  },
+  rearmTerminalAttachmentsAfterCatalog,
   replaceState(snapshot: State) {
     stopPolling();
     refreshingConnectionKeys.clear();
@@ -2651,6 +2678,7 @@ export const __storeTesting = {
     focusActionChain = Promise.resolve();
     taskCompletionTracker.clear();
     state = snapshot;
+    terminalReattachPending = false;
     catalogReadyForConnection = snapshot.connections.length > 0;
     bridge.setConnectionRuntimeGenerations(snapshot.connections);
   },

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -706,6 +706,7 @@ let catalogRequestSeq = 0;
 let appliedCatalogRequestSeq = 0;
 let catalogReadyForConnection = false;
 let terminalReattachPending = false;
+let connectionRecoveryIntent: "resume" | "reconnect" | null = null;
 let focusActionChain: Promise<unknown> = Promise.resolve();
 type PaneStatusTracker = {
   ready: boolean;
@@ -1699,19 +1700,23 @@ export const store = {
         focusActionChain = Promise.resolve();
         queuedConnectionKeys.clear();
       }
-      const resumed =
-        s === "connected" &&
-        !state.connectionPaused &&
-        state.notice?.loading &&
-        state.notice.message === "Resuming connection";
+      const completedRecovery =
+        s === "connected" && !state.connectionPaused && state.notice?.loading
+          ? connectionRecoveryIntent
+          : null;
+      if (s === "connected") connectionRecoveryIntent = null;
+      const completedRecoveryMessage =
+        completedRecovery === "reconnect"
+          ? "Browser reconnected"
+          : "Browser sync resumed";
       set(
-        resumed
+        completedRecovery
           ? {
               status: s,
               connectionGeneration: state.connectionGeneration,
               notice: {
                 kind: "success",
-                message: "Connection resumed",
+                message: completedRecoveryMessage,
                 autoDismissMs: 5000,
               },
             }
@@ -1815,6 +1820,7 @@ export const store = {
   pauseConnection(
     detail = "This browser will stop syncing until you resume it.",
   ) {
+    connectionRecoveryIntent = null;
     localStorage.setItem("connectionPaused", "true");
     stopPolling();
     disposeTerminalConnection(
@@ -1859,13 +1865,17 @@ export const store = {
   },
 
   resumeConnection() {
+    connectionRecoveryIntent = state.connectionPaused ? "resume" : "reconnect";
     localStorage.setItem("connectionPaused", "false");
     set({
       connectionPaused: false,
       error: null,
       notice: {
         kind: "info",
-        message: "Resuming connection",
+        message:
+          connectionRecoveryIntent === "reconnect"
+            ? "Reconnecting browser"
+            : "Resuming browser sync",
         loading: true,
       },
     });
@@ -2679,6 +2689,7 @@ export const __storeTesting = {
     taskCompletionTracker.clear();
     state = snapshot;
     terminalReattachPending = false;
+    connectionRecoveryIntent = null;
     catalogReadyForConnection = snapshot.connections.length > 0;
     bridge.setConnectionRuntimeGenerations(snapshot.connections);
   },

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -586,7 +586,7 @@ textarea:focus {
   gap: 12px;
 }
 .topbar-start {
-  overflow: visible;
+  overflow: hidden;
 }
 .topbar-actions {
   justify-self: end;
@@ -602,8 +602,10 @@ textarea:focus {
   box-shadow: 0 1px 2px color-mix(in srgb, var(--bg) 28%, transparent);
 }
 .brand {
+  min-width: 0;
   display: inline-flex;
   align-items: center;
+  flex: 0 1 auto;
   gap: 8px;
   font-weight: 700;
   letter-spacing: 0.2px;
@@ -662,10 +664,13 @@ textarea:focus {
 .connection-switcher {
   position: relative;
   min-width: 0;
+  max-width: min(360px, 42vw);
+  flex: 0 1 auto;
 }
 .connection-switcher-trigger {
+  width: fit-content;
   min-width: 0;
-  max-width: min(360px, 42vw);
+  max-width: 100%;
   height: 30px;
   display: flex;
   align-items: center;
@@ -681,6 +686,14 @@ textarea:focus {
   border-color: var(--topbar-control-active-border);
   background: var(--topbar-control-active-bg);
   color: var(--text-strong);
+}
+.connection-switcher-trigger.has-browser-warning {
+  border-color: rgba(240, 196, 83, 0.4);
+  background: var(--warning-soft);
+}
+.connection-switcher-warning {
+  flex: 0 0 auto;
+  color: var(--warning-text);
 }
 .connection-switcher-label,
 .connection-switcher-meta {
@@ -750,6 +763,41 @@ textarea:focus {
 }
 .browser-disconnected {
   background: var(--red);
+}
+.connection-browser-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  padding: 5px;
+  border-bottom: 1px solid var(--border-soft);
+}
+.connection-browser-actions button {
+  min-width: min(150px, 100%);
+  min-height: 34px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex: 1 1 150px;
+  padding: 7px 8px;
+  border-color: var(--border-soft);
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  white-space: nowrap;
+}
+.connection-browser-actions button:hover,
+.connection-browser-actions button:focus-visible {
+  background: var(--panel-2);
+}
+.connection-browser-actions button.is-warning {
+  border-color: rgba(240, 196, 83, 0.32);
+  background: var(--warning-soft);
+  color: var(--warning-text);
+}
+.connection-browser-actions button.is-warning:hover,
+.connection-browser-actions button.is-warning:focus-visible {
+  border-color: rgba(240, 196, 83, 0.5);
+  background: color-mix(in srgb, var(--warning-soft) 78%, var(--yellow));
 }
 .connection-switcher-list {
   min-height: 0;
@@ -836,11 +884,6 @@ textarea:focus {
 .topbar-command-group .topbar-button.is-active {
   border-color: var(--topbar-control-active-border);
   background: var(--topbar-control-active-bg);
-}
-.topbar-button.is-paused {
-  color: var(--warning-text);
-  background: var(--warning-soft);
-  border-color: rgba(240, 196, 83, 0.32);
 }
 .view-switcher {
   display: flex;
@@ -1293,33 +1336,6 @@ textarea:focus {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.config-inline-actions {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 6px;
-  padding: 6px 8px 0;
-}
-.config-inline-actions button {
-  min-width: 0;
-  height: 32px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 0 8px;
-  border-radius: 7px;
-  color: var(--text);
-  font-size: 11px;
-  white-space: nowrap;
-}
-.config-inline-actions button.is-primary {
-  border-color: var(--accent);
-  background: var(--accent-soft);
-  color: var(--text-strong);
-}
-.config-inline-actions button.is-primary:hover:not(:disabled) {
-  background: var(--accent-hover);
-}
 .errorbar {
   background: var(--danger-soft);
   color: var(--danger-text);
@@ -1661,8 +1677,6 @@ textarea:focus {
   border-radius: 10px;
   background: var(--viewer-panel-bg);
   box-shadow: var(--shadow-lg);
-  container-name: workspace-inspector;
-  container-type: inline-size;
 }
 .workspace-inspector-head {
   flex: 0 0 auto;
@@ -1875,68 +1889,67 @@ textarea:focus {
 .workspace-inspector-unavailable strong {
   color: var(--text-strong);
 }
-@container workspace-inspector (max-width: 559px) {
-  .workspace-inspector-head {
-    grid-template-columns: minmax(0, 1fr) auto;
-  }
-  .workspace-inspector-identity {
-    grid-column: 1;
-  }
-  .workspace-inspector-actions {
-    grid-column: 2;
-    grid-row: 1;
-  }
-  .workspace-inspector-tabs {
-    grid-column: 1 / -1;
-    grid-row: 2;
-    width: 100%;
-  }
-  .workspace-inspector-tabs button {
-    flex: 1 1 0;
-  }
-  .workspace-inspector-resource {
-    display: flex;
-    padding: 0;
-  }
+.workspace-inspector.is-compact .workspace-inspector-head {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+.workspace-inspector.is-compact .workspace-inspector-identity {
+  grid-column: 1;
+}
+.workspace-inspector.is-compact .workspace-inspector-actions {
+  grid-column: 2;
+  grid-row: 1;
+}
+.workspace-inspector.is-compact .workspace-inspector-tabs {
+  grid-column: 1 / -1;
+  grid-row: 2;
+  width: 100%;
+}
+.workspace-inspector.is-compact .workspace-inspector-tabs button {
+  flex: 1 1 0;
+}
+.workspace-inspector.is-compact .workspace-inspector-resource {
+  display: flex;
+  padding: 0;
+}
+.workspace-inspector.is-compact
   .workspace-inspector-resource.inspector-history-resource {
-    padding: 0;
-  }
-  .workspace-inspector-navigation,
-  .workspace-inspector-detail {
-    flex: 1 1 auto;
-    width: 100%;
-  }
-  .workspace-inspector-detail {
-    display: none;
-  }
-  .workspace-inspector.has-detail .workspace-inspector-navigation {
-    display: none;
-  }
-  .workspace-inspector.has-detail .workspace-inspector-detail {
-    display: flex;
-  }
-  .workspace-inspector.has-detail .workspace-inspector-back {
-    flex: 0 0 auto;
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    min-height: 34px;
-    padding: 0 10px;
-    border: 0;
-    border-bottom: 1px solid var(--viewer-border);
-    border-radius: 0;
-    background: var(--viewer-header-bg);
-    color: var(--text);
-    font-size: 12px;
-  }
-  .workspace-inspector .file-explorer-side,
-  .workspace-inspector .diff-viewer-side,
-  .workspace-inspector .diff-content-view,
-  .workspace-inspector .file-preview,
-  .workspace-inspector .agent-history-drawer.is-embedded {
-    border: 0;
-    border-radius: 0;
-  }
+  padding: 0;
+}
+.workspace-inspector.is-compact .workspace-inspector-navigation,
+.workspace-inspector.is-compact .workspace-inspector-detail {
+  flex: 1 1 auto;
+  width: 100%;
+}
+.workspace-inspector.is-compact .workspace-inspector-detail {
+  display: none;
+}
+.workspace-inspector.is-compact.has-detail .workspace-inspector-navigation {
+  display: none;
+}
+.workspace-inspector.is-compact.has-detail .workspace-inspector-detail {
+  display: flex;
+}
+.workspace-inspector.is-compact.has-detail .workspace-inspector-back {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 34px;
+  padding: 0 10px;
+  border: 0;
+  border-bottom: 1px solid var(--viewer-border);
+  border-radius: 0;
+  background: var(--viewer-header-bg);
+  color: var(--text);
+  font-size: 12px;
+}
+.workspace-inspector.is-compact .file-explorer-side,
+.workspace-inspector.is-compact .diff-viewer-side,
+.workspace-inspector.is-compact .diff-content-view,
+.workspace-inspector.is-compact .file-preview,
+.workspace-inspector.is-compact .agent-history-drawer.is-embedded {
+  border: 0;
+  border-radius: 0;
 }
 @container workspace-stage (max-width: 999px) {
   .workspace-inspector-resizer {
@@ -7543,9 +7556,7 @@ textarea:focus {
     white-space: nowrap;
   }
   .brand-version {
-    height: 18px;
-    padding: 0 5px;
-    font-size: 9px;
+    display: none;
   }
   .status {
     gap: 0;
@@ -7566,12 +7577,18 @@ textarea:focus {
   .topbar-view-switcher {
     display: none;
   }
+  .workspace-inspector-actions .workspace-inspector-dock-action,
+  .workspace-inspector-actions .workspace-inspector-expand-action {
+    display: none;
+  }
   .topbar-start,
   .topbar-actions {
     gap: 8px;
   }
-  .connection-switcher-trigger {
+  .connection-switcher {
     max-width: min(220px, 42vw);
+  }
+  .connection-switcher-trigger {
     height: 28px;
   }
   .connection-switcher-meta {
@@ -7624,13 +7641,9 @@ textarea:focus {
   }
 
   .toast-viewport {
-    top: auto;
+    top: calc(56px + env(safe-area-inset-top, 0px));
     right: calc(10px + env(safe-area-inset-right, 0px));
-    bottom: calc(
-      148px +
-      env(safe-area-inset-bottom, 0px) +
-      var(--keyboard-inset-bottom, 0px)
-    );
+    bottom: auto;
     left: calc(10px + env(safe-area-inset-left, 0px));
     width: auto;
   }
@@ -8258,5 +8271,14 @@ textarea:focus {
   }
   .layout-pane-head {
     font-size: 12px;
+  }
+}
+
+@media (max-width: 360px) {
+  .brand {
+    flex: 0 0 auto;
+  }
+  .brand-title {
+    display: none;
   }
 }


### PR DESCRIPTION
## Summary

- consolidate browser pause, resume, reconnect, and pause-other-browser actions in Connections
- restore terminal attachments reliably after resume, including transient connection-catalog failures
- improve responsive Connections, Inspector, Toast, and topbar behavior across narrow layouts
- add visible loading feedback to Diff Viewer refreshes
- centralize tested browser transport and Inspector layout presentation logic

## Verification

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test` — 675 passed, 1 skipped
- `cd web && bun run build`
- manually verified the Inspector at 574px and at a 558px-wide desktop dock
- manually verified the Connections menu at 390px
- manually verified terminal restoration after Pause → Resume without reloading
