### PR TITLE
Improve Files and Changes workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Changed
+
+- Align Files and Changes with shared Git status, keyboard file-tree navigation,
+  and inline per-file diff controls that preserve the selected view settings.
+
 ## 0.4.6 - 2026-08-25
 
 ### Added

--- a/web/src/components/DiffContentView.test.ts
+++ b/web/src/components/DiffContentView.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import type { GitDiffEntry, GitDiffFile } from "../types";
-import { diffContentEntries, diffSearchGroups } from "./DiffContentView";
+import {
+  diffContentEntries,
+  diffHunkTargets,
+  diffSearchGroups,
+  nextDiffHunkIndex,
+} from "./DiffContentView";
 
 const entries: GitDiffEntry[] = [
   { path: "src/one.ts", kind: "unstaged", status: "M" },
@@ -27,6 +32,35 @@ describe("diffContentEntries", () => {
   test("falls back to the selected entry before a summary is available", () => {
     expect(diffContentEntries([], entries[0])).toEqual([entries[0]]);
     expect(diffContentEntries([], null)).toEqual([]);
+  });
+});
+
+describe("diffHunkTargets", () => {
+  test("starts navigation at the first or last hunk", () => {
+    expect(nextDiffHunkIndex(-1, 1, 3)).toBe(0);
+    expect(nextDiffHunkIndex(-1, -1, 3)).toBe(2);
+    expect(nextDiffHunkIndex(2, 1, 3)).toBe(0);
+    expect(nextDiffHunkIndex(0, -1, 3)).toBe(2);
+    expect(nextDiffHunkIndex(0, 1, 0)).toBe(-1);
+  });
+
+  test("locates the first changed lines in each patch hunk", () => {
+    expect(
+      diffHunkTargets(
+        [
+          "@@ -3,4 +3,5 @@",
+          " context",
+          "-before",
+          "+after",
+          "+added",
+          "@@ -20,2 +21,0 @@",
+          "-removed",
+        ].join("\n"),
+      ),
+    ).toEqual([
+      { oldLine: 4, newLine: 4 },
+      { oldLine: 20, newLine: null },
+    ]);
   });
 });
 

--- a/web/src/components/DiffContentView.tsx
+++ b/web/src/components/DiffContentView.tsx
@@ -125,6 +125,69 @@ type DiffSection = {
   error: string | null;
 };
 
+export type DiffHunkTarget = {
+  oldLine: number | null;
+  newLine: number | null;
+};
+
+export function nextDiffHunkIndex(
+  current: number,
+  delta: -1 | 1,
+  count: number,
+) {
+  if (count <= 0) return -1;
+  if (current < 0 || current >= count) return delta > 0 ? 0 : count - 1;
+  return (current + delta + count) % count;
+}
+
+export function diffHunkTargets(patch: string): DiffHunkTarget[] {
+  const targets: DiffHunkTarget[] = [];
+  const lines = patch.split("\n");
+  let oldLine = 0;
+  let newLine = 0;
+  let target: DiffHunkTarget | null = null;
+
+  for (const line of lines) {
+    const header = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (header) {
+      if (target) targets.push(target);
+      oldLine = Number(header[1]);
+      newLine = Number(header[2]);
+      target = { oldLine: null, newLine: null };
+      continue;
+    }
+    if (!target) continue;
+    if (line.startsWith("+") && !line.startsWith("+++")) {
+      target.newLine ??= newLine;
+      newLine += 1;
+    } else if (line.startsWith("-") && !line.startsWith("---")) {
+      target.oldLine ??= oldLine;
+      oldLine += 1;
+    } else if (!line.startsWith("\\")) {
+      oldLine += 1;
+      newLine += 1;
+    }
+  }
+  if (target) targets.push(target);
+  return targets;
+}
+
+function deepQuerySelector(
+  root: ParentNode,
+  selectors: string[],
+): HTMLElement | null {
+  for (const selector of selectors) {
+    const match = root.querySelector<HTMLElement>(selector);
+    if (match) return match;
+  }
+  for (const element of root.querySelectorAll<HTMLElement>("*")) {
+    if (!element.shadowRoot) continue;
+    const match = deepQuerySelector(element.shadowRoot, selectors);
+    if (match) return match;
+  }
+  return null;
+}
+
 function loadDiffViewMode(): DiffViewMode {
   return localStorage.getItem(DIFF_VIEW_MODE_KEY) === "unified"
     ? "unified"
@@ -298,6 +361,7 @@ type DiffFileSectionProps = {
   imagePreviewState?: ImagePreviewState;
   options: PierreDiffOptions;
   currentSearchMatch: boolean;
+  embedded: boolean;
   onToggle: (key: string, collapsed: boolean) => void;
   onSelectFile?: (entry: GitDiffEntry) => void;
   onOpenFile?: (entry: GitDiffEntry) => void;
@@ -309,6 +373,7 @@ const DiffFileSection = memo(function DiffFileSection({
   imagePreviewState,
   options,
   currentSearchMatch,
+  embedded,
   onToggle,
   onSelectFile,
   onOpenFile,
@@ -324,56 +389,79 @@ const DiffFileSection = memo(function DiffFileSection({
 
   return (
     <article
-      className={`diff-file-section ${currentSearchMatch ? "is-search-current" : ""}`}
+      className={`diff-file-section ${embedded ? "is-embedded" : ""} ${currentSearchMatch ? "is-search-current" : ""}`}
       data-diff-entry-key={section.key}
       aria-current={currentSearchMatch ? "true" : undefined}
     >
-      <header className="diff-file-section-head">
-        <button
-          type="button"
-          className="diff-file-collapse"
-          onClick={toggle}
-          disabled={!section.active && !onSelectFile}
-          aria-expanded={!section.collapsed}
-          aria-label={`${section.collapsed ? "Expand" : "Collapse"} ${section.entry.path}`}
-          title={section.collapsed ? "Expand" : "Collapse"}
-        >
-          {section.collapsed ? (
-            <ChevronRight size={14} />
-          ) : (
-            <ChevronDown size={14} />
-          )}
-        </button>
-        <div className="diff-file-section-title">
-          <strong>{section.entry.path}</strong>
-          <span>
-            {section.entry.kind} · {section.entry.status}
-            {section.autoCollapse ? ` · ${section.autoCollapse.label}` : ""}
-            {section.file?.truncated ? " · truncated" : ""}
-            {section.collapsed && section.autoCollapse
-              ? " · auto-collapsed"
-              : ""}
-          </span>
-        </div>
-        <button
-          type="button"
-          className="diff-file-open"
-          onClick={() => onOpenFile?.(section.entry)}
-          disabled={!onOpenFile}
-        >
-          <FolderOpen size={14} />
-          <span>Open in Files</span>
-        </button>
-      </header>
+      {embedded ? null : (
+        <header className="diff-file-section-head">
+          <button
+            type="button"
+            className="diff-file-collapse"
+            onClick={toggle}
+            disabled={!section.active && !onSelectFile}
+            aria-expanded={!section.collapsed}
+            aria-label={`${section.collapsed ? "Expand" : "Collapse"} ${section.entry.path}`}
+            title={section.collapsed ? "Expand" : "Collapse"}
+          >
+            {section.collapsed ? (
+              <ChevronRight size={14} />
+            ) : (
+              <ChevronDown size={14} />
+            )}
+          </button>
+          <div className="diff-file-section-title">
+            <strong>{section.entry.path}</strong>
+            <span>
+              {section.entry.kind} · {section.entry.status}
+              {section.autoCollapse ? ` · ${section.autoCollapse.label}` : ""}
+              {section.file?.truncated ? " · truncated" : ""}
+              {section.collapsed && section.autoCollapse
+                ? " · auto-collapsed"
+                : ""}
+            </span>
+          </div>
+          <button
+            type="button"
+            className="diff-file-open"
+            onClick={() => onOpenFile?.(section.entry)}
+            disabled={!onOpenFile}
+          >
+            <FolderOpen size={14} />
+            <span>Open in Files</span>
+          </button>
+        </header>
+      )}
       {section.collapsed ? null : (
         <>
           {section.error ? (
-            <div className="diff-content-state is-error">{section.error}</div>
+            <div className="diff-content-state is-error">
+              <span>{section.error}</span>
+              {onSelectFile ? (
+                <button
+                  type="button"
+                  onClick={() => onSelectFile(section.entry)}
+                >
+                  Retry
+                </button>
+              ) : null}
+            </div>
           ) : null}
           {!section.file && !section.error ? (
             <div className="diff-content-state">
               {loading ? <span className="file-loading-spinner" /> : null}
-              {loading ? "Loading diff" : "Select this file to load its diff."}
+              {loading ? (
+                "Loading diff"
+              ) : onSelectFile ? (
+                <button
+                  type="button"
+                  onClick={() => onSelectFile(section.entry)}
+                >
+                  Load diff
+                </button>
+              ) : (
+                "Select this file to load its diff."
+              )}
             </div>
           ) : null}
           {section.file && !section.file.diff && !section.imagePreview ? (
@@ -423,6 +511,7 @@ function areDiffFileSectionPropsEqual(
     previous.imagePreviewState === next.imagePreviewState &&
     previous.options === next.options &&
     previous.currentSearchMatch === next.currentSearchMatch &&
+    previous.embedded === next.embedded &&
     previous.onToggle === next.onToggle &&
     previous.onSelectFile === next.onSelectFile &&
     previous.onOpenFile === next.onOpenFile
@@ -443,6 +532,7 @@ export function DiffContentView({
   connectionClient,
   onSelectFile,
   onOpenFile,
+  embedded = false,
 }: {
   entry: GitDiffEntry | null;
   file: GitDiffFile | null;
@@ -457,6 +547,7 @@ export function DiffContentView({
   connectionClient: ConnectionClient;
   onSelectFile?: (entry: GitDiffEntry) => void;
   onOpenFile?: (entry: GitDiffEntry) => void;
+  embedded?: boolean;
 }) {
   const sectionRef = useRef<HTMLElement | null>(null);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
@@ -470,6 +561,9 @@ export function DiffContentView({
   const [searchQuery, setSearchQuery] = useState("");
   const deferredSearchQuery = useDeferredValue(searchQuery);
   const [searchIndex, setSearchIndex] = useState(-1);
+  const [hunkIndex, setHunkIndex] = useState(-1);
+  const hunkIndexRef = useRef(-1);
+  const hunkNavigationRevisionRef = useRef(0);
   const [imagePreviews, setImagePreviews] = useState<
     Record<string, ImagePreviewState>
   >({});
@@ -513,12 +607,14 @@ export function DiffContentView({
           imagePreview,
           autoCollapse,
           collapsed:
-            !active || (manualCollapseStates.get(key) ?? defaultCollapsed),
+            !embedded &&
+            (!active || (manualCollapseStates.get(key) ?? defaultCollapsed)),
           error: fileErrors[key] ?? null,
         };
       }),
     [
       activeEntryKey,
+      embedded,
       fileErrors,
       filesByKey,
       manualCollapseStates,
@@ -558,12 +654,89 @@ export function DiffContentView({
     () => Object.values(filesByKey).some((candidate) => !!candidate.diff),
     [filesByKey],
   );
+  const hunkTargets = useMemo(
+    () => diffHunkTargets(file?.diff ?? ""),
+    [file?.diff],
+  );
   const handleSelectFile = useCallback((target: GitDiffEntry) => {
     selectFileRef.current?.(target);
   }, []);
   const handleOpenFile = useCallback((target: GitDiffEntry) => {
     openFileRef.current?.(target);
   }, []);
+  const goToHunk = useCallback(
+    (delta: -1 | 1) => {
+      if (!hunkTargets.length) return;
+      const nextIndex = nextDiffHunkIndex(
+        hunkIndexRef.current,
+        delta,
+        hunkTargets.length,
+      );
+      const target = hunkTargets[nextIndex];
+      hunkIndexRef.current = nextIndex;
+      setHunkIndex(nextIndex);
+      const navigationRevision = ++hunkNavigationRevisionRef.current;
+
+      let attempts = 0;
+      const reveal = () => {
+        if (hunkNavigationRevisionRef.current !== navigationRevision) return;
+        const section = sectionRef.current;
+        if (!section) return;
+        const activeArticle = Array.from(
+          section.querySelectorAll<HTMLElement>(".diff-file-section"),
+        ).find(
+          (candidate) => candidate.dataset.diffEntryKey === activeEntryKey,
+        );
+        const selectors = [
+          target.newLine === null
+            ? ""
+            : `[data-line='${target.newLine}'][data-line-type='change-addition']`,
+          target.oldLine === null
+            ? ""
+            : `[data-line='${target.oldLine}'][data-line-type='change-deletion']`,
+          target.newLine === null
+            ? ""
+            : `[data-line='${target.newLine}'][data-line-type^='change-']`,
+          target.oldLine === null
+            ? ""
+            : `[data-line='${target.oldLine}'][data-line-type^='change-']`,
+        ].filter(Boolean);
+        const line = activeArticle
+          ? deepQuerySelector(activeArticle, selectors)
+          : null;
+        if (line) {
+          line.scrollIntoView({ behavior: "smooth", block: "center" });
+          return;
+        }
+        attempts += 1;
+        if (attempts === 8) {
+          const scroller = section.querySelector<HTMLElement>(
+            ".pierre-diff-scroll",
+          );
+          if (scroller) {
+            const targetLine = target.newLine ?? target.oldLine ?? 1;
+            const maxTargetLine = Math.max(
+              1,
+              ...hunkTargets.map(
+                (candidate) => candidate.newLine ?? candidate.oldLine ?? 1,
+              ),
+            );
+            const ratio = (targetLine - 1) / Math.max(1, maxTargetLine - 1);
+            const availableHeight = activeArticle
+              ? Math.max(0, activeArticle.scrollHeight - scroller.clientHeight)
+              : Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+            scroller.scrollTo({
+              top: (activeArticle?.offsetTop ?? 0) + ratio * availableHeight,
+              behavior: "auto",
+            });
+          }
+        }
+        if (attempts < 24) requestAnimationFrame(reveal);
+      };
+      requestAnimationFrame(reveal);
+    },
+    [activeEntryKey, hunkTargets],
+  );
   const completeImagePreview = useCallback(
     (key: string, state: ImagePreviewState) => {
       setImagePreviews((current) => ({ ...current, [key]: state }));
@@ -588,6 +761,12 @@ export function DiffContentView({
     }),
     [effectiveViewMode, theme, wrapEnabled],
   );
+
+  useEffect(() => {
+    hunkIndexRef.current = -1;
+    hunkNavigationRevisionRef.current += 1;
+    setHunkIndex(-1);
+  }, [activeEntryKey, file?.diff]);
 
   useEffect(() => {
     selectFileRef.current = onSelectFile;
@@ -728,6 +907,7 @@ export function DiffContentView({
   );
 
   useEffect(() => {
+    if (embedded) return;
     const onKey = (e: KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
       if (e.key.toLowerCase() !== "f") return;
@@ -741,7 +921,7 @@ export function DiffContentView({
     window.addEventListener("keydown", onKey, { capture: true });
     return () =>
       window.removeEventListener("keydown", onKey, { capture: true });
-  }, [focusSearch]);
+  }, [embedded, focusSearch]);
 
   const diffList = visibleEntries.length ? (
     <Virtualizer
@@ -760,6 +940,7 @@ export function DiffContentView({
           }
           options={pierreOptions}
           currentSearchMatch={currentSearchEntryKey === section.key}
+          embedded={embedded}
           onToggle={toggleSectionCollapsed}
           onSelectFile={onSelectFile ? handleSelectFile : undefined}
           onOpenFile={onOpenFile ? handleOpenFile : undefined}
@@ -771,11 +952,15 @@ export function DiffContentView({
   return (
     <section
       ref={sectionRef}
-      className="diff-content-view"
-      aria-label="Diff Viewer content"
+      className={`diff-content-view ${embedded ? "is-embedded" : ""}`}
+      aria-label={embedded ? "File changes" : "Diff Viewer content"}
       tabIndex={-1}
       onKeyDownCapture={(e) => {
-        if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "f") {
+        if (
+          !embedded &&
+          (e.metaKey || e.ctrlKey) &&
+          e.key.toLowerCase() === "f"
+        ) {
           if (isEditableSearchTarget(e.target)) return;
           e.preventDefault();
           e.stopPropagation();
@@ -784,16 +969,18 @@ export function DiffContentView({
       }}
     >
       <div className="diff-content-head">
-        <div className="diff-content-title">
-          <strong>
-            {changedFileCount
-              ? `${changedFileCount} changed file${
-                  changedFileCount === 1 ? "" : "s"
-                }`
-              : "Diff Viewer"}
-          </strong>
-          {entry ? <span>{entry.path}</span> : null}
-        </div>
+        {embedded ? null : (
+          <div className="diff-content-title">
+            <strong>
+              {changedFileCount
+                ? `${changedFileCount} changed file${
+                    changedFileCount === 1 ? "" : "s"
+                  }`
+                : "Diff Viewer"}
+            </strong>
+            {entry ? <span>{entry.path}</span> : null}
+          </div>
+        )}
         {mobile ? (
           <button
             type="button"
@@ -805,71 +992,100 @@ export function DiffContentView({
           </button>
         ) : null}
         <div className="diff-content-actions">
-          <div className="diff-search-controls">
-            <label className="diff-search">
-              <Search size={13} />
-              <input
-                ref={searchInputRef}
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.currentTarget.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    goToSearchMatch(e.shiftKey ? -1 : 1);
-                  } else if (e.key === "Escape") {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    setSearchQuery("");
-                  }
-                }}
-                placeholder="Find loaded files"
-                disabled={!hasSearchableDiff}
-              />
-            </label>
-            <span
-              className="diff-search-count"
-              role="status"
-              aria-live="polite"
+          {hunkTargets.length ? (
+            <div
+              className="diff-hunk-navigation"
+              aria-label="Change navigation"
             >
-              {deferredSearchQuery && searchMatchCount
-                ? `${searchIndex + 1}/${searchMatchCount}`
-                : deferredSearchQuery
-                  ? "No results"
-                  : ""}
-            </span>
-            <button
-              type="button"
-              className="diff-search-button"
-              onClick={() => goToSearchMatch(-1)}
-              disabled={!searchMatchCount}
-              aria-label="Previous matching loaded file"
-            >
-              <ChevronUp size={14} />
-            </button>
-            <button
-              type="button"
-              className="diff-search-button"
-              onClick={() => goToSearchMatch(1)}
-              disabled={!searchMatchCount}
-              aria-label="Next matching loaded file"
-            >
-              <ChevronDown size={14} />
-            </button>
-            {searchQuery ? (
+              <button
+                type="button"
+                onClick={() => goToHunk(-1)}
+                aria-label="Previous change"
+                title="Previous change"
+              >
+                <ChevronUp size={14} />
+              </button>
+              <span>
+                {hunkIndex < 0 ? "–" : hunkIndex + 1}/{hunkTargets.length}{" "}
+                {hunkTargets.length === 1 ? "change" : "changes"}
+              </span>
+              <button
+                type="button"
+                onClick={() => goToHunk(1)}
+                aria-label="Next change"
+                title="Next change"
+              >
+                <ChevronDown size={14} />
+              </button>
+            </div>
+          ) : null}
+          {!embedded ? (
+            <div className="diff-search-controls">
+              <label className="diff-search">
+                <Search size={13} />
+                <input
+                  ref={searchInputRef}
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.currentTarget.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      goToSearchMatch(e.shiftKey ? -1 : 1);
+                    } else if (e.key === "Escape") {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      setSearchQuery("");
+                    }
+                  }}
+                  placeholder="Find loaded files"
+                  disabled={!hasSearchableDiff}
+                />
+              </label>
+              <span
+                className="diff-search-count"
+                role="status"
+                aria-live="polite"
+              >
+                {deferredSearchQuery && searchMatchCount
+                  ? `${searchIndex + 1}/${searchMatchCount}`
+                  : deferredSearchQuery
+                    ? "No results"
+                    : ""}
+              </span>
               <button
                 type="button"
                 className="diff-search-button"
-                onClick={() => {
-                  setSearchQuery("");
-                  focusSearch();
-                }}
-                aria-label="Clear diff search"
+                onClick={() => goToSearchMatch(-1)}
+                disabled={!searchMatchCount}
+                aria-label="Previous matching loaded file"
               >
-                <X size={14} />
+                <ChevronUp size={14} />
               </button>
-            ) : null}
-          </div>
+              <button
+                type="button"
+                className="diff-search-button"
+                onClick={() => goToSearchMatch(1)}
+                disabled={!searchMatchCount}
+                aria-label="Next matching loaded file"
+              >
+                <ChevronDown size={14} />
+              </button>
+              {searchQuery ? (
+                <button
+                  type="button"
+                  className="diff-search-button"
+                  onClick={() => {
+                    setSearchQuery("");
+                    focusSearch();
+                  }}
+                  aria-label="Clear diff search"
+                >
+                  <X size={14} />
+                </button>
+              ) : null}
+            </div>
+          ) : null}
           {!mobile ? (
             <div className="diff-display-controls">
               <div className="diff-view-toggle" aria-label="Diff view mode">

--- a/web/src/components/DiffViewerPanel.test.ts
+++ b/web/src/components/DiffViewerPanel.test.ts
@@ -7,6 +7,7 @@ import {
   diffCacheKey,
   diffRuntimeContextKey,
   diffSelectionStorageKey,
+  expandedDirsForEntries,
   expandedDirsForSelection,
   mergeResolvedDiffFile,
   prefetchDiffFilesInBatches,
@@ -39,7 +40,7 @@ describe("connection-scoped diff identity", () => {
     );
   });
 
-  test("expands only the selected file ancestors", () => {
+  test("expands the selected file ancestors", () => {
     expect(
       Array.from(
         expandedDirsForSelection({
@@ -50,6 +51,30 @@ describe("connection-scoped diff identity", () => {
       ),
     ).toEqual(["", "src", "src/components"]);
     expect(Array.from(expandedDirsForSelection(null))).toEqual([""]);
+  });
+
+  test("expands every directory in a refreshed diff tree", () => {
+    expect(
+      Array.from(
+        expandedDirsForEntries([
+          {
+            path: "src/components/App.tsx",
+            kind: "unstaged",
+            status: "M",
+          },
+          {
+            path: "server/src/index.ts",
+            kind: "staged",
+            status: "M",
+          },
+          {
+            path: "README.md",
+            kind: "untracked",
+            status: "added",
+          },
+        ]),
+      ),
+    ).toEqual(["", "src", "src/components", "server", "server/src"]);
   });
 
   test("honors explicit null selection overrides", () => {

--- a/web/src/components/DiffViewerPanel.tsx
+++ b/web/src/components/DiffViewerPanel.tsx
@@ -1270,7 +1270,7 @@ export const DiffViewerPanel = forwardRef<
       const stats = diffStatsForEntries(child.entries);
       const statusCodes = Array.from(
         new Set(child.entries.map((entry) => gitDiffCode(entry))),
-      );
+      ).sort();
       items.push(
         <button
           type="button"

--- a/web/src/components/DiffViewerPanel.tsx
+++ b/web/src/components/DiffViewerPanel.tsx
@@ -18,18 +18,19 @@ import {
   RefreshCw,
 } from "lucide-react";
 import type { ConnectionClient } from "../api";
-import type {
-  GitDiffEntry,
-  GitDiffFile,
-  GitDiffKind,
-  GitDiffSummary,
-} from "../types";
+import type { GitDiffEntry, GitDiffFile, GitDiffSummary } from "../types";
 import { useStoreSelector } from "../store";
 import {
   connectionClientScopeKey,
   useConnectionClient,
 } from "../useConnectionClient";
 import { connectionStorageKey } from "../connectionStorage";
+import { gitDiffCode, gitDiffCodeLabel } from "../gitDiffStatus";
+import {
+  refreshGitDiffSummary,
+  retireGitDiffSummaryResource,
+  useGitDiffSummaryState,
+} from "../gitDiffSummaryStore";
 import { diffAutoCollapseInfo } from "./diffAutoCollapse";
 
 export type ActiveDiffSelection = {
@@ -49,6 +50,8 @@ export type DiffSelectionMeta = {
 
 export type DiffViewerPanelHandle = {
   selectEntry: (entry: GitDiffEntry) => void;
+  selectWorkingEntry: (entry: GitDiffEntry) => void;
+  selectWorkingEntries: (entries: GitDiffEntry[]) => void;
 };
 
 export type DiffViewerPanelProps = {
@@ -376,6 +379,7 @@ export function clearDiffViewerResourceCache(
       diffSelectionStorageKey(client.connectionId, resourceKey, scope),
     );
   }
+  retireGitDiffSummaryResource(client, resourceKey);
   storage.removeItem(diffScopeStorageKey(client.connectionId, resourceKey));
   diffPrefetches.delete(
     connectionClientScopeKey(client, "diff-prefetch", resourceKey),
@@ -585,21 +589,6 @@ export function prefetchDiffFilesInBatches(
   ).then(() => undefined);
 }
 
-function kindLabel(kind: GitDiffKind) {
-  switch (kind) {
-    case "staged":
-      return "Staged";
-    case "unstaged":
-      return "Unstaged";
-    case "untracked":
-      return "Untracked";
-    case "conflicted":
-      return "Conflict";
-    case "branch":
-      return "Branch";
-  }
-}
-
 function diffStatsForEntries(entries: GitDiffEntry[]) {
   return entries.reduce(
     (total, entry) => ({
@@ -669,10 +658,16 @@ function treeOrderedDiffEntries(entries: GitDiffEntry[]) {
 }
 
 export function expandedDirsForSelection(entry: GitDiffEntry | null) {
+  return expandedDirsForEntries(entry ? [entry] : []);
+}
+
+export function expandedDirsForEntries(entries: GitDiffEntry[]) {
   const expanded = new Set<string>([""]);
-  const parts = entry?.path.split("/").filter(Boolean) ?? [];
-  for (let index = 1; index < parts.length; index += 1) {
-    expanded.add(parts.slice(0, index).join("/"));
+  for (const entry of entries) {
+    const parts = entry.path.split("/").filter(Boolean);
+    for (let index = 1; index < parts.length; index += 1) {
+      expanded.add(parts.slice(0, index).join("/"));
+    }
   }
   return expanded;
 }
@@ -696,10 +691,12 @@ export function prefetchDiffViewerWorkspace(
     const cacheKey = diffCacheKey(client, workspaceId, scope, resourceKey);
     let revision = diffCacheRevision(cacheKey);
     const cached = readDiffCache(client, workspaceId, scope, resourceKey);
-    const summary = (await client.call("git.diff_summary", {
-      workspace_id: workspaceId,
-      mode: scope,
-    })) as GitDiffSummary;
+    const summary = await refreshGitDiffSummary(
+      client,
+      workspaceId,
+      scope,
+      resourceKey,
+    );
     if (!client.isCurrent() || diffCacheRevision(cacheKey) !== revision) return;
     const selected = resolveSelectedEntry(
       client,
@@ -782,6 +779,12 @@ export const DiffViewerPanel = forwardRef<
   const [diffScope, setDiffScope] = useState<DiffScope>(() =>
     loadDiffScope(connectionClient.connectionId, cacheResourceKey),
   );
+  const sharedSummaryState = useGitDiffSummaryState(
+    connectionClient,
+    cacheWorkspaceId,
+    diffScope,
+    cacheResourceKey,
+  );
   const [cache, setCache] = useState<DiffCache>(() =>
     readDiffCache(
       connectionClient,
@@ -790,7 +793,8 @@ export const DiffViewerPanel = forwardRef<
       cacheResourceKey,
     ),
   );
-  const [summaryLoading, setSummaryLoading] = useState(false);
+  const [summaryRequestLoading, setSummaryRequestLoading] = useState(false);
+  const summaryLoading = summaryRequestLoading || sharedSummaryState.loading;
   const [fileLoadingKey, setFileLoadingKey] = useState<string | null>(null);
   const [expandedDirs, setExpandedDirs] = useState<Set<string>>(
     () => new Set([""]),
@@ -806,6 +810,10 @@ export const DiffViewerPanel = forwardRef<
   const selectedEntryKeyRef = useRef(
     cache.selected ? diffEntryKey(cache.selected) : "",
   );
+  const pendingWorkingEntriesRef = useRef<GitDiffEntry[]>([]);
+  const preferredSummarySelectionRef = useRef<GitDiffEntry | null>(null);
+  const diffScopeRef = useRef(diffScope);
+  diffScopeRef.current = diffScope;
   const onSelectionChangeRef = useRef(onSelectionChange);
 
   useLayoutEffect(() => {
@@ -858,6 +866,63 @@ export const DiffViewerPanel = forwardRef<
     });
   };
 
+  useEffect(() => {
+    const summary = sharedSummaryState.summary;
+    if (
+      !workspace?.workspace_id ||
+      !summary ||
+      cache.summary === summary ||
+      !isCurrentContext(workspace.workspace_id, diffScope)
+    ) {
+      return;
+    }
+    const selected = resolveSelectedEntry(
+      connectionClient,
+      workspace.workspace_id,
+      diffScope,
+      summary.entries,
+      preferredSummarySelectionRef.current ?? cache.selected,
+      cacheResourceKey,
+    );
+    preferredSummarySelectionRef.current = null;
+    advanceDiffCacheRevision(
+      diffCacheKey(
+        connectionClient,
+        workspace.workspace_id,
+        diffScope,
+        cacheResourceKey,
+      ),
+    );
+    selectedEntryKeyRef.current = selected ? diffEntryKey(selected) : "";
+    updateCache({
+      summary,
+      selected,
+      files: {},
+      fileErrors: {},
+      error: null,
+    });
+    setExpandedDirs(expandedDirsForEntries(summary.entries));
+    const pendingEntries = pendingWorkingEntriesRef.current;
+    if (diffScope === "working" && pendingEntries.length) {
+      pendingWorkingEntriesRef.current = [];
+      const currentEntries = pendingEntries.flatMap((target) => {
+        const match = summary.entries.find(
+          (entry) =>
+            entry.path === target.path &&
+            entry.kind === target.kind &&
+            entry.status === target.status,
+        );
+        return match ? [match] : [];
+      });
+      for (const target of currentEntries) {
+        void loadFileRef.current(target, { userInitiated: true });
+      }
+    }
+    // The shared snapshot is the synchronization boundary; cache adoption is
+    // intentionally driven only when that immutable snapshot changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sharedSummaryState.summary]);
+
   const diffSelection = useCallback(
     (
       source: DiffCache = cache,
@@ -871,64 +936,35 @@ export const DiffViewerPanel = forwardRef<
     onSelectionChangeRef.current?.(diffSelection(cache));
   }, [cache, diffSelection]);
 
-  const loadSummary = async (previousSelected = cache.selected) => {
+  const loadSummary = async (
+    previousSelected = cache.selected,
+    afterCurrent = false,
+  ) => {
     if (!workspace?.workspace_id || !connectionClient.isCurrent()) return;
     const workspaceId = workspace.workspace_id;
     const scope = diffScope;
-    const cacheKey = diffCacheKey(
-      connectionClient,
-      workspaceId,
-      scope,
-      cacheResourceKey,
+    preferredSummarySelectionRef.current = previousSelected;
+    advanceDiffCacheRevision(
+      diffCacheKey(connectionClient, workspaceId, scope, cacheResourceKey),
     );
-    let ownedRevision = advanceDiffCacheRevision(cacheKey);
     setFileLoadingKey(null);
-    setSummaryLoading(true);
+    setSummaryRequestLoading(true);
     updateCache({ error: null });
     try {
-      const summary = (await connectionClient.call("git.diff_summary", {
-        workspace_id: workspaceId,
-        mode: scope,
-      })) as GitDiffSummary;
-      if (
-        !isCurrentContext(workspaceId, scope) ||
-        diffCacheRevision(cacheKey) !== ownedRevision
-      ) {
-        return;
-      }
-      const selected = resolveSelectedEntry(
+      await refreshGitDiffSummary(
         connectionClient,
         workspaceId,
         scope,
-        summary.entries,
-        previousSelected,
         cacheResourceKey,
+        { afterCurrent },
       );
-      // Retire work started from the stale summary while this refresh was in
-      // flight before publishing and prefetching the replacement snapshot.
-      ownedRevision = advanceDiffCacheRevision(cacheKey);
-      selectedEntryKeyRef.current = selected ? diffEntryKey(selected) : "";
-      updateCache({
-        summary,
-        selected,
-        files: {},
-        fileErrors: {},
-      });
-      setExpandedDirs(expandedDirsForSelection(selected));
     } catch (e) {
-      if (
-        !isCurrentContext(workspaceId, scope) ||
-        diffCacheRevision(cacheKey) !== ownedRevision
-      ) {
-        return;
+      if (isCurrentContext(workspaceId, scope)) {
+        updateCache({ error: (e as Error).message });
       }
-      updateCache({ error: (e as Error).message });
     } finally {
-      if (
-        isCurrentContext(workspaceId, scope) &&
-        diffCacheRevision(cacheKey) === ownedRevision
-      ) {
-        setSummaryLoading(false);
+      if (isCurrentContext(workspaceId, scope)) {
+        setSummaryRequestLoading(false);
       }
     }
   };
@@ -1088,15 +1124,26 @@ export const DiffViewerPanel = forwardRef<
   useLayoutEffect(() => {
     loadFileRef.current = loadFile;
   });
-  useImperativeHandle(
-    ref,
-    () => ({
+  useImperativeHandle(ref, () => {
+    const selectWorkingEntries = (targets: GitDiffEntry[]) => {
+      if (!targets.length) return;
+      if (diffScopeRef.current === "working") {
+        for (const target of targets) {
+          void loadFileRef.current(target, { userInitiated: true });
+        }
+        return;
+      }
+      pendingWorkingEntriesRef.current = targets;
+      setDiffScope("working");
+    };
+    return {
       selectEntry: (target) => {
         void loadFileRef.current(target, { userInitiated: true });
       },
-    }),
-    [],
-  );
+      selectWorkingEntry: (target) => selectWorkingEntries([target]),
+      selectWorkingEntries,
+    };
+  }, []);
 
   const selectedDiffEntryKey = cache.selected
     ? diffEntryKey(cache.selected)
@@ -1123,8 +1170,16 @@ export const DiffViewerPanel = forwardRef<
     selectedEntryKeyRef.current = cached.selected
       ? diffEntryKey(cached.selected)
       : "";
+    const pendingWorkingEntries =
+      diffScope === "working" ? pendingWorkingEntriesRef.current : [];
+    const preferredWorkingEntry =
+      pendingWorkingEntries[pendingWorkingEntries.length - 1] ?? null;
     setCache(cached);
-    setExpandedDirs(expandedDirsForSelection(cached.selected));
+    setExpandedDirs(
+      expandedDirsForEntries(
+        cached.summary?.entries ?? (cached.selected ? [cached.selected] : []),
+      ),
+    );
     onSelectionChangeRef.current?.({
       entry: cached.selected,
       file: cached.selected
@@ -1137,7 +1192,7 @@ export const DiffViewerPanel = forwardRef<
       fileErrors: cached.fileErrors,
       summaryLoading: false,
     });
-    void loadSummary(cached.selected);
+    void loadSummary(preferredWorkingEntry ?? cached.selected);
     // Reopen against a fresh workspace snapshot.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cacheResourceKey, cacheWorkspaceId, connectionClient, diffScope]);
@@ -1213,6 +1268,9 @@ export const DiffViewerPanel = forwardRef<
         (entry) => diffEntryKey(entry) === selectedKey,
       );
       const stats = diffStatsForEntries(child.entries);
+      const statusCodes = Array.from(
+        new Set(child.entries.map((entry) => gitDiffCode(entry))),
+      );
       items.push(
         <button
           type="button"
@@ -1227,12 +1285,15 @@ export const DiffViewerPanel = forwardRef<
           <File size={15} />
           <span className="diff-tree-name">{child.name}</span>
           <span className="diff-tree-badges">
-            {child.entries.map((entry) => (
+            {statusCodes.map((code) => (
               <span
-                className={`diff-kind diff-kind-${entry.kind}`}
-                key={diffEntryKey(entry)}
+                className={`git-status-code git-status-${code.toLowerCase()}`}
+                key={code}
+                role="img"
+                aria-label={gitDiffCodeLabel(code)}
+                title={gitDiffCodeLabel(code)}
               >
-                {kindLabel(entry.kind)}
+                {code}
               </span>
             ))}
           </span>
@@ -1274,7 +1335,7 @@ export const DiffViewerPanel = forwardRef<
           aria-label={summaryLoading ? "Refreshing changes" : "Refresh changes"}
           aria-busy={summaryLoading}
           disabled={summaryLoading}
-          onClick={() => void loadSummary()}
+          onClick={() => void loadSummary(cache.selected, true)}
         >
           <RefreshCw
             className={summaryLoading ? "is-spinning" : ""}

--- a/web/src/components/DiffViewerPanel.tsx
+++ b/web/src/components/DiffViewerPanel.tsx
@@ -793,8 +793,7 @@ export const DiffViewerPanel = forwardRef<
       cacheResourceKey,
     ),
   );
-  const [summaryRequestLoading, setSummaryRequestLoading] = useState(false);
-  const summaryLoading = summaryRequestLoading || sharedSummaryState.loading;
+  const summaryLoading = sharedSummaryState.loading;
   const [fileLoadingKey, setFileLoadingKey] = useState<string | null>(null);
   const [expandedDirs, setExpandedDirs] = useState<Set<string>>(
     () => new Set([""]),
@@ -948,7 +947,6 @@ export const DiffViewerPanel = forwardRef<
       diffCacheKey(connectionClient, workspaceId, scope, cacheResourceKey),
     );
     setFileLoadingKey(null);
-    setSummaryRequestLoading(true);
     updateCache({ error: null });
     try {
       await refreshGitDiffSummary(
@@ -961,10 +959,6 @@ export const DiffViewerPanel = forwardRef<
     } catch (e) {
       if (isCurrentContext(workspaceId, scope)) {
         updateCache({ error: (e as Error).message });
-      }
-    } finally {
-      if (isCurrentContext(workspaceId, scope)) {
-        setSummaryRequestLoading(false);
       }
     }
   };

--- a/web/src/components/FileExplorerDialog.test.ts
+++ b/web/src/components/FileExplorerDialog.test.ts
@@ -76,6 +76,29 @@ describe("file explorer git status", () => {
     expect(status?.label).toBe("Modified");
     expect(status?.codes).toEqual(["M"]);
   });
+
+  test("sorts file and directory status codes independently of summary order", () => {
+    const summary: GitDiffSummary = {
+      workspace_id: "workspace",
+      root: "/repo",
+      entries: [
+        { path: "src/app.ts", kind: "unstaged", status: "modified" },
+        { path: "src/new.ts", kind: "untracked", status: "untracked" },
+        { path: "src/app.ts", kind: "staged", status: "added" },
+      ],
+      counts: {
+        staged: 1,
+        unstaged: 1,
+        untracked: 1,
+        conflicted: 0,
+        branch: 0,
+      },
+    };
+
+    const maps = buildGitStatusMaps(summary, "/repo");
+    expect(maps.fileStatuses.get("src/app.ts")?.codes).toEqual(["A", "M"]);
+    expect(maps.directoryStatuses.get("src")?.codes).toEqual(["A", "M", "U"]);
+  });
 });
 
 describe("connection-scoped file prefetch", () => {

--- a/web/src/components/FileExplorerDialog.test.ts
+++ b/web/src/components/FileExplorerDialog.test.ts
@@ -57,7 +57,7 @@ describe("file explorer git status", () => {
     const summary: GitDiffSummary = {
       workspace_id: "workspace",
       root: "/repo",
-      entries: [unstaged, staged],
+      entries: [staged, unstaged],
       counts: {
         staged: 1,
         unstaged: 1,

--- a/web/src/components/FileExplorerDialog.test.ts
+++ b/web/src/components/FileExplorerDialog.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import type { ConnectionClient } from "../api";
-import type { FilePreview } from "../types";
+import type { FilePreview, GitDiffEntry, GitDiffSummary } from "../types";
 import {
+  buildGitStatusMaps,
   clearFileExplorerResourceCache,
   explorerCacheKey,
   explorerRuntimeContextKey,
   filePreviewCacheKey,
+  invalidateFilePreviewCache,
   prefetchFileExplorerWorkspace,
   requestFilePreview,
 } from "./FileExplorerDialog";
@@ -39,6 +41,42 @@ function client(
     acceptsServerGeneration: (value) => value === generation,
   };
 }
+
+describe("file explorer git status", () => {
+  test("preserves every diff entry for a partially staged file", () => {
+    const unstaged: GitDiffEntry = {
+      path: "src/components/App.tsx",
+      kind: "unstaged",
+      status: "modified",
+    };
+    const staged: GitDiffEntry = {
+      path: unstaged.path,
+      kind: "staged",
+      status: "modified",
+    };
+    const summary: GitDiffSummary = {
+      workspace_id: "workspace",
+      root: "/repo",
+      entries: [unstaged, staged],
+      counts: {
+        staged: 1,
+        unstaged: 1,
+        untracked: 0,
+        conflicted: 0,
+        branch: 0,
+      },
+    };
+
+    const status = buildGitStatusMaps(summary, "/repo").fileStatuses.get(
+      unstaged.path,
+    );
+
+    expect(status?.entry).toBe(staged);
+    expect(status?.entries).toEqual([unstaged, staged]);
+    expect(status?.label).toBe("Modified");
+    expect(status?.codes).toEqual(["M"]);
+  });
+});
 
 describe("connection-scoped file prefetch", () => {
   test("a retired prefetch cannot replace or detach its successor", async () => {
@@ -140,31 +178,55 @@ describe("connection-scoped file previews", () => {
     expect(calls).toBe(2);
   });
 
-  test("supersedes an in-flight preview when a refresh starts", async () => {
-    const resolvers: Array<(value: FilePreview) => void> = [];
+  test("deduplicates concurrent refresh consumers", async () => {
+    let resolvePreview: ((value: FilePreview) => void) | undefined;
     let calls = 0;
     const scopedClient = client("refresh-in-flight", 1, () => {
       calls += 1;
-      return new Promise<FilePreview>((resolve) => resolvers.push(resolve));
+      return new Promise<FilePreview>((resolve) => {
+        resolvePreview = resolve;
+      });
     });
 
-    const stale = requestFilePreview("same", "same.txt", {
+    const initial = requestFilePreview("same", "same.txt", {
       client: scopedClient,
     });
-    const fresh = requestFilePreview("same", "same.txt", {
+    const refresh = requestFilePreview("same", "same.txt", {
       client: scopedClient,
       refresh: true,
     });
-    expect(calls).toBe(2);
+    expect(refresh).toBe(initial);
+    expect(calls).toBe(1);
 
-    resolvers[0]?.(preview("stale"));
-    await expect(stale).rejects.toThrow("superseded");
-    resolvers[1]?.(preview("fresh"));
-    await expect(fresh).resolves.toMatchObject({ text: "fresh" });
-    await expect(
-      requestFilePreview("same", "same.txt", { client: scopedClient }),
-    ).resolves.toMatchObject({ text: "fresh" });
-    expect(calls).toBe(2);
+    resolvePreview?.(preview("shared"));
+    await expect(initial).resolves.toMatchObject({ text: "shared" });
+    await expect(refresh).resolves.toMatchObject({ text: "shared" });
+    expect(calls).toBe(1);
+  });
+
+  test("invalidates cached descendants without touching sibling paths", async () => {
+    let calls = 0;
+    const scopedClient = client(
+      "invalidate-directory",
+      1,
+      async (_method, params) => {
+        calls += 1;
+        return preview(String(params?.path));
+      },
+    );
+    for (const path of ["dir/a.txt", "dir/nested/b.txt", "dir-two/c.txt"]) {
+      await requestFilePreview("same", path, { client: scopedClient });
+    }
+    invalidateFilePreviewCache(scopedClient, "same", "dir", true);
+
+    await requestFilePreview("same", "dir/a.txt", { client: scopedClient });
+    await requestFilePreview("same", "dir/nested/b.txt", {
+      client: scopedClient,
+    });
+    await requestFilePreview("same", "dir-two/c.txt", {
+      client: scopedClient,
+    });
+    expect(calls).toBe(5);
   });
 
   test("evicts old previews when their estimated memory exceeds the budget", async () => {

--- a/web/src/components/FileExplorerDialog.tsx
+++ b/web/src/components/FileExplorerDialog.tsx
@@ -500,11 +500,17 @@ export function buildGitStatusMaps(
     const currentDescriptions = descriptions.get(mappedPath) ?? [];
     currentDescriptions.push(next.title);
     descriptions.set(mappedPath, currentDescriptions);
-    if (!existing || next.priority > existing.priority) {
-      fileStatuses.set(mappedPath, next);
-    } else {
+    const preferred =
+      !existing || next.priority > existing.priority ? next : existing;
+    const orderedEntries = [
+      ...entries.filter((candidate) => candidate !== preferred.entry),
+      ...(preferred.entry ? [preferred.entry] : []),
+    ];
+    if (preferred === next) {
+      fileStatuses.set(mappedPath, { ...next, entries: orderedEntries });
+    } else if (existing) {
       existing.codes = codes;
-      existing.entries = entries;
+      existing.entries = orderedEntries;
     }
 
     const parts = mappedPath.split("/").filter(Boolean);
@@ -1037,17 +1043,13 @@ function FileExplorerContent({
     () => buildGitStatusMaps(gitSummaryState.summary, rootInfo?.root),
     [gitSummaryState.summary, rootInfo?.root],
   );
-  const activeDiffEntries = useMemo(() => {
-    const status = activePath
-      ? gitStatusMaps.fileStatuses.get(activePath)
-      : undefined;
-    return status
-      ? [
-          ...(status.entries ?? []).filter((entry) => entry !== status.entry),
-          ...(status.entry ? [status.entry] : []),
-        ]
-      : [];
-  }, [activePath, gitStatusMaps]);
+  const activeDiffEntries = useMemo(
+    () =>
+      activePath
+        ? (gitStatusMaps.fileStatuses.get(activePath)?.entries ?? [])
+        : [],
+    [activePath, gitStatusMaps],
+  );
   const emitPreviewChange = (
     selection: ActiveFilePreviewSelection,
     meta?: FilePreviewSelectionMeta,

--- a/web/src/components/FileExplorerDialog.tsx
+++ b/web/src/components/FileExplorerDialog.tsx
@@ -486,7 +486,7 @@ export function buildGitStatusMaps(
     const existing = fileStatuses.get(mappedPath);
     const codes = Array.from(
       new Set([...(existing?.codes ?? []), gitDiffCode(entry)]),
-    );
+    ).sort();
     const entries = [...(existing?.entries ?? []), entry];
     const next: FileGitStatus = {
       label: gitStatusLabel(entry),
@@ -543,7 +543,7 @@ export function buildGitStatusMaps(
       tone: "directory",
       priority: 10,
       count,
-      codes: Array.from(directoryCodes.get(path) ?? []),
+      codes: Array.from(directoryCodes.get(path) ?? []).sort(),
     });
   }
 

--- a/web/src/components/FileExplorerDialog.tsx
+++ b/web/src/components/FileExplorerDialog.tsx
@@ -1,5 +1,6 @@
 import {
   type DragEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
   useEffect,
   useMemo,
@@ -22,6 +23,12 @@ import type { ConnectionClient } from "../api";
 import { connectionHttpPath } from "../connectionHttp";
 import { connectionStorageKey } from "../connectionStorage";
 import { downloadFileFromUrl } from "../downloadFile";
+import { gitDiffCode, type GitDiffCode } from "../gitDiffStatus";
+import {
+  refreshGitDiffSummary,
+  retireGitDiffSummaryResource,
+  useGitDiffSummaryState,
+} from "../gitDiffSummaryStore";
 import { store, useStoreSelector } from "../store";
 import {
   connectionClientScopeKey,
@@ -37,6 +44,11 @@ import type {
 } from "../types";
 import { CloseButton } from "./CloseButton";
 import { ConfirmDialog } from "./ModalDialogs";
+import {
+  focusTreeItem,
+  keyboardContextMenuPoint,
+  treeKeyboardAction,
+} from "./treeKeyboard";
 import {
   FilePreviewContent,
   type ActiveFilePreviewSelection,
@@ -82,6 +94,9 @@ type FileGitStatus = {
   tone: string;
   priority: number;
   count?: number;
+  entry?: GitDiffEntry;
+  entries?: GitDiffEntry[];
+  codes: GitDiffCode[];
 };
 
 const explorerCache = new Map<string, FileExplorerCache>();
@@ -148,6 +163,7 @@ export function clearFileExplorerResourceCache(
     const key = explorerCacheKey(client, undefined, showHidden, resourceKey);
     retireExplorerCache(key);
   }
+  retireGitDiffSummaryResource(client, resourceKey);
   storage.removeItem(
     connectionStorageKey(
       client.connectionId,
@@ -237,22 +253,89 @@ function readCachedPreview(key: string) {
   return preview;
 }
 
-function writeCachedPreview(key: string, preview: FilePreview) {
+function removeCachedPreview(key: string, retireRequest = false) {
   const existing = previewCache.get(key);
-  if (existing) previewCacheBytes -= estimatedPreviewBytes(existing);
+  if (existing) {
+    previewCacheBytes = Math.max(
+      0,
+      previewCacheBytes - estimatedPreviewBytes(existing),
+    );
+  }
   previewCache.delete(key);
+  if (retireRequest) {
+    const running = previewRequests.has(key);
+    previewRequests.delete(key);
+    if (running) {
+      previewRequestRevisions.set(
+        key,
+        (previewRequestRevisions.get(key) ?? 0) + 1,
+      );
+    } else {
+      previewRequestRevisions.delete(key);
+    }
+  } else if (!previewRequests.has(key)) {
+    previewRequestRevisions.delete(key);
+  }
+}
+
+function previewCacheKeyParts(key: string) {
+  try {
+    const parts = JSON.parse(key) as unknown[];
+    if (
+      typeof parts[0] !== "string" ||
+      typeof parts[1] !== "number" ||
+      parts[2] !== "preview" ||
+      typeof parts[3] !== "string" ||
+      typeof parts[4] !== "string"
+    ) {
+      return null;
+    }
+    return {
+      connectionId: parts[0],
+      generation: parts[1],
+      workspaceId: parts[3],
+      path: parts[4],
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function invalidateFilePreviewCache(
+  client: Pick<ConnectionClient, "connectionId" | "generation">,
+  workspaceId: string,
+  path: string,
+  recursive = false,
+) {
+  const keys = new Set([...previewCache.keys(), ...previewRequests.keys()]);
+  for (const key of keys) {
+    const parts = previewCacheKeyParts(key);
+    if (
+      !parts ||
+      parts.connectionId !== client.connectionId ||
+      parts.generation !== client.generation ||
+      parts.workspaceId !== workspaceId
+    ) {
+      continue;
+    }
+    if (
+      parts.path === path ||
+      (recursive && parts.path.startsWith(`${path}/`))
+    ) {
+      removeCachedPreview(key, true);
+    }
+  }
+}
+
+function writeCachedPreview(key: string, preview: FilePreview) {
+  removeCachedPreview(key);
   previewCache.set(key, preview);
   previewCacheBytes += estimatedPreviewBytes(preview);
 
   while (previewCacheBytes > MAX_PREVIEW_CACHE_BYTES && previewCache.size > 1) {
     const oldestKey = previewCache.keys().next().value;
     if (typeof oldestKey !== "string") break;
-    const oldest = previewCache.get(oldestKey);
-    previewCache.delete(oldestKey);
-    if (!previewRequests.has(oldestKey)) {
-      previewRequestRevisions.delete(oldestKey);
-    }
-    if (oldest) previewCacheBytes -= estimatedPreviewBytes(oldest);
+    removeCachedPreview(oldestKey);
   }
 }
 
@@ -379,12 +462,13 @@ function gitKindLabel(kind: GitDiffKind) {
   }
 }
 
-function buildGitStatusMaps(
+export function buildGitStatusMaps(
   summary: GitDiffSummary | null,
   explorerRoot?: string,
 ) {
   const fileStatuses = new Map<string, FileGitStatus>();
   const directoryChangedFiles = new Map<string, Set<string>>();
+  const directoryCodes = new Map<string, Set<GitDiffCode>>();
   if (!summary || !explorerRoot)
     return {
       fileStatuses,
@@ -400,17 +484,27 @@ function buildGitStatusMaps(
     );
     if (!mappedPath) continue;
     const existing = fileStatuses.get(mappedPath);
+    const codes = Array.from(
+      new Set([...(existing?.codes ?? []), gitDiffCode(entry)]),
+    );
+    const entries = [...(existing?.entries ?? []), entry];
     const next: FileGitStatus = {
       label: gitStatusLabel(entry),
       title: `${gitKindLabel(entry.kind)} ${entry.status}`,
       tone: gitStatusTone(entry),
       priority: gitStatusPriority(entry),
+      entry,
+      entries,
+      codes,
     };
     const currentDescriptions = descriptions.get(mappedPath) ?? [];
     currentDescriptions.push(next.title);
     descriptions.set(mappedPath, currentDescriptions);
     if (!existing || next.priority > existing.priority) {
       fileStatuses.set(mappedPath, next);
+    } else {
+      existing.codes = codes;
+      existing.entries = entries;
     }
 
     const parts = mappedPath.split("/").filter(Boolean);
@@ -420,6 +514,10 @@ function buildGitStatusMaps(
         directoryChangedFiles.get(directory) ?? new Set<string>();
       changedFiles.add(mappedPath);
       directoryChangedFiles.set(directory, changedFiles);
+      const codesBelow =
+        directoryCodes.get(directory) ?? new Set<GitDiffCode>();
+      codesBelow.add(gitDiffCode(entry));
+      directoryCodes.set(directory, codesBelow);
     }
   }
 
@@ -439,6 +537,7 @@ function buildGitStatusMaps(
       tone: "directory",
       priority: 10,
       count,
+      codes: Array.from(directoryCodes.get(path) ?? []),
     });
   }
 
@@ -458,7 +557,7 @@ export function requestFilePreview(
   const cached = readCachedPreview(key);
   if (cached && !options.refresh) return Promise.resolve(cached);
   const running = previewRequests.get(key);
-  if (running && !options.refresh) return running;
+  if (running) return running;
 
   const revision = (previewRequestRevisions.get(key) ?? 0) + 1;
   previewRequestRevisions.set(key, revision);
@@ -480,7 +579,9 @@ export function requestFilePreview(
     .finally(() => {
       if (previewRequests.get(key) === scopedTask) {
         previewRequests.delete(key);
-        if (!previewCache.has(key)) previewRequestRevisions.delete(key);
+      }
+      if (!previewCache.has(key) && !previewRequests.has(key)) {
+        previewRequestRevisions.delete(key);
       }
     });
   previewRequests.set(key, scopedTask);
@@ -670,19 +771,23 @@ export function FileExplorerPanel({
   resourceKey,
   initialDirectory,
   activePath,
+  keyboardActive = false,
   onClose,
   onPreviewChange,
+  onActiveDiffEntriesChange,
 }: {
   open: boolean;
   workspaceId?: string;
   resourceKey?: string;
   initialDirectory?: string;
   activePath?: string;
+  keyboardActive?: boolean;
   onClose: () => void;
   onPreviewChange?: (
     selection: ActiveFilePreviewSelection,
     meta?: FilePreviewSelectionMeta,
   ) => void;
+  onActiveDiffEntriesChange?: (entries: GitDiffEntry[]) => void;
 }) {
   if (!open) return null;
 
@@ -697,7 +802,9 @@ export function FileExplorerPanel({
         showCloseButton={false}
         previewPlacement="external"
         activePath={activePath}
+        keyboardActive={keyboardActive}
         onPreviewChange={onPreviewChange}
+        onActiveDiffEntriesChange={onActiveDiffEntriesChange}
       />
     </aside>
   );
@@ -723,27 +830,57 @@ function FileExplorerEntryMenu({
   onDelete: (entry: FileExplorerEntry) => void;
 }) {
   const ref = useRef<HTMLDivElement>(null);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
 
   useEffect(() => {
     if (!state) return;
+    const previousFocus = document.activeElement as HTMLElement | null;
+    const close = () => onCloseRef.current();
     const onDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+      if (ref.current && !ref.current.contains(e.target as Node)) close();
     };
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      if (e.key === "Escape" || e.key === "Tab") {
+        e.preventDefault();
+        close();
+        return;
+      }
+      if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(e.key)) return;
+      const buttons = Array.from(
+        ref.current?.querySelectorAll<HTMLButtonElement>("[role='menuitem']") ??
+          [],
+      );
+      const currentIndex = buttons.indexOf(
+        document.activeElement as HTMLButtonElement,
+      );
+      if (!buttons.length || currentIndex < 0) return;
+      e.preventDefault();
+      const nextIndex =
+        e.key === "Home"
+          ? 0
+          : e.key === "End"
+            ? buttons.length - 1
+            : e.key === "ArrowDown"
+              ? (currentIndex + 1) % buttons.length
+              : (currentIndex - 1 + buttons.length) % buttons.length;
+      buttons[nextIndex]?.focus();
     };
     const t = setTimeout(() => {
       window.addEventListener("mousedown", onDown);
       window.addEventListener("keydown", onKey);
-      window.addEventListener("scroll", onClose, true);
+      window.addEventListener("scroll", close, true);
+      ref.current?.querySelector<HTMLButtonElement>("button")?.focus();
     }, 0);
     return () => {
       clearTimeout(t);
       window.removeEventListener("mousedown", onDown);
       window.removeEventListener("keydown", onKey);
-      window.removeEventListener("scroll", onClose, true);
+      window.removeEventListener("scroll", close, true);
+      if (previousFocus?.isConnected)
+        previousFocus.focus({ preventScroll: true });
     };
-  }, [state, onClose]);
+  }, [state]);
 
   if (!state) return null;
 
@@ -780,11 +917,12 @@ function FileExplorerEntryMenu({
   };
 
   return (
-    <div ref={ref} className="context-menu" style={style}>
+    <div ref={ref} className="context-menu" style={style} role="menu">
       {items.map((item) => (
         <button
           key={item.label}
           className={`context-menu-item ${item.danger ? "is-danger" : ""}`}
+          role="menuitem"
           onClick={() => {
             onClose();
             item.action();
@@ -806,7 +944,9 @@ function FileExplorerContent({
   showCloseButton,
   previewPlacement = "inline",
   activePath,
+  keyboardActive = false,
   onPreviewChange,
+  onActiveDiffEntriesChange,
 }: {
   open: boolean;
   workspaceId?: string;
@@ -816,10 +956,12 @@ function FileExplorerContent({
   showCloseButton: boolean;
   previewPlacement?: "inline" | "external";
   activePath?: string;
+  keyboardActive?: boolean;
   onPreviewChange?: (
     selection: ActiveFilePreviewSelection,
     meta?: FilePreviewSelectionMeta,
   ) => void;
+  onActiveDiffEntriesChange?: (entries: GitDiffEntry[]) => void;
 }) {
   const workspaces = useStoreSelector((state) => state.workspaces);
   const connectionClient = useConnectionClient();
@@ -859,22 +1001,24 @@ function FileExplorerContent({
   );
   const [pendingDeleteEntry, setPendingDeleteEntry] =
     useState<FileExplorerEntry | null>(null);
-  const [gitSummary, setGitSummary] = useState<GitDiffSummary | null>(null);
-  const [gitStatusLoading, setGitStatusLoading] = useState(false);
   const [previewEntry, setPreviewEntry] = useState<FileExplorerEntry | null>(
     null,
   );
   const [preview, setPreview] = useState<FilePreview | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
+  const [focusedTreePath, setFocusedTreePath] = useState<string | null>(
+    activePath ?? null,
+  );
+  const [treeHasFocus, setTreeHasFocus] = useState(false);
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const longPressStart = useRef<{ x: number; y: number } | null>(null);
   const longPressTriggered = useRef(false);
-  const gitStatusRequestKeyRef = useRef<string | null>(null);
   const previewRequestKeyRef = useRef<string | null>(null);
   const previewRequestSequenceRef = useRef(0);
   const previousCacheResourceKeyRef = useRef<string | undefined>(undefined);
   const fileTreeRef = useRef<HTMLDivElement | null>(null);
+  const treeAutoFocusAppliedRef = useRef(false);
   const runtimeContext = explorerRuntimeContextKey(
     connectionClient,
     cacheWorkspaceId,
@@ -883,10 +1027,27 @@ function FileExplorerContent({
   const runtimeContextRef = useRef(runtimeContext);
   runtimeContextRef.current = runtimeContext;
   const { search, rootInfo, children, expanded, error } = cache;
-  const gitStatusMaps = useMemo(
-    () => buildGitStatusMaps(gitSummary, rootInfo?.root),
-    [gitSummary, rootInfo?.root],
+  const gitSummaryState = useGitDiffSummaryState(
+    connectionClient,
+    cacheWorkspaceId,
+    "working",
+    cacheResourceKey,
   );
+  const gitStatusMaps = useMemo(
+    () => buildGitStatusMaps(gitSummaryState.summary, rootInfo?.root),
+    [gitSummaryState.summary, rootInfo?.root],
+  );
+  const activeDiffEntries = useMemo(() => {
+    const status = activePath
+      ? gitStatusMaps.fileStatuses.get(activePath)
+      : undefined;
+    return status
+      ? [
+          ...(status.entries ?? []).filter((entry) => entry !== status.entry),
+          ...(status.entry ? [status.entry] : []),
+        ]
+      : [];
+  }, [activePath, gitStatusMaps]);
   const emitPreviewChange = (
     selection: ActiveFilePreviewSelection,
     meta?: FilePreviewSelectionMeta,
@@ -899,6 +1060,10 @@ function FileExplorerContent({
   useEffect(() => {
     localStorage.setItem(showHiddenStorageKey, String(showHidden));
   }, [showHidden, showHiddenStorageKey]);
+
+  useEffect(() => {
+    onActiveDiffEntriesChange?.(activeDiffEntries);
+  }, [activeDiffEntries, onActiveDiffEntriesChange]);
 
   const updateCache = (patch: Partial<FileExplorerCache>) => {
     setCache((current) => {
@@ -985,47 +1150,18 @@ function FileExplorerContent({
     }
   };
 
-  const loadGitStatus = async () => {
-    if (!connectionClient.isCurrent()) return;
-    if (!workspace?.workspace_id) {
-      gitStatusRequestKeyRef.current = null;
-      setGitSummary(null);
-      setGitStatusLoading(false);
-      return;
-    }
-    const workspaceId = workspace.workspace_id;
-    const requestKey = connectionClientScopeKey(
-      connectionClient,
-      "git-status",
-      workspaceId,
-    );
-    gitStatusRequestKeyRef.current = requestKey;
-    setGitStatusLoading(true);
+  const loadGitStatus = async (afterCurrent = false) => {
+    if (!connectionClient.isCurrent() || !workspace?.workspace_id) return;
     try {
-      const summary = (await connectionClient.call("git.diff_summary", {
-        workspace_id: workspaceId,
-        mode: "working",
-      })) as GitDiffSummary;
-      if (
-        connectionClient.isCurrent() &&
-        gitStatusRequestKeyRef.current === requestKey
-      ) {
-        setGitSummary(summary);
-      }
+      await refreshGitDiffSummary(
+        connectionClient,
+        workspace.workspace_id,
+        "working",
+        cacheResourceKey,
+        { afterCurrent },
+      );
     } catch {
-      if (
-        connectionClient.isCurrent() &&
-        gitStatusRequestKeyRef.current === requestKey
-      ) {
-        setGitSummary(null);
-      }
-    } finally {
-      if (
-        connectionClient.isCurrent() &&
-        gitStatusRequestKeyRef.current === requestKey
-      ) {
-        setGitStatusLoading(false);
-      }
+      // Git status is supplementary; keep the file explorer usable on failure.
     }
   };
 
@@ -1069,9 +1205,6 @@ function FileExplorerContent({
     setDropTargetPath(null);
     setEntryMenu(null);
     setPendingDeleteEntry(null);
-    setGitSummary(null);
-    setGitStatusLoading(false);
-    gitStatusRequestKeyRef.current = null;
     if (resourceChanged && !activePath) {
       setPreviewEntry(null);
       setPreview(null);
@@ -1257,13 +1390,22 @@ function FileExplorerContent({
         }),
     [children],
   );
-  const searchEntries = query
-    ? loadedEntries.filter((entry) =>
-        [entry.name, entry.path].some((value) =>
-          value.toLowerCase().includes(query),
-        ),
-      )
-    : [];
+  const searchEntries = useMemo(
+    () =>
+      query
+        ? loadedEntries.filter((entry) =>
+            [entry.name, entry.path].some((value) =>
+              value.toLowerCase().includes(query),
+            ),
+          )
+        : [],
+    [loadedEntries, query],
+  );
+
+  useEffect(() => {
+    if (!activePath || !isWorkspaceRelativePath(activePath)) return;
+    setFocusedTreePath(activePath);
+  }, [activePath]);
 
   useEffect(() => {
     if (!activePath || !isWorkspaceRelativePath(activePath)) return;
@@ -1274,6 +1416,57 @@ function FileExplorerContent({
     ).find((candidate) => candidate.dataset.filePath === activePath);
     row?.scrollIntoView({ block: "nearest" });
   }, [activePath, children, expanded, query]);
+
+  useEffect(() => {
+    const items = Array.from(
+      fileTreeRef.current?.querySelectorAll<HTMLElement>(
+        ".file-row[role='treeitem']",
+      ) ?? [],
+    );
+    if (!items.length) {
+      if (focusedTreePath !== null) setFocusedTreePath(null);
+      return;
+    }
+    if (
+      focusedTreePath &&
+      items.some((item) => item.dataset.filePath === focusedTreePath)
+    ) {
+      return;
+    }
+    const next =
+      items.find((item) => item.dataset.filePath === activePath) ?? items[0];
+    setFocusedTreePath(next?.dataset.filePath ?? null);
+  }, [activePath, children, expanded, focusedTreePath, query, searchEntries]);
+
+  useEffect(() => {
+    if (!keyboardActive) {
+      treeAutoFocusAppliedRef.current = false;
+      return;
+    }
+    if (treeAutoFocusAppliedRef.current) return;
+    const tree = fileTreeRef.current;
+    const items = Array.from(
+      tree?.querySelectorAll<HTMLElement>(".file-row[role='treeitem']") ?? [],
+    );
+    if (!tree || !items.length) return;
+    const focusedElement = document.activeElement as HTMLElement | null;
+    const content = tree.closest(".file-explorer-content");
+    if (
+      focusedElement &&
+      (content?.contains(focusedElement) ||
+        focusedElement.closest("[role='tab']"))
+    ) {
+      treeAutoFocusAppliedRef.current = true;
+      return;
+    }
+    const target =
+      items.find((item) => item.dataset.filePath === focusedTreePath) ??
+      items.find((item) => item.dataset.filePath === activePath) ??
+      items[0];
+    target?.focus({ preventScroll: true });
+    target?.scrollIntoView({ block: "nearest" });
+    treeAutoFocusAppliedRef.current = true;
+  }, [activePath, children, focusedTreePath, keyboardActive]);
 
   const toggleDirectory = (path: string) => {
     const next = new Set(expanded);
@@ -1288,6 +1481,9 @@ function FileExplorerContent({
 
   const loadPreview = async (entry: FileExplorerEntry) => {
     if (!workspace?.workspace_id || entry.type === "directory") return;
+    onActiveDiffEntriesChange?.(
+      gitStatusMaps.fileStatuses.get(entry.path)?.entries ?? [],
+    );
     const workspaceId = workspace.workspace_id;
     const key = filePreviewCacheKey(connectionClient, workspaceId, entry.path);
     const requestKey = `${key}:${++previewRequestSequenceRef.current}`;
@@ -1453,18 +1649,12 @@ function FileExplorerContent({
       selectedPath === entry.path ||
       (entry.type === "directory" &&
         selectedPath?.startsWith(`${entry.path}/`));
-    const cacheKey = filePreviewCacheKey(
+    invalidateFilePreviewCache(
       connectionClient,
       workspace.workspace_id,
       entry.path,
+      entry.type === "directory",
     );
-    previewCache.delete(cacheKey);
-    if (entry.type === "directory") {
-      const childCacheKeyPrefix = `${cacheKey}/`;
-      for (const key of previewCache.keys()) {
-        if (key.startsWith(childCacheKeyPrefix)) previewCache.delete(key);
-      }
-    }
     if (!deletedSelection) return;
     setPreviewEntry(null);
     setPreview(null);
@@ -1492,7 +1682,7 @@ function FileExplorerContent({
       clearDeletedPreview(entry);
       await loadDirectory(parentDirectoryPath(entry.path), true);
       if (!runtimeContextIsCurrent(requestContext)) return;
-      void loadGitStatus();
+      void loadGitStatus(true);
       store.notify({
         kind: "success",
         message:
@@ -1517,8 +1707,10 @@ function FileExplorerContent({
   const invalidateUploadedPreviews = (paths: string[]) => {
     if (!workspace?.workspace_id || !paths.length) return;
     for (const path of paths) {
-      previewCache.delete(
-        filePreviewCacheKey(connectionClient, workspace.workspace_id, path),
+      invalidateFilePreviewCache(
+        connectionClient,
+        workspace.workspace_id,
+        path,
       );
     }
     if (previewEntry && paths.includes(previewEntry.path)) {
@@ -1572,7 +1764,7 @@ function FileExplorerContent({
           result.status === "fulfilled" ? [result.value.path] : [],
         ),
       );
-      void loadGitStatus();
+      void loadGitStatus(true);
       const uploaded = results.length;
       store.notify({
         kind: "success",
@@ -1668,7 +1860,85 @@ function FileExplorerContent({
     longPressStart.current = null;
   };
 
-  const renderEntry = (entry: FileExplorerEntry, depth: number) => {
+  const activateEntry = (entry: FileExplorerEntry) => {
+    if (entry.type === "directory") toggleDirectory(entry.path);
+    else void loadPreview(entry);
+  };
+
+  const focusFirstChild = (current: HTMLElement) => {
+    const items = Array.from(
+      fileTreeRef.current?.querySelectorAll<HTMLElement>(
+        ".file-row[role='treeitem']",
+      ) ?? [],
+    );
+    const index = items.indexOf(current);
+    const child = items[index + 1];
+    if (
+      !child ||
+      Number(child.getAttribute("aria-level")) !==
+        Number(current.getAttribute("aria-level")) + 1
+    ) {
+      return;
+    }
+    current.tabIndex = -1;
+    child.tabIndex = 0;
+    child.focus({ preventScroll: true });
+    child.scrollIntoView({ block: "nearest" });
+  };
+
+  const handleEntryKeyDown = (
+    event: ReactKeyboardEvent<HTMLDivElement>,
+    entry: FileExplorerEntry,
+    isDirectory: boolean,
+    isExpanded: boolean,
+  ) => {
+    if (event.target !== event.currentTarget) return;
+    const action = treeKeyboardAction(event.key, event.shiftKey);
+    if (!action) return;
+    event.preventDefault();
+
+    if (
+      action === "next" ||
+      action === "previous" ||
+      action === "first" ||
+      action === "last"
+    ) {
+      focusTreeItem(event.currentTarget, action);
+      return;
+    }
+    if (action === "expand") {
+      if (isDirectory && !isExpanded) toggleDirectory(entry.path);
+      else if (isDirectory) focusFirstChild(event.currentTarget);
+      return;
+    }
+    if (action === "collapse") {
+      if (isDirectory && isExpanded) {
+        toggleDirectory(entry.path);
+        return;
+      }
+      const parentPath = parentDirectoryPath(entry.path);
+      const parent = Array.from(
+        fileTreeRef.current?.querySelectorAll<HTMLElement>(
+          ".file-row[role='treeitem']",
+        ) ?? [],
+      ).find((candidate) => candidate.dataset.filePath === parentPath);
+      parent?.focus({ preventScroll: true });
+      parent?.scrollIntoView({ block: "nearest" });
+      return;
+    }
+    event.stopPropagation();
+    if (action === "activate") activateEntry(entry);
+    else {
+      const point = keyboardContextMenuPoint(event.currentTarget);
+      openEntryMenu(entry, point.x, point.y);
+    }
+  };
+
+  const renderEntry = (
+    entry: FileExplorerEntry,
+    depth: number,
+    defaultTabStop = false,
+  ) => {
     const isDirectory = entry.type === "directory";
     const uploadDirectory = isDirectory
       ? entry.path
@@ -1689,13 +1959,30 @@ function FileExplorerContent({
         <div
           className={`file-row ${
             previewEntry?.path === entry.path ? "is-selected" : ""
-          } ${dropTargetPath === entry.path && isDirectory ? "is-drop-target" : ""} ${
-            uploading && isDirectory ? "is-uploading" : ""
-          }`}
+          } ${
+            treeHasFocus && focusedTreePath === entry.path ? "is-focused" : ""
+          } ${
+            dropTargetPath === entry.path && isDirectory ? "is-drop-target" : ""
+          } ${uploading && isDirectory ? "is-uploading" : ""}`}
           data-file-path={entry.path}
+          data-parent-path={parentDirectoryPath(entry.path)}
+          role="treeitem"
+          tabIndex={
+            focusedTreePath === entry.path ||
+            (!focusedTreePath && defaultTabStop)
+              ? 0
+              : -1
+          }
+          aria-level={depth + 1}
+          aria-selected={previewEntry?.path === entry.path}
+          aria-expanded={isDirectory ? isExpanded : undefined}
           style={{
             paddingLeft: FILE_TREE_BASE_INDENT + depth * FILE_TREE_INDENT,
           }}
+          onFocus={() => setFocusedTreePath(entry.path)}
+          onKeyDown={(event) =>
+            handleEntryKeyDown(event, entry, isDirectory, isExpanded)
+          }
           onDragOver={(e) => handleDirectoryDragOver(e, uploadDirectory)}
           onDragLeave={(e) => {
             if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
@@ -1713,24 +2000,25 @@ function FileExplorerContent({
           onPointerUp={handleEntryPointerEnd}
           onPointerCancel={handleEntryPointerEnd}
           onPointerLeave={handleEntryPointerEnd}
-          onClick={() => {
+          onClick={(event) => {
+            event.currentTarget.focus({ preventScroll: true });
             if (longPressTriggered.current) {
               longPressTriggered.current = false;
               return;
             }
-            if (isDirectory) {
-              toggleDirectory(entry.path);
-            } else {
-              void loadPreview(entry);
-            }
+            activateEntry(entry);
           }}
         >
           <button
             type="button"
             className="file-twisty"
+            tabIndex={-1}
             disabled={!isDirectory}
             onClick={(e) => {
               e.stopPropagation();
+              e.currentTarget
+                .closest<HTMLElement>(".file-row")
+                ?.focus({ preventScroll: true });
               if (isDirectory) toggleDirectory(entry.path);
             }}
             aria-label={isExpanded ? "Collapse folder" : "Expand folder"}
@@ -1760,10 +2048,20 @@ function FileExplorerContent({
           </span>
           {gitStatus ? (
             <span
-              className={`file-git-status is-${gitStatus.tone}`}
+              className="file-git-status"
               title={gitStatus.title}
+              role="img"
+              aria-label={gitStatus.title}
             >
-              {gitStatus.label}
+              {gitStatus.codes.map((code) => (
+                <span
+                  className={`git-status-code git-status-${code.toLowerCase()}`}
+                  key={code}
+                  aria-hidden="true"
+                >
+                  {code}
+                </span>
+              ))}
             </span>
           ) : null}
           {meta ? <span className="file-meta">{meta}</span> : null}
@@ -1774,11 +2072,15 @@ function FileExplorerContent({
             <button
               type="button"
               className="ghost file-action"
+              tabIndex={-1}
               title={
                 isDirectory ? "Download directory as tar.gz" : "Download file"
               }
               onClick={(e) => {
                 e.stopPropagation();
+                e.currentTarget
+                  .closest<HTMLElement>(".file-row")
+                  ?.focus({ preventScroll: true });
                 downloadEntry(entry);
               }}
             >
@@ -1787,9 +2089,13 @@ function FileExplorerContent({
             <button
               type="button"
               className="ghost file-action"
+              tabIndex={-1}
               title="Copy absolute path"
               onClick={(e) => {
                 e.stopPropagation();
+                e.currentTarget
+                  .closest<HTMLElement>(".file-row")
+                  ?.focus({ preventScroll: true });
                 void copyEntryPath(entry);
               }}
             >
@@ -1832,7 +2138,9 @@ function FileExplorerContent({
         </div>
       );
     }
-    return entries.map((entry) => renderEntry(entry, depth));
+    return entries.map((entry, index) =>
+      renderEntry(entry, depth, path === "" && index === 0),
+    );
   };
 
   const renderInitialLoading = () => (
@@ -1903,12 +2211,12 @@ function FileExplorerContent({
                 for (const path of pathsToRefresh) {
                   void loadDirectory(path, true);
                 }
-                void loadGitStatus();
+                void loadGitStatus(true);
                 if (previewEntry) void loadPreview(previewEntry);
               }}
             >
               <RefreshCw
-                className={gitStatusLoading ? "is-spinning" : ""}
+                className={gitSummaryState.loading ? "is-spinning" : ""}
                 size={15}
               />
             </button>
@@ -1925,6 +2233,12 @@ function FileExplorerContent({
             ref={fileTreeRef}
             className={`file-tree ${dropTargetPath === "" ? "is-drop-target" : ""}`}
             role="tree"
+            onFocusCapture={() => setTreeHasFocus(true)}
+            onBlurCapture={(event) => {
+              if (!event.currentTarget.contains(event.relatedTarget as Node)) {
+                setTreeHasFocus(false);
+              }
+            }}
             onDragOver={handleRootDragOver}
             onDragLeave={(e) => {
               if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
@@ -1946,7 +2260,9 @@ function FileExplorerContent({
             ) : null}
             {query ? (
               searchEntries.length ? (
-                searchEntries.map((entry) => renderEntry(entry, 0))
+                searchEntries.map((entry, index) =>
+                  renderEntry(entry, 0, index === 0),
+                )
               ) : (
                 <div className="file-row file-row-muted">
                   No loaded files match.

--- a/web/src/components/FilePreviewContent.tsx
+++ b/web/src/components/FilePreviewContent.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useRef, useState, type MutableRefObject } from "react";
+import {
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MutableRefObject,
+  type ReactNode,
+} from "react";
 import type { EditorView as CodeMirrorEditorView } from "@codemirror/view";
 import type { FileExplorerEntry, FilePreview } from "../types";
 import { MarkdownPreview } from "./markdown";
@@ -103,17 +111,29 @@ export function FilePreviewContent({
   preview,
   loading,
   error,
+  changesContent,
+  changesKey,
+  onOpenChanges,
 }: {
   entry: FileExplorerEntry | null;
   preview: FilePreview | null;
   loading: boolean;
   error: string | null;
+  changesContent?: ReactNode;
+  changesKey?: string;
+  onOpenChanges?: () => void;
 }) {
   const previewSectionRef = useRef<HTMLElement | null>(null);
   const editorViewRef = useRef<CodeMirrorEditorView | null>(null);
+  const fileTabRef = useRef<HTMLButtonElement | null>(null);
+  const changesTabRef = useRef<HTMLButtonElement | null>(null);
+  const tabId = useId();
+  const onOpenChangesRef = useRef(onOpenChanges);
+  onOpenChangesRef.current = onOpenChanges;
   const [previewMode, setPreviewMode] = useState<"rendered" | "raw">(
     "rendered",
   );
+  const [detailTab, setDetailTab] = useState<"file" | "changes">("file");
   const theme = useDocumentTheme();
   const previewText = preview?.text ?? null;
   const previewPath = preview?.path ?? "";
@@ -122,13 +142,45 @@ export function FilePreviewContent({
   const hasMermaidPreview = hasPreviewText && isMermaidPath(previewPath);
   const hasRichPreview = hasMarkdownPreview || hasMermaidPreview;
   const renderRichPreview = hasRichPreview && previewMode === "rendered";
+  const changesAvailable =
+    changesContent !== undefined && !!changesKey && !!onOpenChanges;
+  const showingChanges = detailTab === "changes" && changesAvailable;
+  const fileTabId = `${tabId}-file-tab`;
+  const changesTabId = `${tabId}-changes-tab`;
+  const filePanelId = `${tabId}-file-panel`;
+  const changesPanelId = `${tabId}-changes-panel`;
+
+  const handleDetailTabKeyDown = (
+    event: ReactKeyboardEvent<HTMLButtonElement>,
+  ) => {
+    if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) {
+      return;
+    }
+    event.preventDefault();
+    const nextTab =
+      !changesAvailable || event.key === "Home"
+        ? "file"
+        : event.key === "End"
+          ? "changes"
+          : showingChanges
+            ? "file"
+            : "changes";
+    setDetailTab(nextTab);
+    (nextTab === "file" ? fileTabRef : changesTabRef).current?.focus();
+  };
 
   useEffect(() => {
     setPreviewMode("rendered");
   }, [previewPath]);
 
   useEffect(() => {
-    if (!hasPreviewText || renderRichPreview) return;
+    if (detailTab === "changes" && changesAvailable) {
+      onOpenChangesRef.current?.();
+    }
+  }, [changesAvailable, changesKey, detailTab]);
+
+  useEffect(() => {
+    if (showingChanges || !hasPreviewText || renderRichPreview) return;
     const onKey = (e: KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
       if (e.key.toLowerCase() !== "f") return;
@@ -142,7 +194,7 @@ export function FilePreviewContent({
     window.addEventListener("keydown", onKey, { capture: true });
     return () =>
       window.removeEventListener("keydown", onKey, { capture: true });
-  }, [hasPreviewText, renderRichPreview]);
+  }, [hasPreviewText, renderRichPreview, showingChanges]);
 
   return (
     <section
@@ -152,7 +204,7 @@ export function FilePreviewContent({
       tabIndex={-1}
       onKeyDownCapture={(e) => {
         if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "f") {
-          if (renderRichPreview) return;
+          if (showingChanges || renderRichPreview) return;
           e.preventDefault();
           e.stopPropagation();
           openPreviewSearch(editorViewRef.current);
@@ -161,8 +213,39 @@ export function FilePreviewContent({
     >
       <div className="file-preview-head">
         <div className="file-preview-title-row">
-          <strong>{entry?.name ?? "Preview"}</strong>
-          {hasRichPreview ? (
+          <div className="file-preview-tabs" role="tablist">
+            <button
+              ref={fileTabRef}
+              id={fileTabId}
+              type="button"
+              role="tab"
+              className={showingChanges ? "" : "is-active"}
+              aria-selected={!showingChanges}
+              aria-controls={filePanelId}
+              tabIndex={showingChanges ? -1 : 0}
+              onClick={() => setDetailTab("file")}
+              onKeyDown={handleDetailTabKeyDown}
+            >
+              {entry?.name ?? "Preview"}
+            </button>
+            {changesAvailable ? (
+              <button
+                ref={changesTabRef}
+                id={changesTabId}
+                type="button"
+                role="tab"
+                className={showingChanges ? "is-active" : ""}
+                aria-selected={showingChanges}
+                aria-controls={changesPanelId}
+                tabIndex={showingChanges ? 0 : -1}
+                onClick={() => setDetailTab("changes")}
+                onKeyDown={handleDetailTabKeyDown}
+              >
+                Changes
+              </button>
+            ) : null}
+          </div>
+          {!showingChanges && hasRichPreview ? (
             <button
               type="button"
               className="file-preview-mode-toggle"
@@ -179,49 +262,74 @@ export function FilePreviewContent({
         {entry ? <span>{entry.path}</span> : null}
       </div>
 
-      {!entry ? (
-        <div className="file-preview-state">Select a text file to preview.</div>
-      ) : null}
-      {loading ? (
-        <div className="file-preview-state">
-          <span className="file-loading-spinner" />
-          Loading preview
+      {showingChanges ? (
+        <div
+          id={changesPanelId}
+          className="file-preview-changes"
+          role="tabpanel"
+          aria-labelledby={changesTabId}
+        >
+          {changesContent}
         </div>
-      ) : null}
-      {error ? (
-        <div className="file-preview-state is-error">{error}</div>
-      ) : null}
-      {!loading && !error && preview?.image_data_url ? (
-        <div className="file-preview-image-wrap">
-          <img
-            className="file-preview-image"
-            src={preview.image_data_url}
-            alt={entry?.name ?? preview.path}
-          />
+      ) : (
+        <div
+          id={filePanelId}
+          className="file-preview-file-content"
+          role="tabpanel"
+          aria-labelledby={fileTabId}
+        >
+          {!entry ? (
+            <div className="file-preview-state">
+              Select a text file to preview.
+            </div>
+          ) : null}
+          {loading ? (
+            <div className="file-preview-state">
+              <span className="file-loading-spinner" />
+              Loading preview
+            </div>
+          ) : null}
+          {error ? (
+            <div className="file-preview-state is-error">{error}</div>
+          ) : null}
+          {!loading && !error && preview?.image_data_url ? (
+            <div className="file-preview-image-wrap">
+              <img
+                className="file-preview-image"
+                src={preview.image_data_url}
+                alt={entry?.name ?? preview.path}
+              />
+            </div>
+          ) : null}
+          {!loading && !error && preview?.binary && !preview.image_data_url ? (
+            <div className="file-preview-state">
+              Binary file cannot be previewed.
+            </div>
+          ) : null}
+          {!loading && !error && preview?.truncated ? (
+            <div className="file-preview-banner">
+              Preview truncated at 512 KB.
+            </div>
+          ) : null}
+          {!loading && !error && hasMarkdownPreview && renderRichPreview ? (
+            <MarkdownPreview text={previewText} />
+          ) : null}
+          {!loading && !error && hasMermaidPreview && renderRichPreview ? (
+            <MermaidDiagram
+              code={previewText}
+              className="file-preview-mermaid"
+            />
+          ) : null}
+          {!loading && !error && hasPreviewText && !renderRichPreview ? (
+            <CodeMirrorPreview
+              text={previewText}
+              path={previewPath}
+              theme={theme}
+              editorViewRef={editorViewRef}
+            />
+          ) : null}
         </div>
-      ) : null}
-      {!loading && !error && preview?.binary && !preview.image_data_url ? (
-        <div className="file-preview-state">
-          Binary file cannot be previewed.
-        </div>
-      ) : null}
-      {!loading && !error && preview?.truncated ? (
-        <div className="file-preview-banner">Preview truncated at 512 KB.</div>
-      ) : null}
-      {!loading && !error && hasMarkdownPreview && renderRichPreview ? (
-        <MarkdownPreview text={previewText} />
-      ) : null}
-      {!loading && !error && hasMermaidPreview && renderRichPreview ? (
-        <MermaidDiagram code={previewText} className="file-preview-mermaid" />
-      ) : null}
-      {!loading && !error && hasPreviewText && !renderRichPreview ? (
-        <CodeMirrorPreview
-          text={previewText}
-          path={previewPath}
-          theme={theme}
-          editorViewRef={editorViewRef}
-        />
-      ) : null}
+      )}
     </section>
   );
 }

--- a/web/src/components/WorkspaceInspectorHost.tsx
+++ b/web/src/components/WorkspaceInspectorHost.tsx
@@ -13,6 +13,7 @@ import {
 import {
   lazy,
   Suspense,
+  useCallback,
   useEffect,
   useId,
   useLayoutEffect,
@@ -23,7 +24,7 @@ import {
   type PointerEvent as ReactPointerEvent,
 } from "react";
 import type { ConnectionClient } from "../api";
-import type { Pane, Workspace } from "../types";
+import type { GitDiffEntry, Pane, Workspace } from "../types";
 import {
   DEFAULT_INSPECTOR_NAVIGATION_RATIO,
   inspectorNavigationRatioAtPosition,
@@ -221,6 +222,10 @@ export function WorkspaceInspectorHost({
   const diffViewerRef = useRef<DiffViewerPanelHandle | null>(null);
   const splitId = useId();
   const [hostWidth, setHostWidth] = useState(0);
+  const [fileDiffState, setFileDiffState] = useState<{
+    resourceKey: string;
+    entries: GitDiffEntry[];
+  }>(() => ({ resourceKey: "", entries: [] }));
   const [drillInByView, setDrillInByView] = useState<
     Record<InspectorView, boolean>
   >(() => ({
@@ -230,6 +235,15 @@ export function WorkspaceInspectorHost({
   }));
   const resourceKey = resourceOwnerKey(state.scope);
   const contentResourceKey = resourceStateKey(state.scope);
+  const fileDiffEntries =
+    fileDiffState.resourceKey === contentResourceKey
+      ? fileDiffState.entries
+      : [];
+  const setFileDiffEntries = useCallback(
+    (entries: GitDiffEntry[]) =>
+      setFileDiffState({ resourceKey: contentResourceKey, entries }),
+    [contentResourceKey],
+  );
   const [navigationRatios, setNavigationRatios] = useState(() => {
     const preferences = readInspectorPreferences(localStorage, state.scope);
     return {
@@ -269,6 +283,21 @@ export function WorkspaceInspectorHost({
         ? !!diffSelection.entry
         : false;
   const hasDetail = detailAvailable && drillInByView[state.view];
+  const fileChangesEntries = fileSelection.entry
+    ? fileDiffEntries.filter(
+        (entry) => entry.path === fileSelection.entry?.path,
+      )
+    : [];
+  const primaryFileChangesEntry =
+    fileChangesEntries[fileChangesEntries.length - 1] ?? null;
+  const fileDiffSelectionMatches = fileChangesEntries.some(
+    (entry) =>
+      diffSelection.entry?.path === entry.path &&
+      diffSelection.entry.kind === entry.kind,
+  );
+  const fileChangesKey = fileChangesEntries
+    .map((entry) => `${entry.kind}:${entry.status}:${entry.path}`)
+    .join("|");
 
   useEffect(() => {
     if (state.view !== "files" || !fileSelection.entry) return;
@@ -276,6 +305,17 @@ export function WorkspaceInspectorHost({
   }, [fileSelection.entry, state.view]);
 
   const handleTabKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === "ArrowDown" && state.view === "files") {
+      const treeItem = hostRef.current?.querySelector<HTMLElement>(
+        ".inspector-files-resource .file-row[role='treeitem'][tabindex='0']",
+      );
+      if (treeItem) {
+        event.preventDefault();
+        treeItem.focus({ preventScroll: true });
+        treeItem.scrollIntoView({ block: "nearest" });
+      }
+      return;
+    }
     const views: InspectorView[] = historyAvailable
       ? ["files", "changes", "history"]
       : ["files", "changes"];
@@ -484,6 +524,9 @@ export function WorkspaceInspectorHost({
                 resourceKey={resourceKey}
                 initialDirectory={state.initialDirectory}
                 activePath={fileSelection.entry?.path}
+                keyboardActive={
+                  state.view === "files" && (!compact || !hasDetail)
+                }
                 onClose={onClose}
                 onPreviewChange={(selection, meta) => {
                   if (selection.entry && meta?.userInitiated) {
@@ -494,6 +537,7 @@ export function WorkspaceInspectorHost({
                   }
                   onFileSelectionChange?.(selection, meta);
                 }}
+                onActiveDiffEntriesChange={setFileDiffEntries}
               />
             </div>
             {splitEnabled ? (
@@ -511,6 +555,60 @@ export function WorkspaceInspectorHost({
                 preview={fileSelection.preview}
                 loading={fileSelection.loading}
                 error={fileSelection.error}
+                onOpenChanges={
+                  primaryFileChangesEntry
+                    ? () =>
+                        diffViewerRef.current?.selectWorkingEntries(
+                          fileChangesEntries,
+                        )
+                    : undefined
+                }
+                changesKey={fileChangesKey || undefined}
+                changesContent={
+                  primaryFileChangesEntry ? (
+                    <Suspense
+                      fallback={
+                        <div className="diff-content-state">
+                          <span className="file-loading-spinner" />
+                          Loading diff viewer
+                        </div>
+                      }
+                    >
+                      <DiffContentView
+                        key={`${contentResourceKey}:file-changes`}
+                        entry={
+                          fileDiffSelectionMatches
+                            ? diffSelection.entry
+                            : primaryFileChangesEntry
+                        }
+                        file={
+                          fileDiffSelectionMatches ? diffSelection.file : null
+                        }
+                        loading={
+                          !fileDiffSelectionMatches || diffSelection.loading
+                        }
+                        error={
+                          fileDiffSelectionMatches ? diffSelection.error : null
+                        }
+                        entries={fileChangesEntries}
+                        files={
+                          fileDiffSelectionMatches ? diffSelection.files : {}
+                        }
+                        fileErrors={
+                          fileDiffSelectionMatches
+                            ? diffSelection.fileErrors
+                            : {}
+                        }
+                        resourceKey={`${contentResourceKey}:file:${fileChangesKey}`}
+                        connectionClient={connectionClient}
+                        onSelectFile={(entry) =>
+                          diffViewerRef.current?.selectWorkingEntry(entry)
+                        }
+                        embedded
+                      />
+                    </Suspense>
+                  ) : undefined
+                }
               />
             </div>
           </div>

--- a/web/src/gitDiffStatus.test.ts
+++ b/web/src/gitDiffStatus.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { gitDiffCode } from "./gitDiffStatus";
+
+describe("gitDiffCode", () => {
+  test("normalizes explorer and diff viewer states to U/A/M/D/C", () => {
+    expect(gitDiffCode({ kind: "untracked", status: "added" })).toBe("U");
+    expect(gitDiffCode({ kind: "staged", status: "added" })).toBe("A");
+    expect(gitDiffCode({ kind: "unstaged", status: "M" })).toBe("M");
+    expect(gitDiffCode({ kind: "staged", status: "deleted" })).toBe("D");
+    expect(gitDiffCode({ kind: "conflicted", status: "modified" })).toBe("C");
+  });
+});

--- a/web/src/gitDiffStatus.ts
+++ b/web/src/gitDiffStatus.ts
@@ -1,0 +1,38 @@
+import type { GitDiffEntry } from "./types";
+
+export type GitDiffCode = "U" | "A" | "M" | "D" | "C";
+
+export function gitDiffCode(
+  entry: Pick<GitDiffEntry, "kind" | "status">,
+): GitDiffCode {
+  if (entry.kind === "conflicted") return "C";
+  if (entry.kind === "untracked") return "U";
+
+  switch (entry.status.toLowerCase()) {
+    case "a":
+    case "added":
+      return "A";
+    case "d":
+    case "deleted":
+      return "D";
+    default:
+      return "M";
+  }
+}
+
+export function gitDiffCodeLabel(code: GitDiffCode): string {
+  switch (code) {
+    case "U":
+      return "Untracked";
+    case "C":
+      return "Conflict";
+    case "A":
+      return "Added";
+    case "D":
+      return "Deleted";
+    case "M":
+      return "Modified";
+    default:
+      return "Unknown";
+  }
+}

--- a/web/src/gitDiffSummaryStore.test.ts
+++ b/web/src/gitDiffSummaryStore.test.ts
@@ -138,12 +138,19 @@ describe("shared git diff summaries", () => {
         });
       },
     };
+    const key = gitDiffSummaryKey(
+      client,
+      "workspace",
+      "working",
+      "checkout:retired",
+    );
     const initial = refreshGitDiffSummary(
       client,
       "workspace",
       "working",
       "checkout:retired",
     );
+    expect(readGitDiffSummary(key).loading).toBe(true);
     const queued = refreshGitDiffSummary(
       client,
       "workspace",
@@ -152,6 +159,7 @@ describe("shared git diff summaries", () => {
       { afterCurrent: true },
     );
     retireGitDiffSummaryResource(client, "checkout:retired");
+    expect(readGitDiffSummary(key).loading).toBe(false);
     resolveInitial?.(summary("stale"));
     await initial;
     await expect(queued).rejects.toThrow("retired");

--- a/web/src/gitDiffSummaryStore.test.ts
+++ b/web/src/gitDiffSummaryStore.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "bun:test";
+import type { ConnectionClient } from "./api";
+import type { GitDiffSummary } from "./types";
+import {
+  gitDiffSummaryKey,
+  readGitDiffSummary,
+  refreshGitDiffSummary,
+  retireGitDiffSummaryResource,
+  subscribeGitDiffSummary,
+} from "./gitDiffSummaryStore";
+
+function summary(workspaceId: string): GitDiffSummary {
+  return {
+    workspace_id: workspaceId,
+    root: "/repo",
+    entries: [],
+    counts: {
+      staged: 0,
+      unstaged: 0,
+      untracked: 0,
+      conflicted: 0,
+      branch: 0,
+    },
+  };
+}
+
+describe("shared git diff summaries", () => {
+  test("deduplicates refreshes and publishes one shared snapshot", async () => {
+    let calls = 0;
+    let resolve!: (value: GitDiffSummary) => void;
+    const client: ConnectionClient = {
+      connectionId: "shared-summary",
+      generation: 1,
+      serverRuntimeGeneration: 1,
+      isCurrent: () => true,
+      acceptsServerGeneration: () => true,
+      call: () => {
+        calls += 1;
+        return new Promise<GitDiffSummary>((done) => {
+          resolve = done;
+        });
+      },
+    };
+    const key = gitDiffSummaryKey(
+      client,
+      "workspace",
+      "working",
+      "checkout:stable",
+    );
+    let publications = 0;
+    const unsubscribe = subscribeGitDiffSummary(key, () => {
+      publications += 1;
+    });
+
+    const first = refreshGitDiffSummary(
+      client,
+      "workspace",
+      "working",
+      "checkout:stable",
+    );
+    const second = refreshGitDiffSummary(
+      client,
+      "workspace",
+      "working",
+      "checkout:stable",
+    );
+
+    expect(first).toBe(second);
+    expect(calls).toBe(1);
+    expect(readGitDiffSummary(key).loading).toBe(true);
+
+    const next = summary("workspace");
+    resolve(next);
+    await first;
+
+    expect(readGitDiffSummary(key)).toMatchObject({
+      summary: next,
+      loading: false,
+      error: null,
+    });
+    expect(publications).toBe(2);
+    unsubscribe();
+  });
+
+  test("queues one fresh request after an in-flight snapshot", async () => {
+    const resolvers: Array<(value: GitDiffSummary) => void> = [];
+    const client: ConnectionClient = {
+      connectionId: "queued-summary",
+      generation: 1,
+      serverRuntimeGeneration: 1,
+      isCurrent: () => true,
+      acceptsServerGeneration: () => true,
+      call: () =>
+        new Promise<GitDiffSummary>((resolve) => resolvers.push(resolve)),
+    };
+    const key = gitDiffSummaryKey(client, "workspace", "working");
+    const initial = refreshGitDiffSummary(client, "workspace", "working");
+    const queued = refreshGitDiffSummary(
+      client,
+      "workspace",
+      "working",
+      "workspace",
+      { afterCurrent: true },
+    );
+    const duplicateQueued = refreshGitDiffSummary(
+      client,
+      "workspace",
+      "working",
+      "workspace",
+      { afterCurrent: true },
+    );
+    expect(queued).toBe(duplicateQueued);
+    expect(resolvers).toHaveLength(1);
+
+    resolvers[0]?.(summary("stale"));
+    await initial;
+    await Promise.resolve();
+    expect(resolvers).toHaveLength(2);
+    const fresh = summary("fresh");
+    resolvers[1]?.(fresh);
+    await queued;
+    expect(readGitDiffSummary(key).summary).toBe(fresh);
+  });
+
+  test("retires a queued refresh before it can restart the resource", async () => {
+    let resolveInitial: ((value: GitDiffSummary) => void) | undefined;
+    let calls = 0;
+    const client: ConnectionClient = {
+      connectionId: "retired-queue",
+      generation: 1,
+      serverRuntimeGeneration: 1,
+      isCurrent: () => true,
+      acceptsServerGeneration: () => true,
+      call: () => {
+        calls += 1;
+        return new Promise<GitDiffSummary>((resolve) => {
+          resolveInitial = resolve;
+        });
+      },
+    };
+    const initial = refreshGitDiffSummary(
+      client,
+      "workspace",
+      "working",
+      "checkout:retired",
+    );
+    const queued = refreshGitDiffSummary(
+      client,
+      "workspace",
+      "working",
+      "checkout:retired",
+      { afterCurrent: true },
+    );
+    retireGitDiffSummaryResource(client, "checkout:retired");
+    resolveInitial?.(summary("stale"));
+    await initial;
+    await expect(queued).rejects.toThrow("retired");
+    expect(calls).toBe(1);
+  });
+
+  test("does not publish a request retired by resource cleanup", async () => {
+    const resolvers: Array<(value: GitDiffSummary) => void> = [];
+    const client: ConnectionClient = {
+      connectionId: "retired-summary",
+      generation: 1,
+      serverRuntimeGeneration: 1,
+      isCurrent: () => true,
+      acceptsServerGeneration: () => true,
+      call: () =>
+        new Promise<GitDiffSummary>((resolve) => resolvers.push(resolve)),
+    };
+    const key = gitDiffSummaryKey(
+      client,
+      "workspace",
+      "working",
+      "checkout:stable",
+    );
+    const retired = refreshGitDiffSummary(
+      client,
+      "workspace",
+      "working",
+      "checkout:stable",
+    );
+    retireGitDiffSummaryResource(client, "checkout:stable");
+    const current = refreshGitDiffSummary(
+      client,
+      "workspace",
+      "working",
+      "checkout:stable",
+    );
+
+    const staleSummary = summary("stale");
+    resolvers[0]?.(staleSummary);
+    await retired;
+    expect(readGitDiffSummary(key).summary).toBeNull();
+
+    const freshSummary = summary("workspace");
+    resolvers[1]?.(freshSummary);
+    await current;
+    expect(readGitDiffSummary(key).summary).toBe(freshSummary);
+  });
+});

--- a/web/src/gitDiffSummaryStore.ts
+++ b/web/src/gitDiffSummaryStore.ts
@@ -1,0 +1,212 @@
+import { useSyncExternalStore } from "react";
+import type { ConnectionClient } from "./api";
+import type { GitDiffSummary } from "./types";
+import { connectionClientScopeKey } from "./useConnectionClient";
+
+export type GitDiffSummaryMode = "working" | "branch-main";
+
+export type GitDiffSummaryState = {
+  summary: GitDiffSummary | null;
+  loading: boolean;
+  error: string | null;
+  revision: number;
+};
+
+const EMPTY_STATE: GitDiffSummaryState = {
+  summary: null,
+  loading: false,
+  error: null,
+  revision: 0,
+};
+
+const states = new Map<string, GitDiffSummaryState>();
+const listeners = new Map<string, Set<() => void>>();
+const requests = new Map<string, Promise<GitDiffSummary>>();
+const trailingRequests = new Map<string, Promise<GitDiffSummary>>();
+const activeTokens = new Map<string, symbol>();
+const MAX_RETAINED_SUMMARIES = 24;
+
+export function gitDiffSummaryKey(
+  client: Pick<ConnectionClient, "connectionId" | "generation">,
+  workspaceId: string,
+  mode: GitDiffSummaryMode,
+  resourceKey = workspaceId,
+) {
+  return connectionClientScopeKey(
+    client,
+    "git-diff-summary",
+    resourceKey,
+    workspaceId,
+    mode,
+  );
+}
+
+function stateForKey(key: string | null): GitDiffSummaryState {
+  return key ? (states.get(key) ?? EMPTY_STATE) : EMPTY_STATE;
+}
+
+function notify(key: string) {
+  for (const listener of listeners.get(key) ?? []) listener();
+}
+
+function pruneStates(preserveKey?: string) {
+  while (states.size > MAX_RETAINED_SUMMARIES) {
+    const candidate = Array.from(states.keys()).find(
+      (key) => key !== preserveKey && !listeners.has(key) && !requests.has(key),
+    );
+    if (!candidate) return;
+    states.delete(candidate);
+    activeTokens.delete(candidate);
+  }
+}
+
+function publish(key: string, patch: Partial<GitDiffSummaryState>) {
+  const current = stateForKey(key);
+  states.delete(key);
+  states.set(key, { ...current, ...patch });
+  pruneStates(key);
+  notify(key);
+}
+
+function keyMatchesResource(
+  key: string,
+  client: Pick<ConnectionClient, "connectionId" | "generation">,
+  resourceKey: string,
+) {
+  try {
+    const parts = JSON.parse(key) as unknown[];
+    return (
+      parts[0] === client.connectionId &&
+      parts[1] === client.generation &&
+      parts[2] === "git-diff-summary" &&
+      parts[3] === resourceKey
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function retireGitDiffSummaryResource(
+  client: Pick<ConnectionClient, "connectionId" | "generation">,
+  resourceKey: string,
+) {
+  const keys = new Set([
+    ...states.keys(),
+    ...requests.keys(),
+    ...trailingRequests.keys(),
+    ...activeTokens.keys(),
+  ]);
+  for (const key of keys) {
+    if (!keyMatchesResource(key, client, resourceKey)) continue;
+    states.delete(key);
+    requests.delete(key);
+    trailingRequests.delete(key);
+    activeTokens.delete(key);
+    notify(key);
+  }
+}
+
+export function subscribeGitDiffSummary(
+  key: string | null,
+  listener: () => void,
+) {
+  if (!key) return () => undefined;
+  const scoped = listeners.get(key) ?? new Set<() => void>();
+  scoped.add(listener);
+  listeners.set(key, scoped);
+  return () => {
+    scoped.delete(listener);
+    if (!scoped.size) listeners.delete(key);
+  };
+}
+
+export function readGitDiffSummary(key: string | null) {
+  return stateForKey(key);
+}
+
+export function useGitDiffSummaryState(
+  client: Pick<ConnectionClient, "connectionId" | "generation">,
+  workspaceId: string | undefined,
+  mode: GitDiffSummaryMode,
+  resourceKey = workspaceId,
+) {
+  const key = workspaceId
+    ? gitDiffSummaryKey(client, workspaceId, mode, resourceKey)
+    : null;
+  return useSyncExternalStore(
+    (listener) => subscribeGitDiffSummary(key, listener),
+    () => readGitDiffSummary(key),
+    () => readGitDiffSummary(key),
+  );
+}
+
+export function refreshGitDiffSummary(
+  client: ConnectionClient,
+  workspaceId: string,
+  mode: GitDiffSummaryMode,
+  resourceKey = workspaceId,
+  options: { afterCurrent?: boolean } = {},
+): Promise<GitDiffSummary> {
+  const key = gitDiffSummaryKey(client, workspaceId, mode, resourceKey);
+  const running = requests.get(key);
+  if (running && options.afterCurrent) {
+    const queued = trailingRequests.get(key);
+    if (queued) return queued;
+    const trailing = running
+      .catch(() => undefined)
+      .then(() => {
+        if (trailingRequests.get(key) !== trailing) {
+          throw new Error("queued diff summary request retired");
+        }
+        if (!client.isCurrent()) {
+          throw new Error(
+            "connection changed before queued diff summary request",
+          );
+        }
+        return refreshGitDiffSummary(client, workspaceId, mode, resourceKey);
+      })
+      .finally(() => {
+        if (trailingRequests.get(key) === trailing) {
+          trailingRequests.delete(key);
+        }
+      });
+    trailingRequests.set(key, trailing);
+    return trailing;
+  }
+  if (running) return running;
+
+  const revision = stateForKey(key).revision + 1;
+  const token = Symbol(key);
+  activeTokens.set(key, token);
+  publish(key, { loading: true, error: null, revision });
+  const task = (
+    client.call("git.diff_summary", {
+      workspace_id: workspaceId,
+      mode,
+    }) as Promise<GitDiffSummary>
+  )
+    .then((summary) => {
+      if (!client.isCurrent()) {
+        throw new Error("connection changed during diff summary request");
+      }
+      if (activeTokens.get(key) === token) {
+        publish(key, { summary, loading: false, error: null });
+      }
+      return summary;
+    })
+    .catch((error) => {
+      if (client.isCurrent() && activeTokens.get(key) === token) {
+        publish(key, {
+          loading: false,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      throw error;
+    })
+    .finally(() => {
+      if (requests.get(key) === task) requests.delete(key);
+      pruneStates();
+    });
+  requests.set(key, task);
+  return task;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4481,6 +4481,12 @@ textarea:focus {
   background: var(--accent-soft);
   color: var(--text-strong);
 }
+.file-row.is-focused,
+.file-row:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: -2px;
+  background: var(--accent-soft);
+}
 .file-row.is-drop-target {
   background: color-mix(in srgb, var(--accent) 22%, transparent);
   outline: 1px dashed var(--accent);
@@ -4490,45 +4496,44 @@ textarea:focus {
   color: var(--text-strong);
 }
 .file-git-status {
-  max-width: 88px;
-  overflow: hidden;
-  padding: 2px 6px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: var(--panel);
-  color: var(--muted);
-  font-size: 10px;
-  font-weight: 800;
-  line-height: 1.1;
-  text-overflow: ellipsis;
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 0 2px;
   white-space: nowrap;
 }
-.file-git-status.is-modified {
-  border-color: color-mix(in srgb, var(--blue) 44%, var(--border));
-  background: color-mix(in srgb, var(--blue) 12%, transparent);
+.git-status-code {
+  min-width: 10px;
+  color: var(--muted);
+  font:
+    800 10px / 1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Consolas,
+    monospace;
+  text-align: center;
+  opacity: 0.72;
+}
+.git-status-u {
   color: var(--blue);
 }
-.file-git-status.is-staged,
-.file-git-status.is-added {
-  border-color: color-mix(in srgb, var(--green) 46%, var(--border));
-  background: color-mix(in srgb, var(--green) 12%, transparent);
-  color: var(--green);
+.git-status-a {
+  color: var(--success-text);
 }
-.file-git-status.is-untracked {
-  border-color: color-mix(in srgb, var(--yellow) 46%, var(--border));
-  background: color-mix(in srgb, var(--yellow) 14%, transparent);
+.git-status-m {
   color: var(--warning-text);
 }
-.file-git-status.is-deleted,
-.file-git-status.is-conflict {
-  border-color: color-mix(in srgb, var(--red) 48%, var(--border));
-  background: var(--danger-soft);
+.git-status-d {
   color: var(--danger-text);
 }
-.file-git-status.is-directory {
-  border-color: var(--border);
-  background: color-mix(in srgb, var(--accent-soft) 68%, transparent);
-  color: var(--muted);
+.git-status-c {
+  color: var(--danger-text);
+}
+.file-row:hover .git-status-code,
+.diff-tree-row:hover .git-status-code,
+.diff-tree-row.is-selected .git-status-code {
+  opacity: 1;
 }
 .file-row-muted {
   display: block;
@@ -4648,13 +4653,40 @@ textarea:focus {
   justify-content: space-between;
   gap: 10px;
 }
-.file-preview-head strong {
+.file-preview-tabs {
   min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--viewer-border);
+  border-radius: 7px;
+  background: var(--viewer-content-bg);
+}
+.file-preview-tabs button {
+  min-width: 0;
+  height: 24px;
   overflow: hidden;
-  color: var(--text-strong);
-  font-size: 13px;
+  padding: 0 8px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.file-preview-tabs button:first-child {
+  max-width: min(34vw, 260px);
+}
+.file-preview-tabs button:hover,
+.file-preview-tabs button.is-active {
+  background: var(--accent-soft);
+  color: var(--text-strong);
+}
+.file-preview-tabs button.is-active {
+  box-shadow: inset 0 0 0 1px var(--accent);
 }
 .file-preview-mode-toggle {
   flex: 0 0 auto;
@@ -4674,6 +4706,18 @@ textarea:focus {
   font-size: 11px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.file-preview-file-content,
+.file-preview-changes {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.file-preview-changes > .diff-content-view {
+  border: none;
+  border-radius: 0;
 }
 .file-preview-state {
   flex: 1 1 auto;
@@ -5029,8 +5073,10 @@ textarea:focus {
 }
 .diff-tree-badges {
   display: inline-flex;
-  gap: 3px;
+  align-items: center;
+  gap: 4px;
   min-width: 0;
+  padding: 0 2px;
 }
 .diff-tree-stats {
   display: inline-flex;
@@ -5051,51 +5097,11 @@ textarea:focus {
 .diff-stat-del {
   color: var(--danger-text);
 }
-.diff-tree-badges .diff-kind {
-  max-width: 74px;
-}
 .diff-file-row:last-child {
   border-bottom: none;
 }
 .diff-file-row:hover,
 .diff-file-row.is-selected {
-  background: var(--accent-soft);
-}
-.diff-kind {
-  overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 1px 5px;
-  color: var(--muted);
-  font-size: 10px;
-  text-align: center;
-  text-overflow: ellipsis;
-  text-transform: uppercase;
-  white-space: nowrap;
-}
-.diff-kind-staged {
-  color: var(--success-text);
-  border-color: var(--green);
-  background: var(--success-soft);
-}
-.diff-kind-unstaged {
-  color: var(--warning-text);
-  border-color: var(--yellow);
-  background: var(--warning-soft);
-}
-.diff-kind-untracked {
-  color: var(--blue);
-  border-color: var(--accent);
-  background: var(--accent-soft);
-}
-.diff-kind-conflicted {
-  color: var(--danger-text);
-  border-color: var(--danger-border);
-  background: var(--danger-soft);
-}
-.diff-kind-branch {
-  color: var(--blue);
-  border-color: var(--blue);
   background: var(--accent-soft);
 }
 .diff-file-main {
@@ -5156,6 +5162,14 @@ textarea:focus {
   border-bottom: 1px solid var(--viewer-border);
   background: var(--viewer-header-bg);
 }
+.diff-content-view.is-embedded .diff-content-head {
+  min-height: 38px;
+  justify-content: flex-end;
+  padding: 5px 8px;
+}
+.diff-content-view.is-embedded .diff-content-actions {
+  flex-basis: auto;
+}
 .diff-content-title {
   min-width: 0;
   flex: 1 1 160px;
@@ -5182,6 +5196,44 @@ textarea:focus {
   justify-content: flex-end;
   flex-wrap: wrap;
   gap: 6px;
+}
+.diff-hunk-navigation {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px;
+  border: 1px solid var(--viewer-border);
+  border-radius: 8px;
+  background: var(--viewer-content-bg);
+}
+.diff-hunk-navigation button {
+  width: 26px;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted);
+}
+.diff-hunk-navigation button:hover {
+  background: var(--accent-soft);
+  color: var(--text-strong);
+}
+.diff-hunk-navigation span {
+  min-width: 64px;
+  color: var(--muted);
+  font:
+    11px / 1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Consolas,
+    monospace;
+  text-align: center;
+  white-space: nowrap;
 }
 .diff-search-controls {
   min-width: 0;
@@ -5323,6 +5375,9 @@ textarea:focus {
   background: var(--diff-bg);
 }
 .diff-file-section:last-child {
+  border-bottom: none;
+}
+.diff-file-section.is-embedded {
   border-bottom: none;
 }
 .diff-file-section-head {


### PR DESCRIPTION
## Summary

- share Git diff summary state between Files and Changes, with bounded cache lifecycle and post-mutation refreshes
- align Git status badges and preserve staged/unstaged entries for partially staged files
- embed per-file changes in the file preview while preserving wrap and split/unified preferences
- add hunk navigation plus reliable virtualized-line targeting
- add VS Code-style file-tree keyboard navigation and accessible File/Changes tabs and context menus
- harden preview and diff request races, invalidation, and resource cleanup

## Verification

- `bun test` — 699 passed, 1 skipped
- `bun run format:check`
- `bun run lint`
- `cd web && bun run typecheck`
- `cd web && bun run build`
- browser smoke test for file-tree navigation, keyboard context menus, and File/Changes tab navigation
