### PR TITLE
Fix terminals staying black after mobile PWA resumes from background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 - Align Files and Changes with shared Git status, keyboard file-tree navigation,
   and inline per-file diff controls that preserve the selected view settings.
 
+### Fixed
+
+- Restore terminal content after returning from the lock screen or switching
+  apps in the mobile PWA: probe the bridge socket as soon as the page
+  foregrounds, repaint and re-attach terminals stuck without frames, and fall
+  back to a single rate-limited reload when the session cannot recover in
+  place instead of requiring a manual refresh.
+
 ## 0.4.6 - 2026-08-25
 
 ### Added

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -1085,4 +1085,151 @@ describe("bridge connection lifecycle", () => {
     expect(parseConnectionSummary({ ...base, type: "unknown" })).toBeNull();
     expect(parseConnectionSummary({ ...base, state: "bogus" })).toBeNull();
   });
+
+  test("probeConnectionNow is a no-op while disconnected", () => {
+    installBrowserGlobals(HangingWebSocket as unknown as typeof WebSocket);
+    const bridge = createTestBridge();
+    expect(() => bridge.probeConnectionNow()).not.toThrow();
+    expect(bridge.status).toBe("disconnected");
+  });
+
+  test("probeConnectionNow drops a socket that closed without a close event", async () => {
+    class FrozenWebSocket extends HangingWebSocket {
+      static instances: FrozenWebSocket[] = [];
+
+      constructor() {
+        super();
+        FrozenWebSocket.instances.push(this);
+        queueMicrotask(() => {
+          this.readyState = FrozenWebSocket.OPEN;
+          this.onopen?.();
+        });
+      }
+
+      // Simulates the OS killing the socket while the page was frozen: the
+      // readyState moves on but no close event is ever delivered.
+      closeSilently() {
+        this.readyState = FrozenWebSocket.CLOSED;
+      }
+    }
+    installBrowserGlobals(FrozenWebSocket as unknown as typeof WebSocket);
+    const bridge = createTestBridge(50, 1);
+    bridge.connect();
+    await Bun.sleep(1);
+    sendHello(FrozenWebSocket.instances[0]);
+    expect(bridge.status).toBe("connected");
+
+    FrozenWebSocket.instances[0].closeSilently();
+    bridge.probeConnectionNow();
+    expect(bridge.status).toBe("disconnected");
+
+    await Bun.sleep(10);
+    expect(FrozenWebSocket.instances.length).toBe(2);
+  });
+
+  test("does not advance the client generation twice when a probe rejects during teardown", async () => {
+    class ProbedWebSocket extends HangingWebSocket {
+      static instance: ProbedWebSocket;
+      sent: string[] = [];
+
+      constructor() {
+        super();
+        ProbedWebSocket.instance = this;
+        queueMicrotask(() => {
+          this.readyState = ProbedWebSocket.OPEN;
+          this.onopen?.();
+        });
+      }
+
+      send(raw = "") {
+        this.sent.push(raw);
+      }
+    }
+    installBrowserGlobals(ProbedWebSocket as unknown as typeof WebSocket);
+    const bridge = createTestBridge(50);
+    bridge.connect();
+    await Bun.sleep(1);
+    sendHello(ProbedWebSocket.instance);
+    const generation = bridge.clientGeneration;
+
+    // Simulate the frozen-page resume burst: a heartbeat probe goes out on
+    // the zombie socket, then the delayed close event arrives. rejectPending
+    // rejects the probe, whose handler must not force a second teardown.
+    bridge.probeConnectionNow();
+    expect(ProbedWebSocket.instance.sent.length).toBe(1);
+    ProbedWebSocket.instance.onclose?.();
+    await Bun.sleep(1);
+
+    expect(bridge.clientGeneration).toBe(generation + 1);
+  });
+
+  test("handleDisconnect stays idempotent once the socket is fully torn down", async () => {
+    class OpeningWebSocket extends HangingWebSocket {
+      static instance: OpeningWebSocket;
+
+      constructor() {
+        super();
+        OpeningWebSocket.instance = this;
+        queueMicrotask(() => {
+          this.readyState = OpeningWebSocket.OPEN;
+          this.onopen?.();
+        });
+      }
+    }
+    installBrowserGlobals(OpeningWebSocket as unknown as typeof WebSocket);
+    const bridge = createTestBridge(50);
+    bridge.connect();
+    await Bun.sleep(1);
+    sendHello(OpeningWebSocket.instance);
+    const generation = bridge.clientGeneration;
+
+    OpeningWebSocket.instance.onclose?.();
+    expect(bridge.clientGeneration).toBe(generation + 1);
+
+    // A repeated teardown with no live socket must not advance the client
+    // generation again: status handlers only fire on transitions, so
+    // generation-scoped clients captured the first advance and would never
+    // learn a second one.
+    const internals = bridge as unknown as {
+      handleDisconnect(ws: WebSocket | null, reason: string): void;
+    };
+    internals.handleDisconnect(null, "stale repeated teardown");
+    expect(bridge.clientGeneration).toBe(generation + 1);
+  });
+
+  test("probeConnectionNow pings an open socket and stays connected on reply", async () => {
+    class ProbedWebSocket extends HangingWebSocket {
+      static instance: ProbedWebSocket;
+      sent: string[] = [];
+
+      constructor() {
+        super();
+        ProbedWebSocket.instance = this;
+        queueMicrotask(() => {
+          this.readyState = ProbedWebSocket.OPEN;
+          this.onopen?.();
+        });
+      }
+
+      send(raw = "") {
+        this.sent.push(raw);
+      }
+    }
+    installBrowserGlobals(ProbedWebSocket as unknown as typeof WebSocket);
+    const bridge = createTestBridge(50);
+    bridge.connect();
+    await Bun.sleep(1);
+    sendHello(ProbedWebSocket.instance);
+
+    bridge.probeConnectionNow();
+    expect(ProbedWebSocket.instance.sent.length).toBe(1);
+    const ping = JSON.parse(ProbedWebSocket.instance.sent[0]);
+    expect(ping.method).toBe("bridge.ping");
+
+    ProbedWebSocket.instance.onmessage?.({
+      data: JSON.stringify({ id: ping.id, result: { ok: true } }),
+    } as MessageEvent);
+    await Bun.sleep(5);
+    expect(bridge.status).toBe("connected");
+  });
 });

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -530,19 +530,48 @@ export class Bridge {
   private startHeartbeat() {
     if (this.heartbeatTimer) clearInterval(this.heartbeatTimer);
     this.heartbeatTimer = setInterval(() => {
-      if (this.heartbeatInFlight) return;
       if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
-      this.heartbeatInFlight = true;
-      this.call("bridge.ping", {}, HEARTBEAT_TIMEOUT_MS).then(
-        () => {
-          this.heartbeatInFlight = false;
-        },
-        () => {
-          this.heartbeatInFlight = false;
-          this.forceReconnect("bridge heartbeat timed out");
-        },
-      );
+      this.runHeartbeatProbe();
     }, HEARTBEAT_INTERVAL_MS);
+  }
+
+  private runHeartbeatProbe() {
+    if (this.heartbeatInFlight) return;
+    this.heartbeatInFlight = true;
+    this.call("bridge.ping", {}, HEARTBEAT_TIMEOUT_MS).then(
+      () => {
+        this.heartbeatInFlight = false;
+      },
+      () => {
+        this.heartbeatInFlight = false;
+        // A rejected ping can also arrive because the socket was already
+        // torn down (rejectPending during handleDisconnect). Only a live
+        // connection may be force-reconnected; otherwise the extra
+        // handleDisconnect would advance the client generation a second
+        // time without a status transition, silently desyncing every
+        // generation-scoped client captured at the first transition.
+        if (this._status === "connected") {
+          this.forceReconnect("bridge heartbeat timed out");
+        }
+      },
+    );
+  }
+
+  /**
+   * Probes a seemingly connected socket right away. Mobile operating systems
+   * can kill the WebSocket while the page is frozen without ever delivering
+   * a close event, so on a foreground resume the next scheduled heartbeat
+   * tick would be the first time a dead connection is noticed.
+   */
+  probeConnectionNow() {
+    if (this._status !== "connected") return;
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      // The close event never fired (the OS froze the page first), so drop
+      // the stale socket instead of waiting for the heartbeat interval.
+      this.forceReconnect("bridge socket is no longer open");
+      return;
+    }
+    this.runHeartbeatProbe();
   }
 
   private stopHeartbeat() {
@@ -572,6 +601,13 @@ export class Bridge {
 
   private handleDisconnect(ws: WebSocket | null, reason: string) {
     if (ws && this.ws !== ws) return;
+    // Defense in depth: once fully torn down, handleDisconnect is
+    // idempotent. Stale close events are filtered by the socket-identity
+    // check above and the heartbeat probe only force-reconnects a live
+    // connection, but no current or future forceReconnect path may advance
+    // the client generation twice without a status transition: listeners
+    // captured the first advance and would never learn the second.
+    if (!ws && this.ws === null && this._status === "disconnected") return;
     this.ws = null;
     this._hello = null;
     this.helloAcceptedForSocket = false;

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -79,6 +79,12 @@ import {
   type MobileTerminalSideShortcuts,
 } from "../mobileTerminalShortcuts";
 import { mobileTerminalShortcutExecution } from "../mobileTerminalShortcutAction";
+import {
+  readTerminalRecoveryReloadAt,
+  shouldArmTerminalRecoveryResume,
+  shouldReloadTerminalAfterResume,
+  writeTerminalRecoveryReloadAt,
+} from "../terminalRecovery";
 
 const SYSTEM_CLIPBOARD = "c" as ClipboardSelectionType;
 
@@ -520,6 +526,10 @@ export function TerminalView({
   }
   const attachTimeoutCountRef = useRef(0);
   const attachTimeoutTerminalRef = useRef<string | null>(null);
+  // Timestamp of the last foreground resume; gates the last-resort reload.
+  const resumedAtRef = useRef<number | null>(null);
+  // When the page last became hidden; measures the suspension length.
+  const hiddenAtRef = useRef<number | null>(null);
   const selectedPaneInLayout =
     s.selectedPaneId &&
     s.layout?.panes.some((p) => p.pane_id === s.selectedPaneId)
@@ -1834,6 +1844,26 @@ export function TerminalView({
                 .catch(() => null);
               if (attachTimeoutCountRef.current > 2) {
                 setTerminalLoading(false);
+                // Repeated attaches produced no frames right after a
+                // foreground resume: the session is wedged in a way in-place
+                // recovery cannot fix (silently killed socket, wedged
+                // stream). Reload once, rate-limited, replicating the
+                // manual refresh that restores the terminal.
+                const now = Date.now();
+                if (
+                  shouldReloadTerminalAfterResume({
+                    now,
+                    resumedAt: resumedAtRef.current,
+                    lastReloadAt: readTerminalRecoveryReloadAt(),
+                  })
+                ) {
+                  writeTerminalRecoveryReloadAt(now);
+                  window.location.reload();
+                  return;
+                }
+                setTerminalAttachError(
+                  "Terminal stopped receiving frames. Reload the app to reconnect.",
+                );
                 return;
               }
               setAttachRetry((value) => value + 1);
@@ -1864,6 +1894,61 @@ export function TerminalView({
     connectionClient,
     termInstance,
   ]);
+
+  // Mobile browsers freeze the page while hidden: the socket can die
+  // silently, rendering pauses, and composited content may come back blank.
+  // On return, force a repaint and re-arm a stuck attach so the terminal
+  // recovers without a full-page reload. A dead socket is handled by the
+  // store-level probe, which flips the status and re-arms the attach epoch.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const recoverTerminal = (fromResume: boolean) => {
+      if (document.visibilityState !== "visible") return;
+      if (fromResume) {
+        // Arm the last-resort reload only after a genuinely long suspension
+        // (mobile lock screen, app backgrounding). Desktop tab switches
+        // fire visibilitychange too; a measured short one keeps the cheap
+        // recovery below but never arms an automatic reload.
+        const now = Date.now();
+        const hiddenAt = hiddenAtRef.current;
+        hiddenAtRef.current = null;
+        if (shouldArmTerminalRecoveryResume({ now, hiddenAt })) {
+          resumedAtRef.current = now;
+        }
+      }
+      attachTimeoutCountRef.current = 0;
+      const term = termRef.current;
+      if (term) {
+        try {
+          term.refresh(0, term.rows - 1);
+        } catch {
+          // The attach recovery below still applies.
+        }
+      }
+      if (!desiredTerminalRef.current) return;
+      if (store.get().status !== "connected") return;
+      // A live attach keeps streaming on its own; only a terminal that lost
+      // its attach (watchdog give-up, failed attach) needs a nudge.
+      if (attachedRef.current || attachingRef.current) return;
+      setAttachRetry((value) => value + 1);
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        hiddenAtRef.current = Date.now();
+        return;
+      }
+      recoverTerminal(true);
+    };
+    const onForegroundEvent = () => recoverTerminal(false);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    window.addEventListener("pageshow", onForegroundEvent);
+    window.addEventListener("focus", onForegroundEvent);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      window.removeEventListener("pageshow", onForegroundEvent);
+      window.removeEventListener("focus", onForegroundEvent);
+    };
+  }, []);
 
   const runMobileShortcut = (shortcut: MobileTerminalShortcut) => {
     const execution = mobileTerminalShortcutExecution(shortcut.action);

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -1775,6 +1775,10 @@ export const store = {
     // visible, focused, or back online instead of waiting out the throttle.
     const refreshOnReturn = () => {
       if (state.connectionPaused || state.status !== "connected") return;
+      // Mobile OSes can silently kill the socket while the page is frozen;
+      // probe now so reconnect and terminal re-attach start immediately
+      // instead of waiting for the next heartbeat tick.
+      bridge.probeConnectionNow();
       void refreshNow();
       void refreshBridgeStatus();
     };

--- a/web/src/terminalRecovery.test.ts
+++ b/web/src/terminalRecovery.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import {
+  readTerminalRecoveryReloadAt,
+  shouldArmTerminalRecoveryResume,
+  shouldReloadTerminalAfterResume,
+  TERMINAL_RECOVERY_MIN_HIDDEN_MS,
+  TERMINAL_RECOVERY_RELOAD_MIN_INTERVAL_MS,
+  TERMINAL_RECOVERY_RESUME_WINDOW_MS,
+  writeTerminalRecoveryReloadAt,
+} from "./terminalRecovery";
+
+describe("shouldReloadTerminalAfterResume", () => {
+  test("never reloads when the page was not resumed from hidden", () => {
+    expect(
+      shouldReloadTerminalAfterResume({
+        now: 100_000,
+        resumedAt: null,
+        lastReloadAt: null,
+      }),
+    ).toBe(false);
+  });
+
+  test("reloads when the failure follows a recent resume", () => {
+    expect(
+      shouldReloadTerminalAfterResume({
+        now: 100_000,
+        resumedAt: 100_000 - TERMINAL_RECOVERY_RESUME_WINDOW_MS,
+        lastReloadAt: null,
+      }),
+    ).toBe(true);
+  });
+
+  test("does not reload long after the resume", () => {
+    expect(
+      shouldReloadTerminalAfterResume({
+        now: 100_000,
+        resumedAt: 100_000 - TERMINAL_RECOVERY_RESUME_WINDOW_MS - 1,
+        lastReloadAt: null,
+      }),
+    ).toBe(false);
+  });
+
+  test("rate-limits consecutive automatic reloads", () => {
+    expect(
+      shouldReloadTerminalAfterResume({
+        now: 100_000,
+        resumedAt: 90_000,
+        lastReloadAt:
+          100_000 - TERMINAL_RECOVERY_RELOAD_MIN_INTERVAL_MS + 1_000,
+      }),
+    ).toBe(false);
+    expect(
+      shouldReloadTerminalAfterResume({
+        now: 100_000,
+        resumedAt: 90_000,
+        lastReloadAt: 100_000 - TERMINAL_RECOVERY_RELOAD_MIN_INTERVAL_MS,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("shouldArmTerminalRecoveryResume", () => {
+  test("arms when the hidden event was never observed", () => {
+    // Some platforms freeze the page without dispatching visibilitychange;
+    // the lock-screen resume must stay armed in that case.
+    expect(
+      shouldArmTerminalRecoveryResume({ now: 100_000, hiddenAt: null }),
+    ).toBe(true);
+  });
+
+  test("does not arm after a measured short tab switch", () => {
+    expect(
+      shouldArmTerminalRecoveryResume({
+        now: 100_000,
+        hiddenAt: 100_000 - TERMINAL_RECOVERY_MIN_HIDDEN_MS + 1_000,
+      }),
+    ).toBe(false);
+  });
+
+  test("arms once the hidden period reaches the suspension threshold", () => {
+    expect(
+      shouldArmTerminalRecoveryResume({
+        now: 100_000,
+        hiddenAt: 100_000 - TERMINAL_RECOVERY_MIN_HIDDEN_MS,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("terminal recovery reload timestamp storage", () => {
+  function memoryStorage(initial: Record<string, string> = {}) {
+    const data = new Map(Object.entries(initial));
+    return {
+      getItem: (key: string) => data.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        data.set(key, value);
+      },
+    };
+  }
+
+  test("round-trips the reload timestamp", () => {
+    const storage = memoryStorage();
+    expect(readTerminalRecoveryReloadAt(storage)).toBe(null);
+    writeTerminalRecoveryReloadAt(123_456, storage);
+    expect(readTerminalRecoveryReloadAt(storage)).toBe(123_456);
+  });
+
+  test("ignores malformed stored values", () => {
+    const storage = memoryStorage({
+      "terminalRecovery.lastReloadAt": "not-a-number",
+    });
+    expect(readTerminalRecoveryReloadAt(storage)).toBe(null);
+  });
+
+  test("tolerates unavailable storage", () => {
+    expect(readTerminalRecoveryReloadAt(null)).toBe(null);
+    expect(() => writeTerminalRecoveryReloadAt(1, null)).not.toThrow();
+    const throwing = {
+      getItem: () => {
+        throw new Error("denied");
+      },
+      setItem: () => {
+        throw new Error("denied");
+      },
+    };
+    expect(readTerminalRecoveryReloadAt(throwing)).toBe(null);
+    expect(() => writeTerminalRecoveryReloadAt(1, throwing)).not.toThrow();
+  });
+});

--- a/web/src/terminalRecovery.ts
+++ b/web/src/terminalRecovery.ts
@@ -1,0 +1,97 @@
+/**
+ * Last-resort recovery for terminals that cannot restore themselves after a
+ * mobile foreground resume (lock screen, app switch). The OS can freeze the
+ * page mid-session, leaving a wedged socket, stream, or compositor that
+ * in-place recovery cannot fix; a page reload is the only way out, and it is
+ * what users otherwise have to do by hand.
+ */
+
+/**
+ * Only a failure shortly after a foreground resume qualifies for an
+ * automatic reload. General attach failures (flaky networks, busy servers)
+ * surface an error instead of reloading the app.
+ */
+export const TERMINAL_RECOVERY_RESUME_WINDOW_MS = 90_000;
+
+/**
+ * Minimum spacing between automatic reloads so a genuinely dead backend can
+ * never trap the app in a reload loop.
+ */
+export const TERMINAL_RECOVERY_RELOAD_MIN_INTERVAL_MS = 10 * 60_000;
+
+/**
+ * Minimum measured hidden duration before a resume may arm the last-resort
+ * reload. Desktop tab switches also fire visibilitychange; only a hidden
+ * period long enough to have suspended the page (mobile lock screen, app
+ * backgrounding) should arm an automatic reload.
+ */
+export const TERMINAL_RECOVERY_MIN_HIDDEN_MS = 30_000;
+
+/**
+ * Decides whether a hidden-to-visible transition arms the last-resort
+ * reload. A measured short tab switch never arms it. An unmeasured
+ * transition (hiddenAt null) does: some platforms freeze the page without
+ * dispatching the hidden event, so the lock-screen case must stay armed.
+ */
+export function shouldArmTerminalRecoveryResume(args: {
+  now: number;
+  hiddenAt: number | null;
+}): boolean {
+  if (args.hiddenAt === null) return true;
+  return args.now - args.hiddenAt >= TERMINAL_RECOVERY_MIN_HIDDEN_MS;
+}
+
+export function shouldReloadTerminalAfterResume(args: {
+  now: number;
+  resumedAt: number | null;
+  lastReloadAt: number | null;
+}): boolean {
+  if (args.resumedAt === null) return false;
+  if (args.now - args.resumedAt > TERMINAL_RECOVERY_RESUME_WINDOW_MS) {
+    return false;
+  }
+  if (
+    args.lastReloadAt !== null &&
+    args.now - args.lastReloadAt < TERMINAL_RECOVERY_RELOAD_MIN_INTERVAL_MS
+  ) {
+    return false;
+  }
+  return true;
+}
+
+const STORAGE_KEY = "terminalRecovery.lastReloadAt";
+
+type RecoveryStorage = Pick<Storage, "getItem" | "setItem">;
+
+function defaultStorage(): RecoveryStorage | null {
+  try {
+    return globalThis.sessionStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function readTerminalRecoveryReloadAt(
+  storage: RecoveryStorage | null = defaultStorage(),
+): number | null {
+  try {
+    const raw = storage?.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const value = Number(raw);
+    return Number.isFinite(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeTerminalRecoveryReloadAt(
+  now: number,
+  storage: RecoveryStorage | null = defaultStorage(),
+): void {
+  try {
+    storage?.setItem(STORAGE_KEY, String(now));
+  } catch {
+    // Storage may be unavailable; skipping the write only weakens the
+    // cross-reload rate limit, never the in-place recovery path.
+  }
+}


### PR DESCRIPTION
## Summary

Fixes terminals staying black after the mobile PWA returns from the lock screen or switches back from another app, requiring a manual page refresh to recover.

**Root cause:** while the OS freezes the page, it can kill the bridge WebSocket without delivering a close event. On resume, the overdue heartbeat fires on the zombie socket, the delayed close event tears the connection down (advancing the client generation, which status listeners capture), and the rejected heartbeat ping then triggers a second teardown that advances the generation again without a status transition. Scoped clients keep the stale generation forever: reconnect and global RPCs succeed, but terminal attach, metadata refresh, and terminal input are silently discarded as stale.

**Changes:**

- Make `handleDisconnect` idempotent once the socket is fully torn down, and only let the heartbeat probe force-reconnect a live connection, so the client generation cannot advance twice without a status transition.
- Probe the bridge socket as soon as the page foregrounds instead of waiting out the heartbeat interval.
- On foreground resume, repaint xterm and re-arm terminals that lost their attach; surface an explicit error instead of a silent black terminal when the attach watchdog exhausts retries.
- Fall back to a single rate-limited page reload when repeated attaches right after a genuine suspension still produce no frames.

## Verification

- `bun run format:check && bun run lint && bun run test` — 716 tests pass, including new regressions covering the frozen-resume generation desync.
- `cd web && bun run typecheck && bun run build`; `cd server && bun run typecheck`.
- Manually verified on a phone PWA over LAN: terminal content restores about two seconds after unlocking instead of staying black until a manual refresh.