### PR TITLE
Improve session History on mobile and add message minimap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+### Fixed
+
+- Improve the session History view on phones: hide the Turns/Tokens overview
+  strip from the Messages tab (it appears under the Details tab instead),
+  hide the Inspector's Files/Changes/History tab bar on phones (the bottom
+  navigation switches views already), shrink the full-message preview font,
+  and render the message and transcript dialogs at the document root so they
+  stay within the visible viewport and above the top bar instead of being
+  covered by it when the on-screen keyboard or pinch zoom shrinks the app.
+- Stop showing hover tooltips for touch taps on phones: focus-triggered
+  tooltips now require keyboard-style (:focus-visible) focus, so tapping the
+  bottom navigation no longer leaves a tooltip stuck until the next tap.
+- Keep the session History drawer's bottom buttons above the phone's safe
+  area so they stay tappable instead of sliding under the browser's bottom
+  bar or home indicator.
+- Always show user and assistant messages together in the session History
+  view (dropping the assistant-message filter switch) and add a message
+  minimap above the timeline with one color-coded bar per message. Bars for
+  the messages in view grow taller as a moving wave while scrolling (the
+  strip auto-scrolls to keep the wave visible for long histories), and
+  tapping or dragging anywhere on the strip scrubs the timeline to the
+  matching position with a brief card highlight.
+
 ## 0.4.7 - 2026-08-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@
 
 ### Fixed
 
-- Improve the session History view on phones: hide the Turns/Tokens overview
-  strip from the Messages tab (it appears under the Details tab instead),
-  hide the Inspector's Files/Changes/History tab bar on phones (the bottom
-  navigation switches views already), shrink the full-message preview font,
-  and render the message and transcript dialogs at the document root so they
-  stay within the visible viewport and above the top bar instead of being
-  covered by it when the on-screen keyboard or pinch zoom shrinks the app.
+- Improve the session History view on phones: move the Turns/Tokens overview
+  strip into the Details tab (the Messages tab keeps the space for the
+  timeline), hide the Inspector's Files/Changes/History tab bar on phones
+  (the bottom navigation switches views already), shrink the full-message
+  preview font, and render the message and transcript dialogs at the document
+  root so they stay within the visible viewport and above the top bar instead
+  of being covered by it when the on-screen keyboard or pinch zoom shrinks
+  the app.
 - Stop showing hover tooltips for touch taps on phones: focus-triggered
   tooltips now require keyboard-style (:focus-visible) focus, so tapping the
   bottom navigation no longer leaves a tooltip stuck until the next tap.

--- a/web/src/components/AgentHistoryDrawer.tsx
+++ b/web/src/components/AgentHistoryDrawer.tsx
@@ -1,5 +1,12 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { Bot, Copy, Download, Eye, RefreshCw, X } from "lucide-react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
+import { Copy, Download, Eye, RefreshCw, X } from "lucide-react";
 import { useStoreSelector } from "../store";
 import { useConnectionClient } from "../useConnectionClient";
 import type { Pane } from "../types";
@@ -16,10 +23,7 @@ import {
   formatOptionalCompact,
   formatTokenTotal,
   tokenUsage,
-  visibleSessionMessages,
 } from "./agentSession";
-
-const SHOW_ASSISTANT_MESSAGES_KEY = "sessionInspectShowAssistantMessages";
 
 type AgentHistoryEntry = {
   id: string;
@@ -71,33 +75,18 @@ function messageSummary(text: string) {
   return `${lines.length} lines`;
 }
 
-function initialShowAssistantMessages() {
-  try {
-    return (
-      typeof localStorage === "undefined" ||
-      localStorage.getItem(SHOW_ASSISTANT_MESSAGES_KEY) !== "false"
-    );
-  } catch {
-    return true;
-  }
-}
-
-function persistShowAssistantMessages(value: boolean) {
-  try {
-    localStorage.setItem(SHOW_ASSISTANT_MESSAGES_KEY, String(value));
-  } catch {
-    // Storage can be unavailable in private or restricted browser contexts.
-  }
-}
-
-function AgentHistoryMessageCard({
+// Cards are memoized because the timeline can hold hundreds of them and the
+// drawer's minimap viewport tracking re-renders on every scroll boundary.
+const AgentHistoryMessageCard = memo(function AgentHistoryMessageCard({
   entry,
   index,
+  highlighted = false,
   onExpand,
 }: {
   entry: AgentHistoryEntry;
   index: number;
-  onExpand: () => void;
+  highlighted?: boolean;
+  onExpand: (entry: AgentHistoryEntry) => void;
 }) {
   const contentRef = useRef<HTMLPreElement>(null);
   const [truncated, setTruncated] = useState(false);
@@ -121,7 +110,12 @@ function AgentHistoryMessageCard({
   const roleLabel = entry.role === "assistant" ? "Assistant" : "You";
   const roleAriaLabel = entry.role === "assistant" ? "assistant" : "user";
   return (
-    <article className={`agent-history-card is-${entry.role}`}>
+    <article
+      className={`agent-history-card is-${entry.role} ${
+        highlighted ? "is-minimap-target" : ""
+      }`}
+      data-sequence={index}
+    >
       <div className="agent-history-card-meta">
         <strong className="agent-history-card-role">{roleLabel}</strong>
         <small>#{index}</small>
@@ -142,13 +136,151 @@ function AgentHistoryMessageCard({
       <button
         type="button"
         className={`agent-history-card-open ${truncated ? "is-truncated" : ""}`}
-        onClick={onExpand}
+        onClick={() => onExpand(entry)}
         aria-label={`View ${roleAriaLabel} message ${index}`}
       >
         <pre ref={contentRef}>{entry.text}</pre>
         {truncated ? <span>View full message</span> : null}
       </button>
     </article>
+  );
+});
+
+type MessageMinimapVisibleRange = { start: number; end: number };
+
+function minimapPrefersReducedMotion() {
+  return (
+    window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false
+  );
+}
+
+// The minimap keeps its bars in a uniform-width flex row, so a pointer
+// position maps to a message index from the strip geometry alone.
+function AgentHistoryMinimap({
+  entries,
+  visibleRange,
+  onSelect,
+}: {
+  entries: { message: AgentHistoryEntry; sequence: number }[];
+  visibleRange: MessageMinimapVisibleRange | null;
+  onSelect: (sequence: number) => void;
+}) {
+  const stripRef = useRef<HTMLDivElement>(null);
+  const scrubbingRef = useRef(false);
+  const visibleRangeRef = useRef<MessageMinimapVisibleRange | null>(null);
+  visibleRangeRef.current = visibleRange;
+
+  // With more messages than the strip can fit, the bars overflow and the
+  // strip scrolls horizontally; keep the raised wave inside the strip's own
+  // viewport instead of letting it drift out of sight. Suppressed while the
+  // user is scrubbing so the strip never moves under their finger.
+  const centerWave = useCallback(() => {
+    const strip = stripRef.current;
+    const range = visibleRangeRef.current;
+    if (!strip || !range || scrubbingRef.current) return;
+    if (strip.scrollWidth <= strip.clientWidth) return;
+    const startBar = strip.children[range.start - 1];
+    const endBar = strip.children[range.end - 1];
+    if (!(startBar instanceof HTMLElement) || !(endBar instanceof HTMLElement))
+      return;
+    const stripRect = strip.getBoundingClientRect();
+    const waveLeft =
+      startBar.getBoundingClientRect().left - stripRect.left + strip.scrollLeft;
+    const waveRight =
+      endBar.getBoundingClientRect().right - stripRect.left + strip.scrollLeft;
+    const target = Math.max(
+      0,
+      Math.min(
+        strip.scrollWidth - strip.clientWidth,
+        (waveLeft + waveRight - strip.clientWidth) / 2,
+      ),
+    );
+    strip.scrollTo({
+      left: target,
+      behavior: minimapPrefersReducedMotion() ? "auto" : "smooth",
+    });
+  }, []);
+
+  useEffect(() => {
+    centerWave();
+  }, [centerWave, visibleRange]);
+
+  const sequenceAtClientX = useCallback(
+    (clientX: number) => {
+      const strip = stripRef.current;
+      const firstBar = strip?.firstElementChild;
+      if (!strip || !(firstBar instanceof HTMLElement)) return null;
+      const count = entries.length;
+      if (count === 0) return null;
+      // Keep the gap in sync with .agent-history-minimap in styles.css.
+      const stride = firstBar.offsetWidth + 2;
+      if (stride <= 0) return null;
+      const stripRect = strip.getBoundingClientRect();
+      const barsLeft =
+        firstBar.getBoundingClientRect().left -
+        stripRect.left +
+        strip.scrollLeft;
+      const contentX = clientX - stripRect.left + strip.scrollLeft - barsLeft;
+      const index = Math.max(
+        0,
+        Math.min(count - 1, Math.floor(contentX / stride)),
+      );
+      return entries[index]?.sequence ?? null;
+    },
+    [entries],
+  );
+
+  const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    // Capture so a drag keeps scrubbing even off the strip.
+    event.currentTarget.setPointerCapture(event.pointerId);
+    scrubbingRef.current = true;
+    const sequence = sequenceAtClientX(event.clientX);
+    if (sequence !== null) onSelect(sequence);
+  };
+  const handlePointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    // Only scrub for drags that started on the strip (pointer capture keeps
+    // routing those here); ignore selections dragged across from elsewhere.
+    if (!scrubbingRef.current || event.buttons === 0) return;
+    const sequence = sequenceAtClientX(event.clientX);
+    if (sequence !== null) onSelect(sequence);
+  };
+  const handlePointerEnd = () => {
+    scrubbingRef.current = false;
+    centerWave();
+  };
+
+  return (
+    <div
+      ref={stripRef}
+      className="agent-history-minimap"
+      role="group"
+      aria-label="Message index"
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerEnd}
+      onPointerCancel={handlePointerEnd}
+    >
+      {entries.map(({ message, sequence }) => {
+        const roleLabel = message.role === "assistant" ? "assistant" : "user";
+        const inView =
+          visibleRange !== null &&
+          sequence >= visibleRange.start &&
+          sequence <= visibleRange.end;
+        return (
+          <button
+            key={message.id}
+            type="button"
+            className={
+              `agent-history-minimap-bar is-${message.role}` +
+              (inView ? " is-in-view" : "")
+            }
+            title={`#${sequence} ${roleLabel}`}
+            aria-label={`Go to message ${sequence} (${roleLabel})`}
+            onClick={() => onSelect(sequence)}
+          />
+        );
+      })}
+    </div>
   );
 }
 
@@ -173,9 +305,6 @@ export function AgentHistoryDrawer({
   const [drawerTab, setDrawerTab] = useState<"messages" | "details">(
     "messages",
   );
-  const [showAssistantMessages, setShowAssistantMessages] = useState(
-    initialShowAssistantMessages,
-  );
   const [previewPane, setPreviewPane] = useState<Pane | null>(null);
   const [previewSummary, setPreviewSummary] =
     useState<AgentSessionSummary | null>(null);
@@ -185,6 +314,15 @@ export function AgentHistoryDrawer({
     useState<AgentHistoryEntry | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [highlightedSequence, setHighlightedSequence] = useState<number | null>(
+    null,
+  );
+  const [visibleRange, setVisibleRange] =
+    useState<MessageMinimapVisibleRange | null>(null);
+  const timelineRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const visibleRangeKeyRef = useRef("");
+  const highlightTimerRef = useRef<number | null>(null);
   const loadSeqRef = useRef(0);
   const previewSeqRef = useRef(0);
 
@@ -252,6 +390,13 @@ export function AgentHistoryDrawer({
     // switched connection or replacement runtime.
     loadSeqRef.current += 1;
     previewSeqRef.current += 1;
+    if (highlightTimerRef.current !== null) {
+      window.clearTimeout(highlightTimerRef.current);
+      highlightTimerRef.current = null;
+    }
+    setHighlightedSequence(null);
+    visibleRangeKeyRef.current = "";
+    setVisibleRange(null);
     setHistory(null);
     setSession(null);
     setDrawerTab("messages");
@@ -324,16 +469,112 @@ export function AgentHistoryDrawer({
     setPreviewError("");
   }, []);
 
+  useEffect(
+    () => () => {
+      if (highlightTimerRef.current !== null) {
+        window.clearTimeout(highlightTimerRef.current);
+      }
+    },
+    [],
+  );
+
+  const messagesKey = history?.messages;
+
+  // Track which messages the timeline viewport contains so the minimap can
+  // raise their bars as a moving "wave" while scrolling. Geometry-based
+  // instead of IntersectionObserver: it updates every scroll frame and does
+  // not depend on observer delivery timing, which mobile browsers throttle
+  // aggressively during momentum scrolling.
+  useEffect(() => {
+    const root = contentRef.current;
+    const timeline = timelineRef.current;
+    if (!open || drawerTab !== "messages" || !root || !timeline) {
+      visibleRangeKeyRef.current = "";
+      setVisibleRange(null);
+      return;
+    }
+    const publish = (range: MessageMinimapVisibleRange | null) => {
+      const key = range ? `${range.start}:${range.end}` : "";
+      // Scrolling crosses card boundaries constantly; skip no-op publishes so
+      // the drawer only re-renders when the visible range actually changes.
+      if (key === visibleRangeKeyRef.current) return;
+      visibleRangeKeyRef.current = key;
+      setVisibleRange(range);
+    };
+    let frame = 0;
+    const recompute = () => {
+      frame = 0;
+      const rootRect = root.getBoundingClientRect();
+      // Clip the viewport rect to the visible screen as well. Normally the
+      // content container clips the timeline itself, but if an ancestor ends
+      // up being the scroller (mobile viewport quirks) the container's rect
+      // spans every card and would mark all bars in-view.
+      const viewTop = Math.max(rootRect.top, 0);
+      const viewBottom = Math.min(rootRect.bottom, window.innerHeight);
+      let min = Infinity;
+      let max = -Infinity;
+      for (const card of timeline.children) {
+        const rect = card.getBoundingClientRect();
+        if (rect.bottom <= viewTop || rect.top >= viewBottom) continue;
+        const sequence = Number((card as HTMLElement).dataset.sequence);
+        if (!Number.isFinite(sequence)) continue;
+        min = Math.min(min, sequence);
+        max = Math.max(max, sequence);
+      }
+      publish(min <= max ? { start: min, end: max } : null);
+    };
+    const schedule = () => {
+      if (frame === 0) frame = window.requestAnimationFrame(recompute);
+    };
+    schedule();
+    const resizeObserver = new ResizeObserver(schedule);
+    resizeObserver.observe(root);
+    // Scroll events do not bubble, but capture listeners on window fire for
+    // scrolls on any descendant, so this covers the content container and
+    // any ancestor that ends up scrolling instead.
+    window.addEventListener("scroll", schedule, {
+      passive: true,
+      capture: true,
+    });
+    window.addEventListener("resize", schedule);
+    return () => {
+      if (frame !== 0) window.cancelAnimationFrame(frame);
+      resizeObserver.disconnect();
+      window.removeEventListener("scroll", schedule, true);
+      window.removeEventListener("resize", schedule);
+    };
+  }, [drawerTab, messagesKey, open]);
+
   // Stable identity so the message dialog's focus effect only re-runs when the
   // message itself changes, not on every drawer re-render.
   const closeExpandedMessage = useCallback(() => setExpandedMessage(null), []);
 
+  const scrollToMessage = useCallback((sequence: number) => {
+    const card = timelineRef.current?.querySelector(
+      `[data-sequence="${sequence}"]`,
+    );
+    if (!(card instanceof HTMLElement)) return;
+    const reduceMotion = minimapPrefersReducedMotion();
+    card.scrollIntoView({
+      behavior: reduceMotion ? "auto" : "smooth",
+      block: "start",
+    });
+    if (highlightTimerRef.current !== null) {
+      window.clearTimeout(highlightTimerRef.current);
+    }
+    setHighlightedSequence(sequence);
+    highlightTimerRef.current = window.setTimeout(() => {
+      highlightTimerRef.current = null;
+      setHighlightedSequence(null);
+    }, 1200);
+  }, []);
+
   const usage = tokenUsage(session);
   const messages = history?.messages ?? [];
-  const visibleMessages = visibleSessionMessages(
-    messages,
-    showAssistantMessages,
-  );
+  const messageEntries = messages.map((message, index) => ({
+    message,
+    sequence: index + 1,
+  }));
   const sessionReady = session?.status === "ok";
   const historyReady = history?.status === "ok" || messages.length > 0;
   const hasSessionData = sessionReady || historyReady;
@@ -356,6 +597,7 @@ export function AgentHistoryDrawer({
         className={`agent-history-drawer ${open ? "is-open" : ""} ${
           embedded ? "is-embedded" : ""
         }`}
+        data-drawer-tab={drawerTab}
         aria-label="Agent session"
         aria-hidden={!open}
       >
@@ -468,49 +710,18 @@ export function AgentHistoryDrawer({
                 role="tablist"
                 aria-label="Session drawer view"
               >
-                <div
-                  className={
-                    "agent-history-message-tab" +
-                    (drawerTab === "messages" ? " is-active" : "")
-                  }
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={drawerTab === "messages"}
+                  className={drawerTab === "messages" ? "is-active" : ""}
+                  onClick={() => setDrawerTab("messages")}
                 >
-                  <button
-                    type="button"
-                    role="tab"
-                    aria-selected={drawerTab === "messages"}
-                    onClick={() => setDrawerTab("messages")}
-                  >
-                    Messages
-                    {visibleMessages.length > 0 ? (
-                      <span>{visibleMessages.length}</span>
-                    ) : null}
-                  </button>
-                  {drawerTab === "messages" ? (
-                    <div
-                      className="agent-history-assistant-filter"
-                      title="Show assistant messages"
-                    >
-                      <Bot size={12} aria-hidden="true" />
-                      <button
-                        type="button"
-                        role="switch"
-                        aria-label="Show assistant messages"
-                        aria-checked={showAssistantMessages}
-                        className={
-                          "agent-history-assistant-switch" +
-                          (showAssistantMessages ? " is-on" : "")
-                        }
-                        onClick={() => {
-                          const next = !showAssistantMessages;
-                          setShowAssistantMessages(next);
-                          persistShowAssistantMessages(next);
-                        }}
-                      >
-                        <span />
-                      </button>
-                    </div>
+                  Messages
+                  {messageEntries.length > 0 ? (
+                    <span>{messageEntries.length}</span>
                   ) : null}
-                </div>
+                </button>
                 <button
                   type="button"
                   role="tab"
@@ -525,31 +736,43 @@ export function AgentHistoryDrawer({
 
             {error ? <div className="agent-history-error">{error}</div> : null}
             {drawerTab === "messages" ? (
-              <div className="agent-history-content" role="tabpanel">
-                {loading && messages.length === 0 ? (
-                  <div className="agent-history-state">
-                    <span className="terminal-loading-dot" />
-                    Loading messages
-                  </div>
-                ) : visibleMessages.length === 0 ? (
-                  <div className="agent-history-state">
-                    {messages.length > 0
-                      ? "No user messages were found in this session."
-                      : "No conversation messages were found in this session."}
-                  </div>
-                ) : (
-                  <div className="agent-history-timeline">
-                    {visibleMessages.map(({ message, sequence }) => (
-                      <AgentHistoryMessageCard
-                        entry={message}
-                        index={sequence}
-                        key={message.id}
-                        onExpand={() => setExpandedMessage(message)}
-                      />
-                    ))}
-                  </div>
-                )}
-              </div>
+              <>
+                {messageEntries.length > 1 ? (
+                  <AgentHistoryMinimap
+                    entries={messageEntries}
+                    visibleRange={visibleRange}
+                    onSelect={scrollToMessage}
+                  />
+                ) : null}
+                <div
+                  className="agent-history-content"
+                  role="tabpanel"
+                  ref={contentRef}
+                >
+                  {loading && messages.length === 0 ? (
+                    <div className="agent-history-state">
+                      <span className="terminal-loading-dot" />
+                      Loading messages
+                    </div>
+                  ) : messageEntries.length === 0 ? (
+                    <div className="agent-history-state">
+                      No conversation messages were found in this session.
+                    </div>
+                  ) : (
+                    <div className="agent-history-timeline" ref={timelineRef}>
+                      {messageEntries.map(({ message, sequence }) => (
+                        <AgentHistoryMessageCard
+                          entry={message}
+                          index={sequence}
+                          key={message.id}
+                          highlighted={highlightedSequence === sequence}
+                          onExpand={setExpandedMessage}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </>
             ) : (
               <div className="agent-history-details" role="tabpanel">
                 <DetailRow label="Workspace" value={workspaceLabel} />

--- a/web/src/components/AgentHistoryDrawer.tsx
+++ b/web/src/components/AgentHistoryDrawer.tsx
@@ -747,7 +747,7 @@ export function AgentHistoryDrawer({
 
             {error ? <div className="agent-history-error">{error}</div> : null}
             {drawerTab === "messages" ? (
-              <>
+              <div className="agent-history-messages" role="tabpanel">
                 {messageEntries.length > 1 ? (
                   <AgentHistoryMinimap
                     entries={messageEntries}
@@ -756,11 +756,7 @@ export function AgentHistoryDrawer({
                     onSelect={scrollToMessage}
                   />
                 ) : null}
-                <div
-                  className="agent-history-content"
-                  role="tabpanel"
-                  ref={contentRef}
-                >
+                <div className="agent-history-content" ref={contentRef}>
                   {loading && messages.length === 0 ? (
                     <div className="agent-history-state">
                       <span className="terminal-loading-dot" />
@@ -784,7 +780,7 @@ export function AgentHistoryDrawer({
                     </div>
                   )}
                 </div>
-              </>
+              </div>
             ) : (
               <div className="agent-history-details" role="tabpanel">
                 {sessionReady ? (

--- a/web/src/components/AgentHistoryDrawer.tsx
+++ b/web/src/components/AgentHistoryDrawer.tsx
@@ -245,9 +245,11 @@ function AgentHistoryMinimap({
     if (sequence !== null) onSelect(sequence);
   };
   const handlePointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
-    // Only scrub for drags that started on the strip (pointer capture keeps
-    // routing those here); ignore selections dragged across from elsewhere.
-    if (!scrubbingRef.current || event.buttons === 0) return;
+    // Only scrub for drags that started on the strip; pointer capture keeps
+    // routing those here until pointerup/pointercancel clears the ref. (No
+    // event.buttons check: some touch implementations report buttons = 0
+    // mid-drag, which would silently break scrubbing.)
+    if (!scrubbingRef.current) return;
     const sequence = sequenceAtClientX(event.clientX);
     if (sequence !== null) onSelect(sequence);
   };
@@ -292,6 +294,12 @@ function AgentHistoryMinimap({
     onSelect(Math.max(1, Math.min(count, next)));
   };
 
+  const currentSequence = visibleRange?.start ?? 1;
+  const currentEntry = entries[currentSequence - 1];
+  const currentValueText = currentEntry
+    ? `#${currentSequence} ${currentEntry.message.role === "assistant" ? "assistant" : "user"}`
+    : undefined;
+
   return (
     <div className="agent-history-minimap-wrap">
       <div
@@ -303,7 +311,8 @@ function AgentHistoryMinimap({
         aria-orientation="horizontal"
         aria-valuemin={1}
         aria-valuemax={entries.length}
-        aria-valuenow={visibleRange?.start ?? 1}
+        aria-valuenow={currentSequence}
+        aria-valuetext={currentValueText}
         onKeyDown={handleKeyDown}
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
@@ -573,9 +582,31 @@ export function AgentHistoryDrawer({
       // spans every card and would mark all bars in-view.
       const viewTop = Math.max(rootRect.top, 0);
       const viewBottom = Math.min(rootRect.bottom, window.innerHeight);
+      const cards = timeline.children;
+      const count = cards.length;
+      // Seed the scan near the expected first visible card (scroll fraction
+      // × count) instead of scanning from the top, then back up to the true
+      // boundary. Heights vary so the seed is approximate, but the walk is
+      // bounded by the estimation error instead of the full history, which
+      // matters for long sessions and for frames with a dirty layout (each
+      // rect read can otherwise force a layout of the whole timeline).
+      let start = 0;
+      if (count > 0 && root.scrollHeight > 0) {
+        const scrollViewTop = root.scrollTop + (viewTop - rootRect.top);
+        start = Math.min(
+          count - 1,
+          Math.max(0, Math.floor((scrollViewTop / root.scrollHeight) * count)),
+        );
+        while (start > 0) {
+          const prev = cards[start - 1].getBoundingClientRect();
+          if (prev.bottom <= viewTop) break;
+          start--;
+        }
+      }
       let min = Infinity;
       let max = -Infinity;
-      for (const card of timeline.children) {
+      for (let i = start; i < count; i++) {
+        const card = cards[i];
         const rect = card.getBoundingClientRect();
         // Cards stack vertically in DOM order, so once one starts below the
         // viewport every later card is below it too.

--- a/web/src/components/AgentHistoryDrawer.tsx
+++ b/web/src/components/AgentHistoryDrawer.tsx
@@ -75,6 +75,47 @@ function messageSummary(text: string) {
   return `${lines.length} lines`;
 }
 
+// Temporary diagnostics for the minimap wave, enabled with ?debug-minimap=1.
+const MINIMAP_DEBUG_ENABLED =
+  typeof window !== "undefined" &&
+  new URLSearchParams(window.location.search).has("debug-minimap");
+
+function MinimapWaveDebug({
+  contentRef,
+  visibleRange,
+  open,
+  drawerTab,
+  messageCount,
+}: {
+  contentRef: React.RefObject<HTMLDivElement | null>;
+  visibleRange: MessageMinimapVisibleRange | null;
+  open: boolean;
+  drawerTab: string;
+  messageCount: number;
+}) {
+  const [line, setLine] = useState("");
+  useEffect(() => {
+    const update = () => {
+      const el = contentRef.current;
+      const bars = document.querySelectorAll(
+        ".agent-history-minimap-bar.is-in-view",
+      ).length;
+      const first = document.querySelector(".agent-history-minimap-bar");
+      const t = first ? getComputedStyle(first).transform : "?";
+      setLine(
+        `dbg4 open=${open} tab=${drawerTab} msgs=${messageCount} ` +
+          `st=${el ? Math.round(el.scrollTop) : "?"} ` +
+          `wave=${visibleRange ? `${visibleRange.start}-${visibleRange.end}` : "null"} ` +
+          `bars=${bars} t=${t.slice(0, 20)}`,
+      );
+    };
+    update();
+    const timer = window.setInterval(update, 400);
+    return () => window.clearInterval(timer);
+  }, [contentRef, visibleRange, open, drawerTab, messageCount]);
+  return <div className="minimap-debug-overlay">{line}</div>;
+}
+
 // Cards are memoized because the timeline can hold hundreds of them and the
 // drawer's minimap viewport tracking re-renders on every scroll boundary.
 const AgentHistoryMessageCard = memo(function AgentHistoryMessageCard({
@@ -524,7 +565,7 @@ export function AgentHistoryDrawer({
   useEffect(() => {
     const root = contentRef.current;
     const timeline = timelineRef.current;
-    if (!open || drawerTab !== "messages" || !root || !timeline) {
+    if (drawerTab !== "messages" || !root || !timeline) {
       visibleRangeKeyRef.current = "";
       setVisibleRange(null);
       return;
@@ -541,6 +582,12 @@ export function AgentHistoryDrawer({
     const recompute = () => {
       frame = 0;
       const rootRect = root.getBoundingClientRect();
+      // A hidden container (e.g. the inspector showing another view) has an
+      // empty rect; skip the scan so background scrolls stay O(1) here.
+      if (rootRect.width === 0 || rootRect.height === 0) {
+        publish(null);
+        return;
+      }
       // Clip the viewport rect to the visible screen as well. Normally the
       // content container clips the timeline itself, but if an ancestor ends
       // up being the scroller (mobile viewport quirks) the container's rect
@@ -582,7 +629,7 @@ export function AgentHistoryDrawer({
       window.removeEventListener("scroll", schedule, true);
       window.removeEventListener("resize", schedule);
     };
-  }, [drawerTab, messagesKey, open]);
+  }, [drawerTab, messagesKey]);
 
   // Stable identity so the message dialog's focus effect only re-runs when the
   // message itself changes, not on every drawer re-render.
@@ -870,6 +917,15 @@ export function AgentHistoryDrawer({
             ) : null}
           </>
         )}
+        {MINIMAP_DEBUG_ENABLED ? (
+          <MinimapWaveDebug
+            contentRef={contentRef}
+            visibleRange={visibleRange}
+            open={open}
+            drawerTab={drawerTab}
+            messageCount={messages.length}
+          />
+        ) : null}
       </aside>
       <AgentMessageDialog
         message={expandedMessage}

--- a/web/src/components/AgentHistoryDrawer.tsx
+++ b/web/src/components/AgentHistoryDrawer.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
   type PointerEvent as ReactPointerEvent,
+  type RefObject,
 } from "react";
 import { Copy, Download, Eye, RefreshCw, X } from "lucide-react";
 import { useStoreSelector } from "../store";
@@ -159,10 +160,12 @@ function minimapPrefersReducedMotion() {
 function AgentHistoryMinimap({
   entries,
   visibleRange,
+  indicatorRef,
   onSelect,
 }: {
   entries: { message: AgentHistoryEntry; sequence: number }[];
   visibleRange: MessageMinimapVisibleRange | null;
+  indicatorRef: RefObject<HTMLDivElement>;
   onSelect: (sequence: number) => void;
 }) {
   const stripRef = useRef<HTMLDivElement>(null);
@@ -249,18 +252,6 @@ function AgentHistoryMinimap({
     centerWave();
   };
 
-  // The indicator marks which slice of the whole history the timeline
-  // viewport currently shows (like a minimap viewport rectangle), so it is
-  // derived from the visible range itself rather than the strip's own
-  // scroll position, which the wave-follow logic deliberately suppresses
-  // while scrubbing.
-  const total = entries.length;
-  const thumbVisible = visibleRange !== null && total > 0;
-  const thumbLeft = thumbVisible ? ((visibleRange.start - 1) / total) * 100 : 0;
-  const thumbWidth = thumbVisible
-    ? Math.max(((visibleRange.end - visibleRange.start + 1) / total) * 100, 2)
-    : 0;
-
   return (
     <div className="agent-history-minimap-wrap">
       <div
@@ -296,12 +287,9 @@ function AgentHistoryMinimap({
       </div>
       <div className="agent-history-minimap-scrollbar" aria-hidden="true">
         <div
+          ref={indicatorRef}
           className="agent-history-minimap-scrollbar-thumb"
-          style={
-            thumbVisible
-              ? { left: `${thumbLeft}%`, width: `${thumbWidth}%` }
-              : { display: "none" }
-          }
+          style={{ display: "none" }}
         />
       </div>
     </div>
@@ -345,6 +333,7 @@ export function AgentHistoryDrawer({
     useState<MessageMinimapVisibleRange | null>(null);
   const timelineRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+  const minimapIndicatorRef = useRef<HTMLDivElement>(null);
   const visibleRangeKeyRef = useRef("");
   const highlightTimerRef = useRef<number | null>(null);
   const loadSeqRef = useRef(0);
@@ -555,6 +544,27 @@ export function AgentHistoryDrawer({
         max = Math.max(max, sequence);
       }
       publish(min <= max ? { start: min, end: max } : null);
+      // Move the minimap indicator like a real scrollbar: a continuous,
+      // per-frame linear mapping of the timeline's scroll geometry (the same
+      // math native scrollbars use), applied imperatively so it glides with
+      // the scroll instead of stepping with the wave state.
+      const thumb = minimapIndicatorRef.current;
+      const track = thumb?.parentElement;
+      if (thumb && track) {
+        const maxScroll = root.scrollHeight - root.clientHeight;
+        if (maxScroll <= 1) {
+          thumb.style.display = "none";
+        } else {
+          const trackWidth = track.clientWidth;
+          const thumbWidth = Math.max(
+            (root.clientHeight / root.scrollHeight) * trackWidth,
+            12,
+          );
+          thumb.style.display = "block";
+          thumb.style.width = `${thumbWidth}px`;
+          thumb.style.transform = `translateX(${(root.scrollTop / maxScroll) * (trackWidth - thumbWidth)}px)`;
+        }
+      }
     };
     const schedule = () => {
       if (frame === 0) frame = window.requestAnimationFrame(recompute);
@@ -742,6 +752,7 @@ export function AgentHistoryDrawer({
                   <AgentHistoryMinimap
                     entries={messageEntries}
                     visibleRange={visibleRange}
+                    indicatorRef={minimapIndicatorRef}
                     onSelect={scrollToMessage}
                   />
                 ) : null}

--- a/web/src/components/AgentHistoryDrawer.tsx
+++ b/web/src/components/AgentHistoryDrawer.tsx
@@ -75,47 +75,6 @@ function messageSummary(text: string) {
   return `${lines.length} lines`;
 }
 
-// Temporary diagnostics for the minimap wave, enabled with ?debug-minimap=1.
-const MINIMAP_DEBUG_ENABLED =
-  typeof window !== "undefined" &&
-  new URLSearchParams(window.location.search).has("debug-minimap");
-
-function MinimapWaveDebug({
-  contentRef,
-  visibleRange,
-  open,
-  drawerTab,
-  messageCount,
-}: {
-  contentRef: React.RefObject<HTMLDivElement | null>;
-  visibleRange: MessageMinimapVisibleRange | null;
-  open: boolean;
-  drawerTab: string;
-  messageCount: number;
-}) {
-  const [line, setLine] = useState("");
-  useEffect(() => {
-    const update = () => {
-      const el = contentRef.current;
-      const bars = document.querySelectorAll(
-        ".agent-history-minimap-bar.is-in-view",
-      ).length;
-      const first = document.querySelector(".agent-history-minimap-bar");
-      const t = first ? getComputedStyle(first).transform : "?";
-      setLine(
-        `dbg4 open=${open} tab=${drawerTab} msgs=${messageCount} ` +
-          `st=${el ? Math.round(el.scrollTop) : "?"} ` +
-          `wave=${visibleRange ? `${visibleRange.start}-${visibleRange.end}` : "null"} ` +
-          `bars=${bars} t=${t.slice(0, 20)}`,
-      );
-    };
-    update();
-    const timer = window.setInterval(update, 400);
-    return () => window.clearInterval(timer);
-  }, [contentRef, visibleRange, open, drawerTab, messageCount]);
-  return <div className="minimap-debug-overlay">{line}</div>;
-}
-
 // Cards are memoized because the timeline can hold hundreds of them and the
 // drawer's minimap viewport tracking re-renders on every scroll boundary.
 const AgentHistoryMessageCard = memo(function AgentHistoryMessageCard({
@@ -905,15 +864,6 @@ export function AgentHistoryDrawer({
             ) : null}
           </>
         )}
-        {MINIMAP_DEBUG_ENABLED ? (
-          <MinimapWaveDebug
-            contentRef={contentRef}
-            visibleRange={visibleRange}
-            open={open}
-            drawerTab={drawerTab}
-            messageCount={messages.length}
-          />
-        ) : null}
       </aside>
       <AgentMessageDialog
         message={expandedMessage}

--- a/web/src/components/AgentHistoryDrawer.tsx
+++ b/web/src/components/AgentHistoryDrawer.tsx
@@ -4,6 +4,7 @@ import {
   useEffect,
   useRef,
   useState,
+  type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
   type RefObject,
 } from "react";
@@ -215,14 +216,17 @@ function AgentHistoryMinimap({
       if (!strip || !(firstBar instanceof HTMLElement)) return null;
       const count = entries.length;
       if (count === 0) return null;
-      // Keep the gap in sync with .agent-history-minimap in styles.css.
-      const stride = firstBar.offsetWidth + 2;
+      // Derive the stride (bar width + gap) from the first two bars'
+      // geometry so the mapping stays correct whatever gap the CSS uses.
+      const firstLeft = firstBar.getBoundingClientRect().left;
+      const secondBar = firstBar.nextElementSibling;
+      const stride =
+        secondBar instanceof HTMLElement
+          ? secondBar.getBoundingClientRect().left - firstLeft
+          : firstBar.offsetWidth;
       if (stride <= 0) return null;
       const stripRect = strip.getBoundingClientRect();
-      const barsLeft =
-        firstBar.getBoundingClientRect().left -
-        stripRect.left +
-        strip.scrollLeft;
+      const barsLeft = firstLeft - stripRect.left + strip.scrollLeft;
       const contentX = clientX - stripRect.left + strip.scrollLeft - barsLeft;
       const index = Math.max(
         0,
@@ -251,14 +255,56 @@ function AgentHistoryMinimap({
     scrubbingRef.current = false;
     centerWave();
   };
+  // The strip is a single slider-like control: one tab stop, with arrow-key
+  // navigation across messages. The bars themselves stay non-focusable.
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    const count = entries.length;
+    if (count === 0) return;
+    const range = visibleRangeRef.current;
+    const current = range?.start ?? 1;
+    const span = range ? range.end - range.start + 1 : 1;
+    let next: number;
+    switch (event.key) {
+      case "ArrowLeft":
+      case "ArrowDown":
+        next = current - 1;
+        break;
+      case "ArrowRight":
+      case "ArrowUp":
+        next = current + 1;
+        break;
+      case "PageUp":
+        next = current - span;
+        break;
+      case "PageDown":
+        next = current + span;
+        break;
+      case "Home":
+        next = 1;
+        break;
+      case "End":
+        next = count;
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+    onSelect(Math.max(1, Math.min(count, next)));
+  };
 
   return (
     <div className="agent-history-minimap-wrap">
       <div
         ref={stripRef}
         className="agent-history-minimap"
-        role="group"
-        aria-label="Message index"
+        role="slider"
+        tabIndex={0}
+        aria-label="Jump to message"
+        aria-orientation="horizontal"
+        aria-valuemin={1}
+        aria-valuemax={entries.length}
+        aria-valuenow={visibleRange?.start ?? 1}
+        onKeyDown={handleKeyDown}
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerEnd}
@@ -271,16 +317,13 @@ function AgentHistoryMinimap({
             sequence >= visibleRange.start &&
             sequence <= visibleRange.end;
           return (
-            <button
+            <div
               key={message.id}
-              type="button"
               className={
                 `agent-history-minimap-bar is-${message.role}` +
                 (inView ? " is-in-view" : "")
               }
               title={`#${sequence} ${roleLabel}`}
-              aria-label={`Go to message ${sequence} (${roleLabel})`}
-              onClick={() => onSelect(sequence)}
             />
           );
         })}
@@ -574,8 +617,19 @@ export function AgentHistoryDrawer({
     resizeObserver.observe(root);
     // Scroll events do not bubble, but capture listeners on window fire for
     // scrolls on any descendant, so this covers the content container and
-    // any ancestor that ends up scrolling instead.
-    window.addEventListener("scroll", schedule, {
+    // any ancestor that ends up scrolling instead. Filter out scrolls that
+    // cannot move the timeline so unrelated views never wake this up.
+    const onScroll = (event: Event) => {
+      const target = event.target;
+      if (
+        target === document ||
+        (target instanceof Node &&
+          (root.contains(target) || target.contains(root)))
+      ) {
+        schedule();
+      }
+    };
+    window.addEventListener("scroll", onScroll, {
       passive: true,
       capture: true,
     });
@@ -583,7 +637,7 @@ export function AgentHistoryDrawer({
     return () => {
       if (frame !== 0) window.cancelAnimationFrame(frame);
       resizeObserver.disconnect();
-      window.removeEventListener("scroll", schedule, true);
+      window.removeEventListener("scroll", onScroll, true);
       window.removeEventListener("resize", schedule);
     };
   }, [drawerTab, messagesKey]);

--- a/web/src/components/AgentHistoryDrawer.tsx
+++ b/web/src/components/AgentHistoryDrawer.tsx
@@ -515,7 +515,10 @@ export function AgentHistoryDrawer({
       let max = -Infinity;
       for (const card of timeline.children) {
         const rect = card.getBoundingClientRect();
-        if (rect.bottom <= viewTop || rect.top >= viewBottom) continue;
+        // Cards stack vertically in DOM order, so once one starts below the
+        // viewport every later card is below it too.
+        if (rect.top >= viewBottom) break;
+        if (rect.bottom <= viewTop) continue;
         const sequence = Number((card as HTMLElement).dataset.sequence);
         if (!Number.isFinite(sequence)) continue;
         min = Math.min(min, sequence);

--- a/web/src/components/AgentHistoryDrawer.tsx
+++ b/web/src/components/AgentHistoryDrawer.tsx
@@ -290,32 +290,17 @@ function AgentHistoryMinimap({
     centerWave();
   };
 
-  // Thin position indicator for the strip's own horizontal scroll, updated
-  // imperatively so native strip scrolls don't need React re-renders.
-  const thumbRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    const strip = stripRef.current;
-    const thumb = thumbRef.current;
-    if (!strip || !thumb) return;
-    const update = () => {
-      const { scrollLeft, scrollWidth, clientWidth } = strip;
-      if (scrollWidth <= clientWidth + 1) {
-        thumb.style.display = "none";
-        return;
-      }
-      thumb.style.display = "block";
-      thumb.style.width = `${(clientWidth / scrollWidth) * 100}%`;
-      thumb.style.left = `${(scrollLeft / scrollWidth) * 100}%`;
-    };
-    update();
-    const resizeObserver = new ResizeObserver(update);
-    resizeObserver.observe(strip);
-    strip.addEventListener("scroll", update, { passive: true });
-    return () => {
-      resizeObserver.disconnect();
-      strip.removeEventListener("scroll", update);
-    };
-  }, [entries.length]);
+  // The indicator marks which slice of the whole history the timeline
+  // viewport currently shows (like a minimap viewport rectangle), so it is
+  // derived from the visible range itself rather than the strip's own
+  // scroll position, which the wave-follow logic deliberately suppresses
+  // while scrubbing.
+  const total = entries.length;
+  const thumbVisible = visibleRange !== null && total > 0;
+  const thumbLeft = thumbVisible ? ((visibleRange.start - 1) / total) * 100 : 0;
+  const thumbWidth = thumbVisible
+    ? Math.max(((visibleRange.end - visibleRange.start + 1) / total) * 100, 2)
+    : 0;
 
   return (
     <div className="agent-history-minimap-wrap">
@@ -352,9 +337,12 @@ function AgentHistoryMinimap({
       </div>
       <div className="agent-history-minimap-scrollbar" aria-hidden="true">
         <div
-          ref={thumbRef}
           className="agent-history-minimap-scrollbar-thumb"
-          style={{ display: "none" }}
+          style={
+            thumbVisible
+              ? { left: `${thumbLeft}%`, width: `${thumbWidth}%` }
+              : { display: "none" }
+          }
         />
       </div>
     </div>

--- a/web/src/components/AgentHistoryDrawer.tsx
+++ b/web/src/components/AgentHistoryDrawer.tsx
@@ -249,37 +249,73 @@ function AgentHistoryMinimap({
     centerWave();
   };
 
+  // Thin position indicator for the strip's own horizontal scroll, updated
+  // imperatively so native strip scrolls don't need React re-renders.
+  const thumbRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const strip = stripRef.current;
+    const thumb = thumbRef.current;
+    if (!strip || !thumb) return;
+    const update = () => {
+      const { scrollLeft, scrollWidth, clientWidth } = strip;
+      if (scrollWidth <= clientWidth + 1) {
+        thumb.style.display = "none";
+        return;
+      }
+      thumb.style.display = "block";
+      thumb.style.width = `${(clientWidth / scrollWidth) * 100}%`;
+      thumb.style.left = `${(scrollLeft / scrollWidth) * 100}%`;
+    };
+    update();
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(strip);
+    strip.addEventListener("scroll", update, { passive: true });
+    return () => {
+      resizeObserver.disconnect();
+      strip.removeEventListener("scroll", update);
+    };
+  }, [entries.length]);
+
   return (
-    <div
-      ref={stripRef}
-      className="agent-history-minimap"
-      role="group"
-      aria-label="Message index"
-      onPointerDown={handlePointerDown}
-      onPointerMove={handlePointerMove}
-      onPointerUp={handlePointerEnd}
-      onPointerCancel={handlePointerEnd}
-    >
-      {entries.map(({ message, sequence }) => {
-        const roleLabel = message.role === "assistant" ? "assistant" : "user";
-        const inView =
-          visibleRange !== null &&
-          sequence >= visibleRange.start &&
-          sequence <= visibleRange.end;
-        return (
-          <button
-            key={message.id}
-            type="button"
-            className={
-              `agent-history-minimap-bar is-${message.role}` +
-              (inView ? " is-in-view" : "")
-            }
-            title={`#${sequence} ${roleLabel}`}
-            aria-label={`Go to message ${sequence} (${roleLabel})`}
-            onClick={() => onSelect(sequence)}
-          />
-        );
-      })}
+    <div className="agent-history-minimap-wrap">
+      <div
+        ref={stripRef}
+        className="agent-history-minimap"
+        role="group"
+        aria-label="Message index"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerEnd}
+        onPointerCancel={handlePointerEnd}
+      >
+        {entries.map(({ message, sequence }) => {
+          const roleLabel = message.role === "assistant" ? "assistant" : "user";
+          const inView =
+            visibleRange !== null &&
+            sequence >= visibleRange.start &&
+            sequence <= visibleRange.end;
+          return (
+            <button
+              key={message.id}
+              type="button"
+              className={
+                `agent-history-minimap-bar is-${message.role}` +
+                (inView ? " is-in-view" : "")
+              }
+              title={`#${sequence} ${roleLabel}`}
+              aria-label={`Go to message ${sequence} (${roleLabel})`}
+              onClick={() => onSelect(sequence)}
+            />
+          );
+        })}
+      </div>
+      <div className="agent-history-minimap-scrollbar" aria-hidden="true">
+        <div
+          ref={thumbRef}
+          className="agent-history-minimap-scrollbar-thumb"
+          style={{ display: "none" }}
+        />
+      </div>
     </div>
   );
 }
@@ -600,7 +636,6 @@ export function AgentHistoryDrawer({
         className={`agent-history-drawer ${open ? "is-open" : ""} ${
           embedded ? "is-embedded" : ""
         }`}
-        data-drawer-tab={drawerTab}
         aria-label="Agent session"
         aria-hidden={!open}
       >
@@ -644,37 +679,6 @@ export function AgentHistoryDrawer({
             ) : null}
           </div>
         </div>
-
-        {sessionReady ? (
-          <section
-            className="agent-history-overview"
-            aria-label="Session overview"
-          >
-            <div>
-              <strong>{formatCount(session.stats.turns)}</strong>
-              <span>Turns</span>
-            </div>
-            <div>
-              <strong>{formatTokenTotal(session)}</strong>
-              <span>Tokens</span>
-            </div>
-            <div>
-              <strong
-                title={updatedAt ? formatHistoryTime(updatedAt) : undefined}
-              >
-                {updatedAt ? formatRelativeTime(updatedAt) : "-"}
-              </strong>
-              <span>Updated</span>
-            </div>
-            <p>
-              Input {formatOptionalCompact(usage?.input_tokens)}
-              <span>·</span>
-              Cached {formatOptionalCompact(usage?.cached_input_tokens)}
-              <span>·</span>
-              Output {formatOptionalCompact(usage?.output_tokens)}
-            </p>
-          </section>
-        ) : null}
 
         {unavailable ? (
           <div className="agent-history-unavailable" role="status">
@@ -778,6 +782,38 @@ export function AgentHistoryDrawer({
               </>
             ) : (
               <div className="agent-history-details" role="tabpanel">
+                {sessionReady ? (
+                  <section
+                    className="agent-history-overview"
+                    aria-label="Session overview"
+                  >
+                    <div>
+                      <strong>{formatCount(session.stats.turns)}</strong>
+                      <span>Turns</span>
+                    </div>
+                    <div>
+                      <strong>{formatTokenTotal(session)}</strong>
+                      <span>Tokens</span>
+                    </div>
+                    <div>
+                      <strong
+                        title={
+                          updatedAt ? formatHistoryTime(updatedAt) : undefined
+                        }
+                      >
+                        {updatedAt ? formatRelativeTime(updatedAt) : "-"}
+                      </strong>
+                      <span>Updated</span>
+                    </div>
+                    <p>
+                      Input {formatOptionalCompact(usage?.input_tokens)}
+                      <span>·</span>
+                      Cached {formatOptionalCompact(usage?.cached_input_tokens)}
+                      <span>·</span>
+                      Output {formatOptionalCompact(usage?.output_tokens)}
+                    </p>
+                  </section>
+                ) : null}
                 <DetailRow label="Workspace" value={workspaceLabel} />
                 <DetailRow label="Agent" value={pane.agent ?? "-"} />
                 <DetailRow label="Pane" value={shortId(pane.pane_id)} />

--- a/web/src/components/AgentMessageDialog.tsx
+++ b/web/src/components/AgentMessageDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { Copy } from "lucide-react";
 import { UI_LOCALE } from "../uiLocale";
 import { CloseButton } from "./CloseButton";
@@ -58,7 +59,11 @@ export function AgentMessageDialog({
   if (!message) return null;
   const roleLabel = message.role === "assistant" ? "Assistant" : "User";
 
-  return (
+  // Render at the document root: on mobile the transformed .app box becomes
+  // the containing block for fixed elements, and the inspector slot's stacking
+  // context (z-index 3) would leave the topbar (z-index 120) painted over the
+  // dialog. A body-level backdrop escapes both.
+  return createPortal(
     <div className="modal-backdrop" onMouseDown={onClose}>
       <div
         ref={dialogRef}
@@ -116,6 +121,7 @@ export function AgentMessageDialog({
           <pre className="agent-message-modal-content">{message.text}</pre>
         )}
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/web/src/components/AgentSessionPreviewDialog.tsx
+++ b/web/src/components/AgentSessionPreviewDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, memo } from "react";
+import { createPortal } from "react-dom";
 import {
   Brain,
   ChevronRight,
@@ -142,7 +143,10 @@ export function AgentSessionPreviewDialog({
     summary?.detail ||
     "No readable session transcript was reported for this agent.";
 
-  return (
+  // Render at the document root for the same reason as AgentMessageDialog:
+  // on mobile the transformed .app box and the inspector slot's stacking
+  // context would otherwise let the topbar paint over the dialog.
+  return createPortal(
     <div className="modal-backdrop" onMouseDown={onClose}>
       <div
         ref={dialogRef}
@@ -319,7 +323,8 @@ export function AgentSessionPreviewDialog({
           </>
         )}
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/web/src/components/GlobalTooltip.tsx
+++ b/web/src/components/GlobalTooltip.tsx
@@ -21,6 +21,18 @@ function tooltipTarget(start: EventTarget | null): HTMLElement | null {
   return title ? target : null;
 }
 
+// matches() throws a SyntaxError for :focus-visible on browsers without the
+// pseudo-class (e.g. Safari < 15.4); this runs inside a document-level focus
+// listener, so translate that failure into "not keyboard focus" and skip the
+// focus tooltip instead of throwing on every focus event.
+function matchesFocusVisible(target: HTMLElement) {
+  try {
+    return target.matches(":focus-visible");
+  } catch {
+    return false;
+  }
+}
+
 function estimatedTooltipWidth(text: string) {
   return Math.min(
     MAX_TOOLTIP_WIDTH,
@@ -115,7 +127,7 @@ export function GlobalTooltip() {
       // buttons on some mobile browsers, and a tooltip shown then lingers
       // until the next tap blurs the button. Browsers exclude exactly that
       // case from :focus-visible while keeping keyboard navigation focused.
-      if (!target?.matches(":focus-visible")) return;
+      if (!target || !matchesFocusVisible(target)) return;
       showFor(target);
     };
     const onFocusOut = () => hide();

--- a/web/src/components/GlobalTooltip.tsx
+++ b/web/src/components/GlobalTooltip.tsx
@@ -111,7 +111,12 @@ export function GlobalTooltip() {
     };
     const onFocusIn = (event: FocusEvent) => {
       const target = tooltipTarget(event.target);
-      if (target) showFor(target);
+      // Only keyboard-driven focus deserves a tooltip. Touch taps also focus
+      // buttons on some mobile browsers, and a tooltip shown then lingers
+      // until the next tap blurs the button. Browsers exclude exactly that
+      // case from :focus-visible while keeping keyboard navigation focused.
+      if (!target?.matches(":focus-visible")) return;
+      showFor(target);
     };
     const onFocusOut = () => hide();
     const onPointerDown = () => hide();

--- a/web/src/components/agentSession.test.ts
+++ b/web/src/components/agentSession.test.ts
@@ -9,7 +9,6 @@ import {
   shouldShowAgentStatusLabel,
   summarizeTabAgents,
   toolArgumentsPreview,
-  visibleSessionMessages,
 } from "./agentSession";
 
 function step(
@@ -118,24 +117,6 @@ describe("agent session presentation", () => {
     expect(groups).toHaveLength(1);
     expect(groups[0].number).toBeNull();
     expect(groups[0].steps).toHaveLength(2);
-  });
-
-  test("filters assistant messages without renumbering user messages", () => {
-    const messages = [
-      { role: "user" as const, text: "first" },
-      { role: "assistant" as const, text: "response" },
-      { role: "user" as const, text: "second" },
-    ];
-
-    expect(visibleSessionMessages(messages, true)).toMatchObject([
-      { sequence: 1, message: { text: "first" } },
-      { sequence: 2, message: { text: "response" } },
-      { sequence: 3, message: { text: "second" } },
-    ]);
-    expect(visibleSessionMessages(messages, false)).toMatchObject([
-      { sequence: 1, message: { text: "first" } },
-      { sequence: 3, message: { text: "second" } },
-    ]);
   });
 
   test("previews tool call arguments by priority key", () => {

--- a/web/src/components/agentSession.ts
+++ b/web/src/components/agentSession.ts
@@ -161,11 +161,6 @@ export type AgentSessionTurn = {
   steps: AgentSessionTrajectoryStep[];
 };
 
-export type SequencedSessionMessage<T> = {
-  message: T;
-  sequence: number;
-};
-
 export type AgentSessionSummary = {
   status: "ok" | "missing_session" | "missing_file";
   detail?: string;
@@ -220,18 +215,6 @@ export function groupTrajectoryTurns(
   }
 
   return groups;
-}
-
-// Filtering must preserve the original conversation index so switching between
-// user-only and full conversation views does not renumber the same message.
-export function visibleSessionMessages<
-  T extends { role: "user" | "assistant" },
->(messages: T[], showAssistant: boolean): SequencedSessionMessage<T>[] {
-  return messages.flatMap((message, index) =>
-    showAssistant || message.role === "user"
-      ? [{ message, sequence: index + 1 }]
-      : [],
-  );
 }
 
 // Build a compact one-line preview for a tool call, preferring the most

--- a/web/src/components/overlayScrollbar.ts
+++ b/web/src/components/overlayScrollbar.ts
@@ -5,6 +5,7 @@ export const OVERLAY_SCROLLBAR_EXCLUDED_SELECTOR = [
   ".context-menu",
   ".pane-jump-popover",
   ".agent-session-export-menu",
+  ".agent-history-minimap",
   ".terminal-mobile-keys-panel",
   "[role=dialog]",
   "[role=menu]",

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1537,9 +1537,6 @@ textarea:focus {
   .agent-history-minimap-bar {
     transition: none;
   }
-  .agent-history-minimap-scrollbar-thumb {
-    transition: none;
-  }
 }
 
 /* ===== main 2-column body (sidebar | resizer | main) ===== */
@@ -7272,13 +7269,11 @@ textarea:focus {
 .agent-history-minimap-scrollbar-thumb {
   position: absolute;
   top: 0;
+  left: 0;
   height: 100%;
   border-radius: 1.5px;
   background: var(--accent);
   opacity: 0.55;
-  transition:
-    left 100ms ease,
-    width 100ms ease;
 }
 .agent-history-minimap-bar {
   /* Bars always fill the strip width, so any horizontal position maps

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7270,6 +7270,8 @@ textarea:focus {
   pointer-events: none;
 }
 .agent-history-minimap-scrollbar-thumb {
+  position: absolute;
+  top: 0;
   height: 100%;
   border-radius: 1.5px;
   background: var(--accent);
@@ -7307,23 +7309,6 @@ textarea:focus {
   transform: scaleY(1.6);
   opacity: 1;
 }
-.minimap-debug-overlay {
-  position: fixed;
-  left: 4px;
-  bottom: 4px;
-  z-index: 9999;
-  max-width: calc(100vw - 8px);
-  padding: 4px 6px;
-  background: rgb(0 0 0 / 0.85);
-  color: #7fff7f;
-  font-family: monospace;
-  font-size: 10px;
-  line-height: 1.4;
-  white-space: pre-wrap;
-  word-break: break-all;
-  pointer-events: none;
-}
-
 .agent-history-minimap-bar:hover,
 .agent-history-minimap-bar:focus-visible {
   opacity: 1;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1537,6 +1537,9 @@ textarea:focus {
   .agent-history-minimap-bar {
     transition: none;
   }
+  .agent-history-minimap-scrollbar-thumb {
+    transition: none;
+  }
 }
 
 /* ===== main 2-column body (sidebar | resizer | main) ===== */
@@ -7271,6 +7274,9 @@ textarea:focus {
   border-radius: 1.5px;
   background: var(--accent);
   opacity: 0.55;
+  transition:
+    left 100ms ease,
+    width 100ms ease;
 }
 .agent-history-minimap-bar {
   /* Bars always fill the strip width, so any horizontal position maps

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1531,6 +1531,12 @@ textarea:focus {
   .close-button svg {
     transition: none;
   }
+  .agent-history-card.is-minimap-target {
+    animation: none;
+  }
+  .agent-history-minimap-bar {
+    transition: none;
+  }
 }
 
 /* ===== main 2-column body (sidebar | resizer | main) ===== */
@@ -2780,6 +2786,11 @@ textarea:focus {
   width: min(720px, 100%);
   max-height: min(760px, calc(100vh - 36px));
   overflow: auto;
+  /* Auto margins center the modal like align/justify-content would, but let
+     an oversized modal align to the start edge instead so the backdrop can
+     scroll every part of it into view (flex centering would clip the top
+     beyond reach whenever the containing block is shorter than the modal). */
+  margin: auto;
   padding: 18px;
   border: 1px solid color-mix(in srgb, var(--shell-border) 84%, var(--text) 16%);
   border-radius: 16px;
@@ -3955,7 +3966,7 @@ textarea:focus {
 }
 .agent-session-modal {
   width: min(1040px, 100%);
-  height: min(820px, calc(100dvh - 36px));
+  height: min(820px, calc(100dvh - 36px), 100%);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -7046,6 +7057,19 @@ textarea:focus {
 .agent-history-card:hover {
   border-color: var(--border);
 }
+.agent-history-card.is-minimap-target {
+  animation: agent-history-card-flash 1.1s ease-out;
+}
+@keyframes agent-history-card-flash {
+  0% {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px var(--accent-soft);
+  }
+  100% {
+    border-color: var(--border-soft);
+    box-shadow: none;
+  }
+}
 .agent-history-card-meta {
   min-width: 0;
   display: flex;
@@ -7203,67 +7227,58 @@ textarea:focus {
   background: var(--panel-2);
   border-radius: 999px;
 }
-.agent-history-message-tab {
-  min-width: 0;
-  display: flex;
-  align-items: stretch;
-  justify-content: center;
-  border-bottom: 2px solid transparent;
-}
-.agent-history-message-tab.is-active {
-  border-bottom-color: var(--accent);
-}
-.agent-history-message-tab > button[role="tab"] {
-  min-width: 0;
-  padding-right: 4px;
-  border-bottom: none;
-}
-.agent-history-assistant-filter {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 0 7px 0 2px;
-  color: var(--muted);
-  white-space: nowrap;
-}
-.agent-history-assistant-switch {
-  position: relative;
-  width: 30px;
-  height: 18px;
+.agent-history-minimap {
   flex: 0 0 auto;
-  padding: 0;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: var(--input-bg);
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.16);
-  transition:
-    border-color 140ms ease,
-    background 140ms ease;
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  /* Fixed height so the wave's taller bars grow into the padding instead of
+     pushing the timeline around. */
+  height: 30px;
+  box-sizing: border-box;
+  padding: 8px 10px 6px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  border-bottom: 1px solid var(--border-soft);
+  scrollbar-width: none;
+  /* Horizontal drags scrub the timeline; vertical ones keep scrolling it. */
+  touch-action: pan-y;
 }
-.agent-history-assistant-switch > span {
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
+.agent-history-minimap::-webkit-scrollbar {
+  display: none;
+}
+.agent-history-minimap-bar {
+  /* Bars always fill the strip width, so any horizontal position maps
+     linearly to a message index when scrubbing. */
+  flex: 1 1 0;
+  min-width: 2px;
+  height: 10px;
+  padding: 0;
+  border: none;
+  border-radius: 1.5px;
   background: var(--muted);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+  opacity: 0.45;
+  /* The wave grows bars via transform (compositor-only) instead of height:
+     no layout thrash while scrolling, and immune to repaint issues on
+     mobile browsers inside transformed/overflow-hidden ancestors. */
+  transform-origin: bottom;
   transition:
     transform 140ms ease,
-    background 140ms ease;
+    opacity 140ms ease;
 }
-.agent-history-assistant-switch.is-on {
-  border-color: color-mix(in srgb, var(--accent) 78%, var(--border));
-  background: color-mix(in srgb, var(--accent) 30%, var(--input-bg));
+.agent-history-minimap-bar.is-user {
+  background: var(--blue);
 }
-.agent-history-assistant-switch.is-on > span {
-  background: var(--accent);
-  transform: translateX(12px);
+.agent-history-minimap-bar.is-assistant {
+  background: var(--green);
 }
-.agent-history-assistant-switch:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent) 62%, transparent);
-  outline-offset: 2px;
+.agent-history-minimap-bar.is-in-view {
+  transform: scaleY(1.6);
+  opacity: 1;
+}
+.agent-history-minimap-bar:hover,
+.agent-history-minimap-bar:focus-visible {
+  opacity: 1;
 }
 .agent-history-content {
   min-height: 0;
@@ -7381,7 +7396,10 @@ textarea:focus {
 }
 .agent-message-modal {
   width: min(820px, 100%);
-  max-height: min(760px, calc(100dvh - 36px));
+  /* The dialog renders in document.body via a portal; the 100% cap keeps it
+     inside its fixed backdrop even when visual viewport units (dvh) resolve
+     larger than the visible area on mobile. */
+  max-height: min(760px, calc(100dvh - 36px), 100%);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -7689,6 +7707,12 @@ textarea:focus {
   .workspace-inspector-actions .workspace-inspector-expand-action {
     display: none;
   }
+  /* The bottom mobile nav already switches between Files/Changes/History
+     and highlights the active view, so the in-inspector tab bar only costs
+     vertical space on phones. */
+  .workspace-inspector-tabs {
+    display: none;
+  }
   .topbar-start,
   .topbar-actions {
     gap: 8px;
@@ -7968,13 +7992,16 @@ textarea:focus {
   }
   .agent-session-modal {
     width: 100%;
-    height: calc(
-      100dvh -
-      28px -
-      env(safe-area-inset-top, 0px) -
-      env(safe-area-inset-bottom, 0px)
+    height: min(
+      calc(
+        100dvh -
+        28px -
+        env(safe-area-inset-top, 0px) -
+        env(safe-area-inset-bottom, 0px)
+      ),
+      100%
     );
-    max-height: calc(100vh - 28px);
+    max-height: min(calc(100vh - 28px), 100%);
   }
   .agent-session-overview {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -8114,6 +8141,10 @@ textarea:focus {
     flex-basis: auto;
     border-radius: 0;
     transform: translateX(18px);
+    /* The mobile app height includes the bottom safe area; keep the drawer's
+       content (especially the footer buttons) above it so it stays tappable
+       and clear of the browser's bottom chrome. */
+    padding-bottom: env(safe-area-inset-bottom, 0px);
   }
   .agent-history-drawer.is-open {
     width: auto;
@@ -8140,16 +8171,36 @@ textarea:focus {
   .agent-history-timeline {
     padding-bottom: calc(76px + env(safe-area-inset-bottom, 0px));
   }
+  /* The overview strip duplicates what the Details tab can hold; keep it out
+     of the Messages view on small screens so the timeline gets the space. */
+  .agent-history-drawer[data-drawer-tab="messages"] > .agent-history-overview {
+    display: none;
+  }
+  /* On the Details tab the strip belongs under the tab bar with the rest of
+     the details, not pinned above it (DOM order stays unchanged). */
+  .agent-history-drawer[data-drawer-tab="details"]
+  > .agent-history-drawer-head {
+    order: -3;
+  }
+  .agent-history-drawer[data-drawer-tab="details"] > .agent-history-tabs {
+    order: -2;
+  }
+  .agent-history-drawer[data-drawer-tab="details"] > .agent-history-overview {
+    order: -1;
+  }
   .agent-history-card pre {
     max-height: 145px;
     font-size: 12px;
   }
   .agent-message-modal {
-    max-height: calc(
-      100dvh -
-      36px -
-      env(safe-area-inset-top, 0px) -
-      env(safe-area-inset-bottom, 0px)
+    max-height: min(
+      calc(
+        100dvh -
+        36px -
+        env(safe-area-inset-top, 0px) -
+        env(safe-area-inset-bottom, 0px)
+      ),
+      100%
     );
   }
   .agent-message-modal-content {
@@ -8159,6 +8210,12 @@ textarea:focus {
       env(safe-area-inset-top, 0px) -
       env(safe-area-inset-bottom, 0px)
     );
+    font-size: 12px;
+    line-height: 1.5;
+  }
+  .agent-message-markdown {
+    font-size: 12px;
+    line-height: 1.55;
   }
   .pane-switcher {
     flex: 0 0 auto;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7308,6 +7308,13 @@ textarea:focus {
 .agent-history-minimap-bar:focus-visible {
   opacity: 1;
 }
+.agent-history-messages {
+  display: flex;
+  min-height: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+}
+
 .agent-history-content {
   min-height: 0;
   flex: 1 1 auto;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7118,6 +7118,11 @@ textarea:focus {
   border-bottom: 1px solid var(--border-soft);
   background: color-mix(in srgb, var(--panel-2) 52%, transparent);
 }
+.agent-history-details > .agent-history-overview {
+  margin-bottom: 8px;
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+}
 .agent-history-overview > div {
   min-width: 0;
   display: grid;
@@ -7227,8 +7232,12 @@ textarea:focus {
   background: var(--panel-2);
   border-radius: 999px;
 }
-.agent-history-minimap {
+.agent-history-minimap-wrap {
+  position: relative;
   flex: 0 0 auto;
+  border-bottom: 1px solid var(--border-soft);
+}
+.agent-history-minimap {
   display: flex;
   align-items: flex-end;
   gap: 2px;
@@ -7236,16 +7245,32 @@ textarea:focus {
      pushing the timeline around. */
   height: 30px;
   box-sizing: border-box;
-  padding: 8px 10px 6px;
+  padding: 7px 10px 6px;
   overflow-x: auto;
   overflow-y: hidden;
-  border-bottom: 1px solid var(--border-soft);
   scrollbar-width: none;
   /* Horizontal drags scrub the timeline; vertical ones keep scrolling it. */
   touch-action: pan-y;
 }
 .agent-history-minimap::-webkit-scrollbar {
   display: none;
+}
+/* Thin position indicator for the strip's own horizontal scroll; the global
+   overlay scrollbar is excluded here because its thumb is too heavy for a
+   30px strip. */
+.agent-history-minimap-scrollbar {
+  position: absolute;
+  right: 10px;
+  bottom: 1px;
+  left: 10px;
+  height: 3px;
+  pointer-events: none;
+}
+.agent-history-minimap-scrollbar-thumb {
+  height: 100%;
+  border-radius: 1.5px;
+  background: var(--muted);
+  opacity: 0.7;
 }
 .agent-history-minimap-bar {
   /* Bars always fill the strip width, so any horizontal position maps
@@ -8170,23 +8195,6 @@ textarea:focus {
   }
   .agent-history-timeline {
     padding-bottom: calc(76px + env(safe-area-inset-bottom, 0px));
-  }
-  /* The overview strip duplicates what the Details tab can hold; keep it out
-     of the Messages view on small screens so the timeline gets the space. */
-  .agent-history-drawer[data-drawer-tab="messages"] > .agent-history-overview {
-    display: none;
-  }
-  /* On the Details tab the strip belongs under the tab bar with the rest of
-     the details, not pinned above it (DOM order stays unchanged). */
-  .agent-history-drawer[data-drawer-tab="details"]
-  > .agent-history-drawer-head {
-    order: -3;
-  }
-  .agent-history-drawer[data-drawer-tab="details"] > .agent-history-tabs {
-    order: -2;
-  }
-  .agent-history-drawer[data-drawer-tab="details"] > .agent-history-overview {
-    order: -1;
   }
   .agent-history-card pre {
     max-height: 145px;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7269,8 +7269,8 @@ textarea:focus {
 .agent-history-minimap-scrollbar-thumb {
   height: 100%;
   border-radius: 1.5px;
-  background: var(--muted);
-  opacity: 0.7;
+  background: var(--accent);
+  opacity: 0.55;
 }
 .agent-history-minimap-bar {
   /* Bars always fill the strip width, so any horizontal position maps
@@ -7301,6 +7301,23 @@ textarea:focus {
   transform: scaleY(1.6);
   opacity: 1;
 }
+.minimap-debug-overlay {
+  position: fixed;
+  left: 4px;
+  bottom: 4px;
+  z-index: 9999;
+  max-width: calc(100vw - 8px);
+  padding: 4px 6px;
+  background: rgb(0 0 0 / 0.85);
+  color: #7fff7f;
+  font-family: monospace;
+  font-size: 10px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-all;
+  pointer-events: none;
+}
+
 .agent-history-minimap-bar:hover,
 .agent-history-minimap-bar:focus-visible {
   opacity: 1;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7252,6 +7252,11 @@ textarea:focus {
   /* Horizontal drags scrub the timeline; vertical ones keep scrolling it. */
   touch-action: pan-y;
 }
+
+.agent-history-minimap:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
 .agent-history-minimap::-webkit-scrollbar {
   display: none;
 }


### PR DESCRIPTION
## Summary

Improves the agent session History view on phones and adds a message minimap for navigating long histories.

**Changes:**

- Add a message minimap above the History timeline: one color-coded bar per message (blue for user, green for assistant). Bars for the messages currently in the viewport grow as a moving wave while scrolling (compositor-only `transform: scaleY`, so it stays smooth on mobile), the strip auto-scrolls to keep the wave visible in long histories with a slim position indicator (the heavy global overlay scrollbar is excluded there), and tapping or dragging anywhere on the strip scrubs the timeline to the matching position with a brief card highlight.
- Always show user and assistant messages together; drop the assistant-message filter switch.
- Move the Turns/Tokens overview strip into the Details tab on all viewports, so the Messages tab keeps the space for the timeline; on phones also hide the Inspector's Files/Changes/History tab bar (the bottom navigation already switches views) and shrink the full-message preview font.
- Render the full-message and transcript dialogs at the document root via portal so they stay within the visible viewport and above the top bar when the on-screen keyboard or pinch zoom shrinks the app.
- Only open focus-triggered tooltips for keyboard-style (`:focus-visible`) focus, so tapping shortcut buttons on touch devices no longer leaves a tooltip stuck.
- Keep the History drawer's bottom buttons above the phone's safe area so they remain tappable instead of sliding under the browser's bottom bar or home indicator.

## Verification

- `bun run format:check && bun run lint && bun run test` — 715 tests pass.
- `cd web && bun run typecheck && bun run build`; `cd server && bun run typecheck`.
- Manually verified on a phone over LAN: the minimap wave follows scrolling and bars settle back when messages leave the viewport, tap/drag on the strip scrubs the timeline, the long-message dialog stays within the viewport and closes, tooltips dismiss after taps, and the footer buttons are tappable.
