### PR TITLE
Add Last step changes scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+
+- Add a Last step scope to Changes that shows the latest completed agent
+  activity period, including commits and untracked files, while retaining that
+  diff until the next period completes.
+
 ### Fixed
 
 - Improve the session History view on phones: move the Turns/Tokens overview

--- a/server/src/connections/agent-status-subscription.test.ts
+++ b/server/src/connections/agent-status-subscription.test.ts
@@ -164,10 +164,13 @@ test("subscribes per agent pane and forwards status events", async () => {
   await herdr.ready;
   const client = new HerdrClient(herdr.path);
   const events: unknown[] = [];
+  const paneLists: Array<{ result: unknown; revision?: number }> = [];
   client.on("event", (event) => events.push(event));
   const loop = createAgentStatusSubscriptionLoop({
     herdr: client,
     connectionId: "test",
+    onPaneListStart: () => 17,
+    onPaneList: (result, revision) => paneLists.push({ result, revision }),
     retryDelayMs: 10,
     rebuildDebounceMs: 5,
     membershipPollMs: 50,
@@ -175,6 +178,10 @@ test("subscribes per agent pane and forwards status events", async () => {
 
   loop.start();
   await waitFor(() => herdr.subscribeCalls.length === 1);
+  expect(paneLists[0]).toEqual({
+    result: { panes: [agentPane("w1:p1"), plainPane("w1:p2")] },
+    revision: 17,
+  });
   expect(herdr.subscribeCalls[0]?.subscriptions).toEqual([
     { type: "pane.agent_status_changed", pane_id: "w1:p1" },
   ]);
@@ -208,8 +215,8 @@ test("rebuilds the subscription when a membership event changes the pane set", a
 
   panes = [agentPane("w1:p1"), agentPane("w1:p2")];
   loop.handleHerdrEvent({
-    event: "pane_agent_detected",
-    data: { type: "pane_agent_detected" },
+    event: "pane.agent_detected",
+    data: { type: "pane.agent_detected" },
   });
   await waitFor(() => herdr.subscribeCalls.length === 2);
   expect(herdr.subscribeCalls[1]?.subscriptions).toEqual([
@@ -219,8 +226,8 @@ test("rebuilds the subscription when a membership event changes the pane set", a
 
   panes = [agentPane("w1:p2")];
   loop.handleHerdrEvent({
-    event: "workspace_closed",
-    data: { type: "workspace_closed" },
+    event: "workspace.closed",
+    data: { type: "workspace.closed" },
   });
   await waitFor(() => herdr.subscribeCalls.length === 3);
   expect(herdr.subscribeCalls[2]?.subscriptions).toEqual([

--- a/server/src/connections/agent-status-subscription.ts
+++ b/server/src/connections/agent-status-subscription.ts
@@ -83,6 +83,8 @@ export function createAgentStatusSubscriptionLoop(args: {
   connectionId: string;
   onSubscribeError?: (error: Error) => void;
   onListError?: (error: Error) => void;
+  onPaneListStart?: () => number;
+  onPaneList?: (result: unknown, startedAtRevision?: number) => void;
   log?: (message: string) => void;
   retryDelayMs?: number;
   rebuildDebounceMs?: number;
@@ -168,9 +170,20 @@ export function createAgentStatusSubscriptionLoop(args: {
   }
 
   async function listAgentPaneIds(): Promise<string[] | null> {
+    let startedAtRevision: number | undefined;
+    try {
+      startedAtRevision = args.onPaneListStart?.();
+    } catch {
+      // Observers must not break the subscription loop.
+    }
     try {
       // Bounded so a hung downstream cannot hold runtime stop hostage.
       const result = await args.herdr.call("pane.list", {}, 5000);
+      try {
+        args.onPaneList?.(result, startedAtRevision);
+      } catch {
+        // Observers must not break the subscription loop.
+      }
       return agentPaneIdsFromPaneList(result);
     } catch (error) {
       report(args.onListError, error);
@@ -351,7 +364,7 @@ export function createAgentStatusSubscriptionLoop(args: {
     },
 
     handleHerdrEvent(event: unknown) {
-      const name = herdrEventName(event);
+      const name = herdrEventName(event)?.replaceAll(".", "_");
       if (name && MEMBERSHIP_EVENT_TYPES.has(name)) requestRebuild();
     },
 

--- a/server/src/connections/runtime.test.ts
+++ b/server/src/connections/runtime.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { createLastStepBaselineStore } from "../workspace/git-diff";
 import { createLegacyConnectionRuntime } from "./runtime";
 
 test("legacy runtime exposes and reports its configured connection identity", async () => {
@@ -37,5 +38,96 @@ test("legacy runtime exposes and reports its configured connection identity", as
   });
   expect(events).toEqual([{ event, connectionId: "remote-dev" }]);
   expect(errors).toEqual([{ error, connectionId: "remote-dev" }]);
-  await runtime.stop();
+  const stopping = runtime.stop();
+  runtime.herdr.emit("event", {
+    event: "pane.agent_status_changed",
+    data: {
+      pane_id: "w1:p1",
+      workspace_id: "w1",
+      agent_status: "working",
+    },
+  });
+  await stopping;
+  expect(events).toEqual([{ event, connectionId: "remote-dev" }]);
+});
+
+test("runtime stop drains an in-flight completion and suppresses publication", async () => {
+  const tree = "a".repeat(40);
+  let snapshotCall = 0;
+  let releaseCompletion: () => void = () => undefined;
+  let signalCompletion: () => void = () => undefined;
+  const completionStarted = new Promise<void>((resolve) => {
+    signalCompletion = resolve;
+  });
+  const completionGate = new Promise<void>((resolve) => {
+    releaseCompletion = resolve;
+  });
+  const baselines = createLastStepBaselineStore({
+    shQuote: (value) => `'${value}'`,
+    runProcessWithCodeTimeout: async () => {
+      snapshotCall += 1;
+      if (snapshotCall === 2) {
+        signalCompletion();
+        await completionGate;
+      }
+      return { code: 0, stdout: `${tree}\n`, stderr: "" };
+    },
+  });
+  const events: unknown[] = [];
+  const runtime = createLegacyConnectionRuntime({
+    config: {
+      socketPath: "/tmp/m3-runtime-stop-control.sock",
+      clientSocketPath: "/tmp/m3-runtime-stop-client.sock",
+      sshHost: undefined,
+      session: undefined,
+      hasExplicitSocketPath: true,
+      hasExplicitClientSocketPath: true,
+    },
+    safeSend: () => true,
+    clientLabel: () => "browser",
+    markRpcError: () => undefined,
+    onEvent: (event) => events.push(event),
+    lastStepBaselines: baselines,
+    resolveLastStepWorkspaceGitRoot: async () => "/repo",
+    lastStepTransitionDebounceMs: 0,
+  });
+
+  runtime.herdr.emit("event", {
+    event: "pane.agent_status_changed",
+    data: {
+      pane_id: "w1:p1",
+      workspace_id: "w1",
+      agent_status: "working",
+    },
+  });
+  for (let index = 0; index < 6; index += 1) await Promise.resolve();
+  runtime.herdr.emit("event", {
+    event: "pane.agent_status_changed",
+    data: {
+      pane_id: "w1:p1",
+      workspace_id: "w1",
+      agent_status: "idle",
+    },
+  });
+  await completionStarted;
+
+  let stopped = false;
+  const stopping = runtime.stop().then(() => {
+    stopped = true;
+  });
+  await Promise.resolve();
+  expect(stopped).toBe(false);
+  releaseCompletion();
+  await stopping;
+
+  expect(
+    events.some(
+      (event) =>
+        (event as { event?: unknown }).event ===
+        "workspace.last_step_completed",
+    ),
+  ).toBe(false);
+  await expect(
+    baselines.captureWorkspace("w1", async () => "/repo"),
+  ).rejects.toMatchObject({ code: "LAST_STEP_STORE_DISPOSED" });
 });

--- a/server/src/connections/runtime.ts
+++ b/server/src/connections/runtime.ts
@@ -19,6 +19,11 @@ import {
 } from "../utils/process-utils";
 import { createWorkspaceAutoSync } from "../workspace/auto-sync";
 import { createFileHandlers } from "../workspace/files";
+import {
+  createLastStepBaselineStore,
+  type LastStepBaselineStore,
+} from "../workspace/git-diff";
+import { createLastStepTurnTracker } from "../workspace/last-step-turns";
 import { runBinaryProcessWithTimeout } from "../workspace/process";
 import { createStatusEnricher } from "../workspace/status";
 import { createWorktreeHookRunner } from "../worktree/worktree-hooks";
@@ -75,6 +80,10 @@ export function createLegacyConnectionRuntime(args: {
   onEvent: (event: unknown, identity: ConnectionIdentity) => void;
   onError?: (error: unknown, identity: ConnectionIdentity) => void;
   onTransportExit?: (error: SshTunnelError) => void;
+  /** Test seam for deterministic shutdown coverage. */
+  lastStepBaselines?: LastStepBaselineStore;
+  resolveLastStepWorkspaceGitRoot?: (workspaceId: string) => Promise<string>;
+  lastStepTransitionDebounceMs?: number;
 }) {
   const { config } = args;
   const identity = { ...(args.identity ?? LEGACY_DEFAULT_CONNECTION) };
@@ -99,11 +108,19 @@ export function createLegacyConnectionRuntime(args: {
   const { handleHerdrInfo } = createHerdrInfoHandler({
     ping: () => herdr.ping(),
   });
+  const lastStepBaselines =
+    args.lastStepBaselines ??
+    createLastStepBaselineStore({
+      host: sshHost(),
+      runProcessWithCodeTimeout,
+      shQuote,
+    });
   const files = createFileHandlers({
     herdr,
     sshHost,
     runProcessWithCodeTimeout,
     shQuote,
+    lastStepBaselines,
   });
   const status = createStatusEnricher({
     connectionId: identity.id,
@@ -188,6 +205,44 @@ export function createLegacyConnectionRuntime(args: {
     },
   });
 
+  const lastStepTurns = createLastStepTurnTracker({
+    captureWorkspaceBaseline: async (workspaceId) => {
+      await lastStepBaselines.captureWorkspace(workspaceId, async () => {
+        if (args.resolveLastStepWorkspaceGitRoot) {
+          return args.resolveLastStepWorkspaceGitRoot(workspaceId);
+        }
+        const { root } = await files.resolveWorkspaceGitRoot({
+          workspace_id: workspaceId,
+        });
+        return root;
+      });
+    },
+    completeWorkspaceStep: async (workspaceId) => {
+      const published = await lastStepBaselines.completeWorkspace(workspaceId);
+      if (!published || disposed) return;
+      args.onEvent(
+        {
+          event: "workspace.last_step_completed",
+          data: {
+            type: "workspace.last_step_completed",
+            workspace_id: workspaceId,
+          },
+        },
+        identity,
+      );
+    },
+    onCaptureError: (error, workspaceId) =>
+      console.error(
+        `[bridge] last-step baseline failed connection=${identity.id} workspace=${workspaceId}:`,
+        sanitizeConnectionError(error),
+      ),
+    onCompleteError: (error, workspaceId) =>
+      console.error(
+        `[bridge] last-step completion failed connection=${identity.id} workspace=${workspaceId}:`,
+        sanitizeConnectionError(error),
+      ),
+    transitionDebounceMs: args.lastStepTransitionDebounceMs ?? 150,
+  });
   const agentStatusSubscriptions = createAgentStatusSubscriptionLoop({
     herdr,
     connectionId: identity.id,
@@ -202,10 +257,13 @@ export function createLegacyConnectionRuntime(args: {
         `[bridge] agent status pane list failed connection=${identity.id}:`,
         sanitizeConnectionError(error),
       ),
+    onPaneListStart: lastStepTurns.beginPaneList,
+    onPaneList: lastStepTurns.reconcilePaneList,
     log: (message) => console.log(`[bridge] ${message}`),
   });
 
   const onHerdrEvent = (event: unknown) => {
+    lastStepTurns.handleHerdrEvent(event);
     agentStatusSubscriptions.handleHerdrEvent(event);
     args.onEvent(event, identity);
   };
@@ -266,10 +324,15 @@ export function createLegacyConnectionRuntime(args: {
     if (disposed) return Promise.resolve();
     disposed = true;
     backgroundStarted = false;
+    herdr.off("event", onHerdrEvent);
+    herdr.off("error", onHerdrError);
     const autoSyncStop = workspaceAutoSync.stop();
     terminalBridge.dispose();
     const subscriptionStop = subscriptionLoop.stop();
     const agentStatusStop = agentStatusSubscriptions.stop();
+    const lastStepStop = lastStepTurns
+      .stop()
+      .then(() => lastStepBaselines.dispose());
     const transportCleanup = sshTunnel.cleanupAutoSshTunnel();
     const transportStop =
       transportStart?.catch(() => undefined) ?? Promise.resolve();
@@ -277,14 +340,10 @@ export function createLegacyConnectionRuntime(args: {
       autoSyncStop,
       subscriptionStop,
       agentStatusStop,
+      lastStepStop,
       transportCleanup,
       transportStop,
-    ])
-      .then(() => undefined)
-      .finally(() => {
-        herdr.off("event", onHerdrEvent);
-        herdr.off("error", onHerdrError);
-      });
+    ]).then(() => undefined);
     return stopTask;
   }
 

--- a/server/src/workspace/file-types.ts
+++ b/server/src/workspace/file-types.ts
@@ -58,9 +58,10 @@ export type GitDiffKind =
   | "unstaged"
   | "untracked"
   | "conflicted"
-  | "branch";
+  | "branch"
+  | "last-step";
 
-export type GitDiffMode = "working" | "branch-main";
+export type GitDiffMode = "working" | "branch-main" | "last-step";
 
 export type GitDiffEntry = {
   path: string;

--- a/server/src/workspace/files.ts
+++ b/server/src/workspace/files.ts
@@ -24,7 +24,12 @@ import {
   resolveRemoteFilePaths,
   uploadRemoteFile,
 } from "./remote-files";
-import { pullGit, readDiffFile, readDiffSummary } from "./git-diff";
+import {
+  pullGit,
+  readDiffFile,
+  readDiffSummary,
+  type LastStepBaselineStore,
+} from "./git-diff";
 import { GIT_DIFF_TIMEOUT_MS } from "./file-constants";
 
 const MAX_FILE_RESOLUTION_CANDIDATES = 32;
@@ -35,11 +40,13 @@ export function createFileHandlers({
   sshHost,
   runProcessWithCodeTimeout,
   shQuote,
+  lastStepBaselines,
 }: {
   herdr: HerdrClient;
   sshHost: () => string | undefined;
   runProcessWithCodeTimeout: RunProcessWithCodeTimeout;
   shQuote: (value: string) => string;
+  lastStepBaselines?: LastStepBaselineStore;
 }) {
   async function explorerRoot(
     workspaceId: string,
@@ -350,6 +357,7 @@ export function createFileHandlers({
       host: sshHost(),
       shQuote,
       runProcessWithCodeTimeout,
+      lastStepBaselines,
     });
   }
 
@@ -362,6 +370,7 @@ export function createFileHandlers({
       host: sshHost(),
       shQuote,
       runProcessWithCodeTimeout,
+      lastStepBaselines,
     });
   }
 

--- a/server/src/workspace/git-diff.test.ts
+++ b/server/src/workspace/git-diff.test.ts
@@ -1,11 +1,54 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtemp, rename, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { RunProcessWithCodeTimeout } from "./file-types";
 import {
+  createLastStepBaselineStore,
   parseBranchSummary,
   parseGeneratedAttributes,
   parseStatusSummary,
+  readDiffFile,
   readDiffSummary,
+  snapshotWorktreeTree,
   statusLabel,
+  type LastStepBaselineStore,
 } from "./git-diff";
+
+const runProcessWithCodeTimeout: RunProcessWithCodeTimeout = async (argv) => {
+  const process = Bun.spawn(argv, { stdout: "pipe", stderr: "pipe" });
+  const [code, stdout, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+  ]);
+  return { code, stdout, stderr };
+};
+
+function shQuote(value: string) {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+async function git(root: string, ...args: string[]) {
+  const result = await runProcessWithCodeTimeout(
+    ["git", "-C", root, ...args],
+    5000,
+  );
+  if (result.code !== 0) throw new Error(result.stderr || result.stdout);
+  return result.stdout;
+}
+
+async function initRepository() {
+  const root = await mkdtemp(join(tmpdir(), "herdr-last-step-"));
+  await git(root, "init");
+  await git(root, "config", "user.email", "test@example.com");
+  await git(root, "config", "user.name", "Herdr Test");
+  return root;
+}
+
+function baselineStore() {
+  return createLastStepBaselineStore({ shQuote, runProcessWithCodeTimeout });
+}
 
 describe("git diff summary parsing", () => {
   test("labels git statuses", () => {
@@ -156,5 +199,867 @@ describe("git diff summary parsing", () => {
     expect(commands.some((command) => command.includes("check-attr -z"))).toBe(
       true,
     );
+  });
+});
+
+describe("last-step worktree snapshots", () => {
+  test("runs temporary-index snapshots through the SSH command path", async () => {
+    const calls: string[][] = [];
+    const tree = "a".repeat(40);
+    const result = await snapshotWorktreeTree({
+      root: "/repo with spaces",
+      host: "dev.example",
+      shQuote,
+      runProcessWithCodeTimeout: async (argv) => {
+        calls.push(argv);
+        return { code: 0, stdout: `${tree}\n`, stderr: "" };
+      },
+    });
+
+    expect(result).toBe(tree);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.[0]).toBe("ssh");
+    expect(calls[0]).toContain("dev.example");
+    const command = calls[0]?.at(-1) ?? "";
+    expect(command).toContain("GIT_INDEX_FILE");
+    expect(command).toContain("git -C '/repo with spaces' add -A");
+    expect(command).toContain("write-tree");
+    expect(command).toContain("trap cleanup EXIT HUP INT TERM");
+  });
+
+  test("includes commits and untracked files made after the baseline", async () => {
+    const root = await initRepository();
+    try {
+      await writeFile(join(root, "tracked.txt"), "before\n");
+      await git(root, "add", "tracked.txt");
+      await git(root, "commit", "-m", "initial");
+      const baselines = baselineStore();
+      await baselines.captureWorkspace("workspace", async () => root);
+
+      await writeFile(join(root, "tracked.txt"), "after commit\n");
+      await git(root, "add", "tracked.txt");
+      await git(root, "commit", "-m", "mid-turn");
+      await writeFile(join(root, "untracked.txt"), "new file\n");
+      await baselines.completeWorkspace("workspace");
+
+      const summary = await readDiffSummary({
+        workspaceId: "workspace",
+        workspace: { label: "Repo" },
+        root,
+        params: { mode: "last-step" },
+        shQuote,
+        runProcessWithCodeTimeout,
+        lastStepBaselines: baselines,
+      });
+
+      expect(summary.baseline_available).toBe(true);
+      expect(summary.entries).toEqual([
+        {
+          path: "tracked.txt",
+          old_path: undefined,
+          kind: "last-step",
+          status: "modified",
+          additions: 1,
+          deletions: 1,
+        },
+        {
+          path: "untracked.txt",
+          old_path: undefined,
+          kind: "last-step",
+          status: "added",
+          additions: 1,
+          deletions: 0,
+        },
+      ]);
+
+      const file = await readDiffFile({
+        workspaceId: "workspace",
+        root,
+        params: {
+          mode: "last-step",
+          kind: "last-step",
+          path: "tracked.txt",
+          snapshot_id: summary.snapshot_id,
+        },
+        shQuote,
+        runProcessWithCodeTimeout,
+        lastStepBaselines: baselines,
+      });
+      expect(file.kind).toBe("last-step");
+      expect(file.diff).toContain("-before");
+      expect(file.diff).toContain("+after commit");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps rename metadata in an individual last-step patch", async () => {
+    const root = await initRepository();
+    try {
+      await writeFile(join(root, "old.txt"), "renamed content\n");
+      await git(root, "add", "old.txt");
+      await git(root, "commit", "-m", "initial");
+      const baselines = baselineStore();
+      await baselines.captureWorkspace("workspace", async () => root);
+      await rename(join(root, "old.txt"), join(root, "new.txt"));
+      await baselines.completeWorkspace("workspace");
+
+      const summary = await readDiffSummary({
+        workspaceId: "workspace",
+        workspace: {},
+        root,
+        params: { mode: "last-step" },
+        shQuote,
+        runProcessWithCodeTimeout,
+        lastStepBaselines: baselines,
+      });
+      expect(summary.entries).toContainEqual(
+        expect.objectContaining({
+          path: "new.txt",
+          old_path: "old.txt",
+          kind: "last-step",
+          status: "renamed",
+        }),
+      );
+
+      const file = await readDiffFile({
+        workspaceId: "workspace",
+        root,
+        params: {
+          mode: "last-step",
+          path: "new.txt",
+          old_path: "old.txt",
+          snapshot_id: summary.snapshot_id,
+        },
+        shQuote,
+        runProcessWithCodeTimeout,
+        lastStepBaselines: baselines,
+      });
+      expect(file.diff).toContain("rename from old.txt");
+      expect(file.diff).toContain("rename to new.txt");
+      expect(file.diff).not.toContain("new file mode");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps the previous completed step visible until the active step completes", async () => {
+    const root = await initRepository();
+    try {
+      await writeFile(join(root, "tracked.txt"), "initial\n");
+      const baselines = baselineStore();
+
+      await baselines.captureWorkspace("workspace", async () => root);
+      await writeFile(join(root, "tracked.txt"), "first completed step\n");
+      await baselines.completeWorkspace("workspace");
+      const first = await readDiffSummary({
+        workspaceId: "workspace",
+        workspace: {},
+        root,
+        params: { mode: "last-step" },
+        shQuote,
+        runProcessWithCodeTimeout,
+        lastStepBaselines: baselines,
+      });
+
+      await baselines.captureWorkspace("workspace", async () => root);
+      await writeFile(join(root, "tracked.txt"), "second active step\n");
+      const whileActive = await readDiffSummary({
+        workspaceId: "workspace",
+        workspace: {},
+        root,
+        params: { mode: "last-step" },
+        shQuote,
+        runProcessWithCodeTimeout,
+        lastStepBaselines: baselines,
+      });
+      expect(whileActive.base).toBe(first.base);
+      expect(whileActive.snapshot_id).not.toBe(first.snapshot_id);
+
+      await baselines.completeWorkspace("workspace");
+      const afterCompletion = await readDiffSummary({
+        workspaceId: "workspace",
+        workspace: {},
+        root,
+        params: { mode: "last-step" },
+        shQuote,
+        runProcessWithCodeTimeout,
+        lastStepBaselines: baselines,
+      });
+      expect(afterCompletion.base).not.toBe(first.base);
+      const file = await readDiffFile({
+        workspaceId: "workspace",
+        root,
+        params: {
+          mode: "last-step",
+          path: "tracked.txt",
+          snapshot_id: afterCompletion.snapshot_id,
+        },
+        shQuote,
+        runProcessWithCodeTimeout,
+        lastStepBaselines: baselines,
+      });
+      expect(file.diff).toContain("-first completed step");
+      expect(file.diff).toContain("+second active step");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("queues a rapid second completion while the first is still finalizing", async () => {
+    const root = await initRepository();
+    let snapshotCall = 0;
+    let releaseFirstCompletion: () => void = () => undefined;
+    let signalFirstCompletion: () => void = () => undefined;
+    const firstCompletionStarted = new Promise<void>((resolve) => {
+      signalFirstCompletion = resolve;
+    });
+    const firstCompletionGate = new Promise<void>((resolve) => {
+      releaseFirstCompletion = resolve;
+    });
+    const runner: RunProcessWithCodeTimeout = async (argv, timeoutMs) => {
+      if (argv.join(" ").includes("herdr-git-index")) {
+        snapshotCall += 1;
+        if (snapshotCall === 2) {
+          signalFirstCompletion();
+          await firstCompletionGate;
+        }
+      }
+      return runProcessWithCodeTimeout(argv, timeoutMs);
+    };
+    try {
+      await writeFile(join(root, "tracked.txt"), "initial\n");
+      const baselines = createLastStepBaselineStore({
+        shQuote,
+        runProcessWithCodeTimeout: runner,
+      });
+      await baselines.captureWorkspace("workspace", async () => root);
+      await writeFile(join(root, "tracked.txt"), "first step\n");
+      const firstCompletion = baselines.completeWorkspace("workspace");
+      await firstCompletionStarted;
+
+      await baselines.captureWorkspace("workspace", async () => root);
+      await writeFile(join(root, "tracked.txt"), "second step\n");
+      releaseFirstCompletion();
+      expect(await firstCompletion).toBe(true);
+
+      const whileSecondIsActive = await readDiffSummary({
+        workspaceId: "workspace",
+        workspace: {},
+        root,
+        params: { mode: "last-step" },
+        shQuote,
+        runProcessWithCodeTimeout: runner,
+        lastStepBaselines: baselines,
+      });
+      const firstFile = await readDiffFile({
+        workspaceId: "workspace",
+        root,
+        params: {
+          mode: "last-step",
+          path: "tracked.txt",
+          snapshot_id: whileSecondIsActive.snapshot_id,
+        },
+        shQuote,
+        runProcessWithCodeTimeout: runner,
+        lastStepBaselines: baselines,
+      });
+      expect(firstFile.diff).toContain("-initial");
+      expect(firstFile.diff).toContain("+first step");
+      expect(firstFile.diff).not.toContain("+second step");
+
+      expect(await baselines.completeWorkspace("workspace")).toBe(true);
+      const completedSecond = await readDiffSummary({
+        workspaceId: "workspace",
+        workspace: {},
+        root,
+        params: { mode: "last-step" },
+        shQuote,
+        runProcessWithCodeTimeout: runner,
+        lastStepBaselines: baselines,
+      });
+      const secondFile = await readDiffFile({
+        workspaceId: "workspace",
+        root,
+        params: {
+          mode: "last-step",
+          path: "tracked.txt",
+          snapshot_id: completedSecond.snapshot_id,
+        },
+        shQuote,
+        runProcessWithCodeTimeout: runner,
+        lastStepBaselines: baselines,
+      });
+      expect(secondFile.diff).toContain("-first step");
+      expect(secondFile.diff).toContain("+second step");
+    } finally {
+      releaseFirstCompletion();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("binds file patches to the exact tree pair returned by the summary", async () => {
+    const root = await initRepository();
+    try {
+      await writeFile(join(root, "tracked.txt"), "baseline\n");
+      await git(root, "add", "tracked.txt");
+      await git(root, "commit", "-m", "initial");
+      const baselines = baselineStore();
+      await baselines.captureWorkspace("workspace", async () => root);
+      await writeFile(join(root, "tracked.txt"), "at summary\n");
+      await baselines.completeWorkspace("workspace");
+
+      const summary = await readDiffSummary({
+        workspaceId: "workspace",
+        workspace: {},
+        root,
+        params: { mode: "last-step" },
+        shQuote,
+        runProcessWithCodeTimeout,
+        lastStepBaselines: baselines,
+      });
+      expect(typeof summary.snapshot_id).toBe("string");
+      await writeFile(join(root, "tracked.txt"), "after summary\n");
+
+      const file = await readDiffFile({
+        workspaceId: "workspace",
+        root,
+        params: {
+          mode: "last-step",
+          path: "tracked.txt",
+          snapshot_id: summary.snapshot_id,
+        },
+        shQuote,
+        runProcessWithCodeTimeout,
+        lastStepBaselines: baselines,
+      });
+      expect(file.diff).toContain("+at summary");
+      expect(file.diff).not.toContain("+after summary");
+
+      await baselines.captureWorkspace("workspace", async () => root);
+      const retainedFile = await readDiffFile({
+        workspaceId: "workspace",
+        root,
+        params: {
+          mode: "last-step",
+          path: "tracked.txt",
+          snapshot_id: summary.snapshot_id,
+        },
+        shQuote,
+        runProcessWithCodeTimeout,
+        lastStepBaselines: baselines,
+      });
+      expect(retainedFile.diff).toContain("+at summary");
+      await baselines.completeWorkspace("workspace");
+
+      let expiredError: unknown;
+      try {
+        await readDiffFile({
+          workspaceId: "workspace",
+          root,
+          params: {
+            mode: "last-step",
+            path: "tracked.txt",
+            snapshot_id: summary.snapshot_id,
+          },
+          shQuote,
+          runProcessWithCodeTimeout,
+          lastStepBaselines: baselines,
+        });
+      } catch (error) {
+        expiredError = error;
+      }
+      expect((expiredError as Error).message).toContain("snapshot expired");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("returns a usable summary token when a newer step completes mid-request", async () => {
+    const root = await initRepository();
+    let blockNameStatus = false;
+    let releaseNameStatus: () => void = () => undefined;
+    let signalNameStatus: () => void = () => undefined;
+    const nameStatusStarted = new Promise<void>((resolve) => {
+      signalNameStatus = resolve;
+    });
+    const nameStatusGate = new Promise<void>((resolve) => {
+      releaseNameStatus = resolve;
+    });
+    const runner: RunProcessWithCodeTimeout = async (argv, timeoutMs) => {
+      if (blockNameStatus && argv.join(" ").includes("diff --name-status")) {
+        blockNameStatus = false;
+        signalNameStatus();
+        await nameStatusGate;
+      }
+      return runProcessWithCodeTimeout(argv, timeoutMs);
+    };
+    try {
+      await writeFile(join(root, "tracked.txt"), "initial\n");
+      const baselines = createLastStepBaselineStore({
+        shQuote,
+        runProcessWithCodeTimeout: runner,
+      });
+      await baselines.captureWorkspace("workspace", async () => root);
+      await writeFile(join(root, "tracked.txt"), "first step\n");
+      await baselines.completeWorkspace("workspace");
+      await baselines.captureWorkspace("workspace", async () => root);
+      await writeFile(join(root, "tracked.txt"), "second step\n");
+
+      blockNameStatus = true;
+      const summaryTask = readDiffSummary({
+        workspaceId: "workspace",
+        workspace: {},
+        root,
+        params: { mode: "last-step" },
+        shQuote,
+        runProcessWithCodeTimeout: runner,
+        lastStepBaselines: baselines,
+      });
+      await nameStatusStarted;
+      await baselines.completeWorkspace("workspace");
+      releaseNameStatus();
+      const summary = await summaryTask;
+
+      const file = await readDiffFile({
+        workspaceId: "workspace",
+        root,
+        params: {
+          mode: "last-step",
+          path: "tracked.txt",
+          snapshot_id: summary.snapshot_id,
+        },
+        shQuote,
+        runProcessWithCodeTimeout: runner,
+        lastStepBaselines: baselines,
+      });
+      expect(file.diff).toContain("-initial");
+      expect(file.diff).toContain("+first step");
+    } finally {
+      releaseNameStatus();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("expires a missing current tree without deleting the valid baseline", async () => {
+    const root = await initRepository();
+    try {
+      await writeFile(join(root, "tracked.txt"), "baseline\n");
+      const baselines = baselineStore();
+      const baseline = await baselines.capture(root);
+      const validSnapshot = baselines.rememberSnapshot(
+        "workspace",
+        root,
+        baseline,
+        baseline,
+      );
+      const expiredSnapshot = baselines.rememberSnapshot(
+        "workspace",
+        root,
+        baseline,
+        "0".repeat(40),
+      );
+
+      let expiredError: unknown;
+      try {
+        await readDiffFile({
+          workspaceId: "workspace",
+          root,
+          params: {
+            mode: "last-step",
+            path: "tracked.txt",
+            snapshot_id: expiredSnapshot,
+          },
+          shQuote,
+          runProcessWithCodeTimeout,
+          lastStepBaselines: baselines,
+        });
+      } catch (error) {
+        expiredError = error;
+      }
+      expect((expiredError as Error).message).toContain("snapshot expired");
+      expect(await baselines.resolve("workspace", root)).toBe(baseline);
+      expect(
+        baselines.resolveSnapshot("workspace", root, validSnapshot),
+      ).toEqual({ baseline, current: baseline });
+      expect(
+        baselines.resolveSnapshot("workspace", root, expiredSnapshot),
+      ).toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("does not let an older failed capture erase a newer same-root baseline", async () => {
+    const root = await initRepository();
+    let snapshotCall = 0;
+    let releaseFirst: () => void = () => undefined;
+    let signalFirstStarted: () => void = () => undefined;
+    const firstStarted = new Promise<void>((resolve) => {
+      signalFirstStarted = resolve;
+    });
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const runner: RunProcessWithCodeTimeout = async (argv, timeoutMs) => {
+      if (argv.join(" ").includes("herdr-git-index")) {
+        snapshotCall += 1;
+        if (snapshotCall === 1) {
+          signalFirstStarted();
+          await firstGate;
+          return { code: 1, stdout: "", stderr: "older capture failed" };
+        }
+      }
+      return runProcessWithCodeTimeout(argv, timeoutMs);
+    };
+    try {
+      await writeFile(join(root, "tracked.txt"), "current\n");
+      const baselines = createLastStepBaselineStore({
+        shQuote,
+        runProcessWithCodeTimeout: runner,
+      });
+      const older = baselines.captureWorkspace("older", async () => root);
+      await firstStarted;
+      const newer = baselines.captureWorkspace("newer", async () => root);
+      await newer;
+      releaseFirst();
+      let olderError: unknown;
+      try {
+        await older;
+      } catch (error) {
+        olderError = error;
+      }
+      expect((olderError as Error).message).toContain("older capture failed");
+      expect(typeof (await baselines.resolve("newer", root))).toBe("string");
+    } finally {
+      releaseFirst();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("preserves the real index in a linked worktree", async () => {
+    const root = await initRepository();
+    const linkedRoot = `${root}-linked`;
+    try {
+      await writeFile(join(root, "tracked.txt"), "base\n");
+      await git(root, "add", "tracked.txt");
+      await git(root, "commit", "-m", "initial");
+      await git(root, "worktree", "add", "-b", "linked-test", linkedRoot);
+      await writeFile(join(linkedRoot, "staged.txt"), "baseline\n");
+      await git(linkedRoot, "add", "staged.txt");
+      const beforeStatus = await git(linkedRoot, "status", "--porcelain=v1");
+      const baselines = baselineStore();
+      await baselines.captureWorkspace("workspace", async () => linkedRoot);
+      expect(await git(linkedRoot, "status", "--porcelain=v1")).toBe(
+        beforeStatus,
+      );
+
+      await writeFile(join(linkedRoot, "staged.txt"), "changed\n");
+      await baselines.completeWorkspace("workspace");
+      const summary = await readDiffSummary({
+        workspaceId: "workspace",
+        workspace: {},
+        root: linkedRoot,
+        params: { mode: "last-step" },
+        shQuote,
+        runProcessWithCodeTimeout,
+        lastStepBaselines: baselines,
+      });
+      expect(summary.entries).toContainEqual(
+        expect.objectContaining({
+          path: "staged.txt",
+          kind: "last-step",
+          status: "modified",
+        }),
+      );
+    } finally {
+      try {
+        await git(root, "worktree", "remove", "--force", linkedRoot);
+      } catch {
+        // The linked worktree may already be absent after a failed setup.
+      }
+      await rm(linkedRoot, { recursive: true, force: true });
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("snapshots an unborn repository without mutating the user index", async () => {
+    const root = await initRepository();
+    try {
+      await writeFile(join(root, "existing.txt"), "baseline\n");
+      await git(root, "add", "existing.txt");
+      const beforeStatus = await git(root, "status", "--porcelain=v1");
+      const baselines = baselineStore();
+      await baselines.captureWorkspace("workspace", async () => root);
+      const afterStatus = await git(root, "status", "--porcelain=v1");
+      expect(afterStatus).toBe(beforeStatus);
+
+      await writeFile(join(root, "existing.txt"), "changed\n");
+      await writeFile(join(root, "new.txt"), "new\n");
+      await baselines.completeWorkspace("workspace");
+      const summary = await readDiffSummary({
+        workspaceId: "workspace",
+        workspace: {},
+        root,
+        params: { mode: "last-step" },
+        shQuote,
+        runProcessWithCodeTimeout,
+        lastStepBaselines: baselines,
+      });
+
+      expect(
+        summary.entries.map((entry) => [entry.path, entry.status]),
+      ).toEqual([
+        ["existing.txt", "modified"],
+        ["new.txt", "added"],
+      ]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("waits for step completion before publishing its replacement", async () => {
+    const root = await initRepository();
+    let holdSnapshots = false;
+    let catFileCalls = 0;
+    let releaseSnapshot = () => undefined;
+    let snapshotGate = Promise.resolve();
+    const runner: RunProcessWithCodeTimeout = async (argv, timeoutMs) => {
+      const command = argv.join(" ");
+      if (command.includes("cat-file --batch-check")) catFileCalls += 1;
+      if (holdSnapshots && command.includes("herdr-git-index")) {
+        await snapshotGate;
+      }
+      return runProcessWithCodeTimeout(argv, timeoutMs);
+    };
+    try {
+      await writeFile(join(root, "tracked.txt"), "first baseline\n");
+      const baselines = createLastStepBaselineStore({
+        shQuote,
+        runProcessWithCodeTimeout: runner,
+      });
+      await baselines.captureWorkspace("workspace", async () => root);
+      await writeFile(join(root, "tracked.txt"), "second baseline\n");
+
+      holdSnapshots = true;
+      snapshotGate = new Promise<void>((resolve) => {
+        releaseSnapshot = () => {
+          holdSnapshots = false;
+          resolve();
+        };
+      });
+      const completion = baselines.completeWorkspace("workspace");
+      const summaryTask = readDiffSummary({
+        workspaceId: "workspace",
+        workspace: {},
+        root,
+        params: { mode: "last-step" },
+        shQuote,
+        runProcessWithCodeTimeout: runner,
+        lastStepBaselines: baselines,
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(catFileCalls).toBe(0);
+
+      releaseSnapshot();
+      await completion;
+      const summary = await summaryTask;
+      expect(summary.baseline_available).toBe(true);
+      expect(summary.entries.map((entry) => entry.path)).toEqual([
+        "tracked.txt",
+      ]);
+    } finally {
+      releaseSnapshot();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("retains the completed step when the next baseline capture fails", async () => {
+    const root = await initRepository();
+    let failNextSnapshot = false;
+    const runner: RunProcessWithCodeTimeout = async (argv, timeoutMs) => {
+      if (failNextSnapshot && argv.join(" ").includes("herdr-git-index")) {
+        failNextSnapshot = false;
+        return { code: 1, stdout: "", stderr: "snapshot failed" };
+      }
+      return runProcessWithCodeTimeout(argv, timeoutMs);
+    };
+    try {
+      await writeFile(join(root, "tracked.txt"), "old baseline\n");
+      const baselines = createLastStepBaselineStore({
+        shQuote,
+        runProcessWithCodeTimeout: runner,
+      });
+      await baselines.captureWorkspace("workspace", async () => root);
+      await writeFile(join(root, "tracked.txt"), "completed turn\n");
+      await baselines.completeWorkspace("workspace");
+      failNextSnapshot = true;
+      let captureError: unknown;
+      try {
+        await baselines.captureWorkspace("workspace", async () => root);
+      } catch (error) {
+        captureError = error;
+      }
+      expect(captureError).toBeInstanceOf(Error);
+      expect((captureError as Error).message).toContain("snapshot failed");
+      expect(await baselines.completeWorkspace("workspace")).toBe(false);
+
+      const summary = await readDiffSummary({
+        workspaceId: "workspace",
+        workspace: {},
+        root,
+        params: { mode: "last-step" },
+        shQuote,
+        runProcessWithCodeTimeout: runner,
+        lastStepBaselines: baselines,
+      });
+      expect(summary.baseline_available).toBe(true);
+      expect(summary.entries.map((entry) => entry.path)).toEqual([
+        "tracked.txt",
+      ]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("preserves a valid baseline across transient cat-file failures", async () => {
+    const root = await initRepository();
+    let failCatFile = false;
+    const runner: RunProcessWithCodeTimeout = async (argv, timeoutMs) => {
+      if (failCatFile && argv.join(" ").includes("cat-file --batch-check")) {
+        return { code: 255, stdout: "", stderr: "ssh disconnected" };
+      }
+      return runProcessWithCodeTimeout(argv, timeoutMs);
+    };
+    try {
+      await writeFile(join(root, "tracked.txt"), "baseline\n");
+      const baselines = createLastStepBaselineStore({
+        shQuote,
+        runProcessWithCodeTimeout: runner,
+      });
+      await baselines.captureWorkspace("workspace", async () => root);
+      await writeFile(join(root, "tracked.txt"), "changed\n");
+      await baselines.completeWorkspace("workspace");
+      const args = {
+        workspaceId: "workspace",
+        workspace: {},
+        root,
+        params: { mode: "last-step" },
+        shQuote,
+        runProcessWithCodeTimeout: runner,
+        lastStepBaselines: baselines,
+      };
+
+      failCatFile = true;
+      let readError: unknown;
+      try {
+        await readDiffSummary(args);
+      } catch (error) {
+        readError = error;
+      }
+      expect(readError).toBeInstanceOf(Error);
+      expect((readError as Error).message).toContain("ssh disconnected");
+      failCatFile = false;
+      const summary = await readDiffSummary(args);
+      expect(summary.entries.map((entry) => entry.path)).toEqual([
+        "tracked.txt",
+      ]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("drains and invalidates in-flight captures during disposal", async () => {
+    const root = await initRepository();
+    let releaseSnapshot: () => void = () => undefined;
+    let signalSnapshot: () => void = () => undefined;
+    const snapshotStarted = new Promise<void>((resolve) => {
+      signalSnapshot = resolve;
+    });
+    const snapshotGate = new Promise<void>((resolve) => {
+      releaseSnapshot = resolve;
+    });
+    const runner: RunProcessWithCodeTimeout = async (argv, timeoutMs) => {
+      if (argv.join(" ").includes("herdr-git-index")) {
+        signalSnapshot();
+        await snapshotGate;
+      }
+      return runProcessWithCodeTimeout(argv, timeoutMs);
+    };
+    try {
+      await writeFile(join(root, "tracked.txt"), "baseline\n");
+      const baselines = createLastStepBaselineStore({
+        shQuote,
+        runProcessWithCodeTimeout: runner,
+      });
+      const capture = baselines.captureWorkspace("workspace", async () => root);
+      await snapshotStarted;
+      let disposed = false;
+      const disposal = baselines.dispose().then(() => {
+        disposed = true;
+      });
+      await Promise.resolve();
+      expect(disposed).toBe(false);
+
+      releaseSnapshot();
+      let captureError: unknown;
+      try {
+        await capture;
+      } catch (error) {
+        captureError = error;
+      }
+      await disposal;
+      expect((captureError as Error & { code?: string }).code).toBe(
+        "LAST_STEP_STORE_DISPOSED",
+      );
+      expect(await baselines.resolve("workspace", root)).toBeUndefined();
+      await expect(
+        baselines.captureWorkspace("workspace", async () => root),
+      ).rejects.toMatchObject({ code: "LAST_STEP_STORE_DISPOSED" });
+    } finally {
+      releaseSnapshot();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("returns an empty state when the baseline object is missing", async () => {
+    const root = await initRepository();
+    let deleted = false;
+    const missingTree = "0".repeat(40);
+    const baselines: LastStepBaselineStore = {
+      capture: async () => missingTree,
+      captureWorkspace: async () => missingTree,
+      completeWorkspace: async () => false,
+      resolve: async () => missingTree,
+      resolveCompleted: async () => ({
+        baseline: missingTree,
+        current: missingTree,
+      }),
+      rememberSnapshot: () => "missing-snapshot",
+      resolveSnapshot: () => undefined,
+      deleteSnapshot: () => undefined,
+      delete: () => {
+        deleted = true;
+      },
+      dispose: async () => undefined,
+      clear: () => undefined,
+    };
+    try {
+      const summary = await readDiffSummary({
+        workspaceId: "workspace",
+        workspace: {},
+        root,
+        params: { mode: "last-step" },
+        shQuote,
+        runProcessWithCodeTimeout,
+        lastStepBaselines: baselines,
+      });
+      expect(summary.baseline_available).toBe(false);
+      expect(summary.entries).toEqual([]);
+      expect(deleted).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/server/src/workspace/git-diff.test.ts
+++ b/server/src/workspace/git-diff.test.ts
@@ -641,7 +641,7 @@ describe("last-step worktree snapshots", () => {
     }
   });
 
-  test("expires a missing current tree without deleting the valid baseline", async () => {
+  test("expires only the snapshot whose tree is missing", async () => {
     const root = await initRepository();
     try {
       await writeFile(join(root, "tracked.txt"), "baseline\n");
@@ -684,6 +684,42 @@ describe("last-step worktree snapshots", () => {
       ).toEqual({ baseline, current: baseline });
       expect(
         baselines.resolveSnapshot("workspace", root, expiredSnapshot),
+      ).toBeUndefined();
+
+      const expiredBaselineSnapshot = baselines.rememberSnapshot(
+        "old-workspace",
+        root,
+        "0".repeat(40),
+        baseline,
+      );
+      let baselineError: unknown;
+      try {
+        await readDiffFile({
+          workspaceId: "old-workspace",
+          root,
+          params: {
+            mode: "last-step",
+            path: "tracked.txt",
+            snapshot_id: expiredBaselineSnapshot,
+          },
+          shQuote,
+          runProcessWithCodeTimeout,
+          lastStepBaselines: baselines,
+        });
+      } catch (error) {
+        baselineError = error;
+      }
+      expect((baselineError as Error).message).toContain("snapshot expired");
+      expect(await baselines.resolve("workspace", root)).toBe(baseline);
+      expect(
+        baselines.resolveSnapshot("workspace", root, validSnapshot),
+      ).toEqual({ baseline, current: baseline });
+      expect(
+        baselines.resolveSnapshot(
+          "old-workspace",
+          root,
+          expiredBaselineSnapshot,
+        ),
       ).toBeUndefined();
     } finally {
       await rm(root, { recursive: true, force: true });

--- a/server/src/workspace/git-diff.test.ts
+++ b/server/src/workspace/git-diff.test.ts
@@ -575,6 +575,57 @@ describe("last-step worktree snapshots", () => {
     }
   });
 
+  test("does not revalidate snapshot trees for every file patch", async () => {
+    const root = await initRepository();
+    let catFileCalls = 0;
+    const runner: RunProcessWithCodeTimeout = async (argv, timeoutMs) => {
+      if (argv.join(" ").includes("cat-file --batch-check")) {
+        catFileCalls += 1;
+      }
+      return runProcessWithCodeTimeout(argv, timeoutMs);
+    };
+    try {
+      await writeFile(join(root, "tracked.txt"), "baseline\n");
+      await git(root, "add", "tracked.txt");
+      await git(root, "commit", "-m", "initial");
+      const baselines = createLastStepBaselineStore({
+        shQuote,
+        runProcessWithCodeTimeout: runner,
+      });
+      await baselines.captureWorkspace("workspace", async () => root);
+      await writeFile(join(root, "tracked.txt"), "changed\n");
+      await baselines.completeWorkspace("workspace");
+      const summary = await readDiffSummary({
+        workspaceId: "workspace",
+        workspace: {},
+        root,
+        params: { mode: "last-step" },
+        shQuote,
+        runProcessWithCodeTimeout: runner,
+        lastStepBaselines: baselines,
+      });
+      expect(catFileCalls).toBe(2);
+
+      catFileCalls = 0;
+      const file = await readDiffFile({
+        workspaceId: "workspace",
+        root,
+        params: {
+          mode: "last-step",
+          path: "tracked.txt",
+          snapshot_id: summary.snapshot_id,
+        },
+        shQuote,
+        runProcessWithCodeTimeout: runner,
+        lastStepBaselines: baselines,
+      });
+      expect(file.diff).toContain("+changed");
+      expect(catFileCalls).toBe(0);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test("returns a usable summary token when a newer step completes mid-request", async () => {
     const root = await initRepository();
     let blockNameStatus = false;

--- a/server/src/workspace/git-diff.ts
+++ b/server/src/workspace/git-diff.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { sshCommandArgv } from "../bridge/ssh-command";
 import {
   GIT_DIFF_MAX_BYTES,
@@ -14,6 +15,61 @@ import type {
 } from "./file-types";
 
 const GIT_ATTRIBUTE_BATCH_SIZE = 100;
+const LAST_STEP_SNAPSHOT_LIMIT = 64;
+const LAST_STEP_STORE_DISPOSED = "LAST_STEP_STORE_DISPOSED";
+
+function lastStepStoreDisposedError() {
+  return Object.assign(new Error("last-step snapshot store is disposed"), {
+    code: LAST_STEP_STORE_DISPOSED,
+  });
+}
+
+export type LastStepBaselineStore = {
+  capture: (root: string) => Promise<string>;
+  captureWorkspace: (
+    workspaceId: string,
+    resolveRoot: () => Promise<string>,
+  ) => Promise<string>;
+  completeWorkspace: (workspaceId: string) => Promise<boolean>;
+  resolve: (workspaceId: string, root: string) => Promise<string | undefined>;
+  resolveCompleted: (
+    workspaceId: string,
+    root: string,
+  ) => Promise<{ baseline: string; current: string } | undefined>;
+  rememberSnapshot: (
+    workspaceId: string,
+    root: string,
+    baseline: string,
+    current: string,
+  ) => string;
+  resolveSnapshot: (
+    workspaceId: string,
+    root: string,
+    snapshotId: string,
+  ) => { baseline: string; current: string } | undefined;
+  deleteSnapshot: (snapshotId: string) => void;
+  delete: (root: string) => void;
+  dispose: () => Promise<void>;
+  clear: () => void;
+};
+
+type WorkspaceBaselineState =
+  | { status: "pending"; promise: Promise<string>; version: number }
+  | { status: "ready"; root: string; baseline: string; version: number }
+  | { status: "unavailable"; version: number };
+
+type WorkspaceActivityCycle = {
+  version: number;
+  capture: Promise<{ root: string; baseline: string }>;
+  completion?: Promise<boolean>;
+  nextCapture?: Promise<{ root: string; baseline: string }>;
+};
+
+type GitCommandContext = {
+  host?: string;
+  shQuote: (value: string) => string;
+  runProcessWithCodeTimeout: RunProcessWithCodeTimeout;
+};
 
 export function statusLabel(code: string, kind: GitDiffKind) {
   if (kind === "untracked") return "untracked";
@@ -98,7 +154,10 @@ export function parseStatusSummary(output: string): GitDiffEntry[] {
   );
 }
 
-export function parseBranchSummary(output: string): GitDiffEntry[] {
+export function parseBranchSummary(
+  output: string,
+  kind: "branch" | "last-step" = "branch",
+): GitDiffEntry[] {
   return output
     .split(/\r?\n/)
     .filter(Boolean)
@@ -111,8 +170,8 @@ export function parseBranchSummary(output: string): GitDiffEntry[] {
       return {
         path,
         old_path: oldPath,
-        kind: "branch" as const,
-        status: statusLabel(rawStatus[0] ?? "M", "branch"),
+        kind,
+        status: statusLabel(rawStatus[0] ?? "M", kind),
       };
     })
     .filter((entry) => entry.path)
@@ -180,7 +239,40 @@ function entryKeyForStats(entry: Pick<GitDiffEntry, "kind" | "path">) {
 }
 
 function diffMode(params: Record<string, unknown>): GitDiffMode {
-  return params.mode === "branch-main" ? "branch-main" : "working";
+  if (params.mode === "branch-main") return "branch-main";
+  if (params.mode === "last-step") return "last-step";
+  return "working";
+}
+
+function diffFileKind(mode: GitDiffMode, requestedKind: unknown): GitDiffKind {
+  if (mode === "branch-main") return "branch";
+  if (mode === "last-step") return "last-step";
+  if (
+    requestedKind === "staged" ||
+    requestedKind === "untracked" ||
+    requestedKind === "conflicted"
+  ) {
+    return requestedKind;
+  }
+  return "unstaged";
+}
+
+function workingDiffFileCommand(
+  kind: GitDiffKind,
+  path: string,
+  pathspec: string,
+  shQuote: (value: string) => string,
+) {
+  switch (kind) {
+    case "staged":
+      return `diff --cached --no-ext-diff -- ${pathspec}`;
+    case "untracked":
+      return `diff --no-ext-diff --no-index -- /dev/null ${shQuote(path)}`;
+    case "conflicted":
+      return `diff --cc --no-ext-diff -- ${pathspec}`;
+    default:
+      return `diff --no-ext-diff -- ${pathspec}`;
+  }
 }
 
 function runGitShellCommand({
@@ -203,6 +295,324 @@ function runGitShellCommand({
     host ? sshCommandArgv(host, fullCommand) : ["sh", "-lc", fullCommand],
     timeoutMs,
   );
+}
+
+export async function snapshotWorktreeTree({
+  root,
+  host,
+  shQuote,
+  runProcessWithCodeTimeout,
+}: { root: string } & GitCommandContext): Promise<string> {
+  const command = `
+set -eu
+index_file=$(mktemp "\${TMPDIR:-/tmp}/herdr-git-index.XXXXXX")
+cleanup() { rm -f "$index_file" "$index_file.lock"; }
+trap cleanup EXIT HUP INT TERM
+rm -f "$index_file"
+export GIT_INDEX_FILE="$index_file"
+if git -C ${shQuote(root)} rev-parse --verify --quiet 'HEAD^{commit}' >/dev/null; then
+  git -C ${shQuote(root)} read-tree HEAD
+else
+  git -C ${shQuote(root)} read-tree --empty
+fi
+git -C ${shQuote(root)} add -A
+git -C ${shQuote(root)} write-tree
+`;
+  const result = await runProcessWithCodeTimeout(
+    host ? sshCommandArgv(host, command) : ["sh", "-lc", command],
+    GIT_DIFF_TIMEOUT_MS,
+  );
+  const tree = result.stdout.trim();
+  if (result.code !== 0 || !/^[0-9a-f]{40,64}$/.test(tree)) {
+    throw new Error(
+      (result.stderr || result.stdout || `git write-tree exited ${result.code}`)
+        .trim()
+        .slice(0, 1000),
+    );
+  }
+  return tree;
+}
+
+export function createLastStepBaselineStore(
+  context: GitCommandContext,
+): LastStepBaselineStore {
+  const baselines = new Map<string, string>();
+  const captureVersions = new Map<string, number>();
+  const workspaceStates = new Map<string, WorkspaceBaselineState>();
+  const completedRanges = new Map<
+    string,
+    { root: string; baseline: string; current: string }
+  >();
+  const completedVersions = new Map<string, number>();
+  const activityCycles = new Map<string, WorkspaceActivityCycle>();
+  const snapshots = new Map<
+    string,
+    { workspaceId: string; root: string; baseline: string; current: string }
+  >();
+  const inFlight = new Set<Promise<unknown>>();
+  let disposed = false;
+  let disposeTask: Promise<void> | null = null;
+
+  function assertActive() {
+    if (disposed) throw lastStepStoreDisposedError();
+  }
+
+  function track<T>(task: Promise<T>): Promise<T> {
+    inFlight.add(task);
+    const remove = () => inFlight.delete(task);
+    void task.then(remove, remove);
+    return task;
+  }
+
+  function clearState() {
+    baselines.clear();
+    captureVersions.clear();
+    workspaceStates.clear();
+    completedRanges.clear();
+    completedVersions.clear();
+    activityCycles.clear();
+    snapshots.clear();
+  }
+
+  function deleteSnapshots(
+    predicate: (workspaceId: string, root: string) => boolean,
+  ) {
+    for (const [snapshotId, snapshot] of snapshots) {
+      if (predicate(snapshot.workspaceId, snapshot.root)) {
+        snapshots.delete(snapshotId);
+      }
+    }
+  }
+
+  async function captureRoot(root: string, invalidateSnapshots = true) {
+    assertActive();
+    const version = (captureVersions.get(root) ?? 0) + 1;
+    captureVersions.set(root, version);
+    baselines.delete(root);
+    if (invalidateSnapshots) {
+      deleteSnapshots((_workspaceId, snapshotRoot) => snapshotRoot === root);
+    }
+    const tree = await snapshotWorktreeTree({ root, ...context });
+    assertActive();
+    if (captureVersions.get(root) === version) baselines.set(root, tree);
+    return { tree, version };
+  }
+
+  return {
+    async capture(root) {
+      const captured = await track(captureRoot(root));
+      return captured.tree;
+    },
+    captureWorkspace(workspaceId, resolveRoot) {
+      if (disposed) return Promise.reject(lastStepStoreDisposedError());
+      const priorCycle = activityCycles.get(workspaceId);
+      const version = (workspaceStates.get(workspaceId)?.version ?? 0) + 1;
+      let resolvedRoot: string | undefined;
+      let rootCaptureVersion: number | undefined;
+      const capture = track(
+        (async () => {
+          try {
+            resolvedRoot = await resolveRoot();
+            const captured = await captureRoot(resolvedRoot, false);
+            rootCaptureVersion = captured.version;
+            if (activityCycles.get(workspaceId)?.version === version) {
+              workspaceStates.set(workspaceId, {
+                status: "ready",
+                root: resolvedRoot,
+                baseline: captured.tree,
+                version,
+              });
+            }
+            return { root: resolvedRoot, baseline: captured.tree };
+          } catch (error) {
+            if (activityCycles.get(workspaceId)?.version === version) {
+              if (
+                resolvedRoot &&
+                rootCaptureVersion !== undefined &&
+                captureVersions.get(resolvedRoot) === rootCaptureVersion
+              ) {
+                baselines.delete(resolvedRoot);
+                captureVersions.delete(resolvedRoot);
+              }
+              workspaceStates.set(workspaceId, {
+                status: "unavailable",
+                version,
+              });
+            }
+            throw error;
+          }
+        })(),
+      );
+      const cycle = { version, capture };
+      activityCycles.set(workspaceId, cycle);
+      if (priorCycle?.completion) priorCycle.nextCapture = capture;
+      const promise = capture.then((result) => result.baseline);
+      workspaceStates.set(workspaceId, {
+        status: "pending",
+        promise,
+        version,
+      });
+      return promise;
+    },
+    completeWorkspace(workspaceId) {
+      if (disposed) return Promise.reject(lastStepStoreDisposedError());
+      const cycle = activityCycles.get(workspaceId);
+      if (!cycle) return Promise.resolve(false);
+      if (cycle.completion) return cycle.completion;
+      const task = (async () => {
+        let captured: { root: string; baseline: string };
+        try {
+          captured = await cycle.capture;
+        } catch {
+          return false;
+        }
+        let current = await snapshotWorktreeTree({
+          root: captured.root,
+          ...context,
+        });
+        if (cycle.nextCapture) {
+          try {
+            const next = await cycle.nextCapture;
+            if (next.root === captured.root) current = next.baseline;
+          } catch {
+            // Do not publish a potentially late endpoint after a newer period
+            // started but failed to establish its boundary snapshot.
+            return false;
+          }
+        }
+        if (disposed) return false;
+        if ((completedVersions.get(workspaceId) ?? 0) >= cycle.version) {
+          return false;
+        }
+        completedVersions.set(workspaceId, cycle.version);
+        completedRanges.set(workspaceId, {
+          root: captured.root,
+          baseline: captured.baseline,
+          current,
+        });
+        deleteSnapshots(
+          (snapshotWorkspaceId) => snapshotWorkspaceId === workspaceId,
+        );
+        return true;
+      })();
+      cycle.completion = track(task);
+      return cycle.completion;
+    },
+    async resolve(workspaceId, root) {
+      if (disposed) return undefined;
+      let state = workspaceStates.get(workspaceId);
+      if (state?.status === "pending") {
+        try {
+          await state.promise;
+        } catch {
+          return undefined;
+        }
+        state = workspaceStates.get(workspaceId);
+      }
+      if (state?.status === "unavailable") return undefined;
+      if (state?.status === "ready") {
+        return state.root === root ? state.baseline : undefined;
+      }
+      return baselines.get(root);
+    },
+    async resolveCompleted(workspaceId, root) {
+      if (disposed) return undefined;
+      const completion = activityCycles.get(workspaceId)?.completion;
+      if (completion) {
+        try {
+          await completion;
+        } catch {
+          // Preserve the previous completed range when finalization fails.
+        }
+      }
+      const range = completedRanges.get(workspaceId);
+      if (!range || range.root !== root) return undefined;
+      return { baseline: range.baseline, current: range.current };
+    },
+    rememberSnapshot(workspaceId, root, baseline, current) {
+      assertActive();
+      const snapshotId = randomUUID();
+      snapshots.set(snapshotId, { workspaceId, root, baseline, current });
+      while (snapshots.size > LAST_STEP_SNAPSHOT_LIMIT) {
+        const oldest = snapshots.keys().next().value;
+        if (typeof oldest !== "string") break;
+        snapshots.delete(oldest);
+      }
+      return snapshotId;
+    },
+    resolveSnapshot(workspaceId, root, snapshotId) {
+      const snapshot = snapshots.get(snapshotId);
+      if (
+        !snapshot ||
+        snapshot.workspaceId !== workspaceId ||
+        snapshot.root !== root
+      ) {
+        return undefined;
+      }
+      return { baseline: snapshot.baseline, current: snapshot.current };
+    },
+    deleteSnapshot: (snapshotId) => snapshots.delete(snapshotId),
+    delete(root) {
+      baselines.delete(root);
+      deleteSnapshots((_workspaceId, snapshotRoot) => snapshotRoot === root);
+      captureVersions.delete(root);
+      for (const [workspaceId, state] of workspaceStates) {
+        if (state.status === "ready" && state.root === root) {
+          workspaceStates.set(workspaceId, {
+            status: "unavailable",
+            version: state.version,
+          });
+        }
+      }
+      for (const [workspaceId, range] of completedRanges) {
+        if (range.root === root) {
+          completedRanges.delete(workspaceId);
+          completedVersions.delete(workspaceId);
+        }
+      }
+    },
+    dispose() {
+      if (disposeTask) return disposeTask;
+      disposed = true;
+      disposeTask = (async () => {
+        // Git subprocess failures are owned by their original callers. This
+        // shutdown boundary only drains every task before final state clearing.
+        await Promise.allSettled(Array.from(inFlight));
+        clearState();
+      })();
+      return disposeTask;
+    },
+    clear() {
+      clearState();
+    },
+  };
+}
+
+async function treeExists({
+  root,
+  tree,
+  host,
+  shQuote,
+  runProcessWithCodeTimeout,
+}: { root: string; tree: string } & GitCommandContext) {
+  const result = await runGitShellCommand({
+    root,
+    command: `cat-file --batch-check=${shQuote("%(objectname) %(objecttype)")} <<'HERDR_EOF'\n${tree}\nHERDR_EOF`,
+    host,
+    shQuote,
+    runProcessWithCodeTimeout,
+  });
+  if (result.code !== 0) {
+    throw new Error(
+      (result.stderr || result.stdout || `git cat-file exited ${result.code}`)
+        .trim()
+        .slice(0, 1000),
+    );
+  }
+  const output = result.stdout.trim();
+  if (output === `${tree} missing`) return false;
+  if (output === `${tree} tree`) return true;
+  throw new Error(`unexpected git cat-file response: ${output.slice(0, 1000)}`);
 }
 
 async function collectGeneratedPaths({
@@ -241,6 +651,7 @@ async function collectStats({
   root,
   mode,
   base,
+  target,
   entries,
   host,
   shQuote,
@@ -249,6 +660,7 @@ async function collectStats({
   root: string;
   mode: GitDiffMode;
   base: string | undefined;
+  target?: string;
   entries: GitDiffEntry[];
   host?: string;
   shQuote: (value: string) => string;
@@ -266,17 +678,20 @@ async function collectStats({
     }
   };
 
-  if (mode === "branch-main") {
+  if (mode === "branch-main" || mode === "last-step") {
+    const kind = mode === "branch-main" ? "branch" : "last-step";
+    const range =
+      mode === "branch-main"
+        ? `${shQuote(base ?? "main")}...HEAD`
+        : `${shQuote(base ?? "")} ${shQuote(target ?? "")}`;
     const result = await runGitShellCommand({
       root,
-      command: `diff --numstat --find-renames ${shQuote(base ?? "main")}...HEAD`,
+      command: `diff --numstat --find-renames ${range}`,
       host,
       shQuote,
       runProcessWithCodeTimeout,
     });
-    if (result.code === 0 || result.code === 1) {
-      mergeStats("branch", result.stdout);
-    }
+    if (result.code === 0 || result.code === 1) mergeStats(kind, result.stdout);
     return stats;
   }
 
@@ -372,6 +787,77 @@ exit 1
   return result.stdout.trim();
 }
 
+async function resolveLastStepRange({
+  workspaceId,
+  root,
+  baselines,
+  snapshotId,
+  host,
+  shQuote,
+  runProcessWithCodeTimeout,
+}: {
+  workspaceId: string;
+  root: string;
+  baselines?: LastStepBaselineStore;
+  snapshotId?: string;
+} & GitCommandContext) {
+  if (snapshotId) {
+    const snapshot = baselines?.resolveSnapshot(workspaceId, root, snapshotId);
+    if (!snapshot) {
+      throw new Error("last-step snapshot expired; refresh Changes");
+    }
+    const [baselineExists, currentExists] = await Promise.all([
+      treeExists({
+        root,
+        tree: snapshot.baseline,
+        host,
+        shQuote,
+        runProcessWithCodeTimeout,
+      }),
+      treeExists({
+        root,
+        tree: snapshot.current,
+        host,
+        shQuote,
+        runProcessWithCodeTimeout,
+      }),
+    ]);
+    if (!baselineExists) {
+      baselines?.delete(root);
+      throw new Error("last-step snapshot expired; refresh Changes");
+    }
+    if (!currentExists) {
+      baselines?.deleteSnapshot(snapshotId);
+      throw new Error("last-step snapshot expired; refresh Changes");
+    }
+    return snapshot;
+  }
+
+  const completed = await baselines?.resolveCompleted(workspaceId, root);
+  if (!completed) return null;
+  const [baselineExists, currentExists] = await Promise.all([
+    treeExists({
+      root,
+      tree: completed.baseline,
+      host,
+      shQuote,
+      runProcessWithCodeTimeout,
+    }),
+    treeExists({
+      root,
+      tree: completed.current,
+      host,
+      shQuote,
+      runProcessWithCodeTimeout,
+    }),
+  ]);
+  if (!baselineExists || !currentExists) {
+    baselines?.delete(root);
+    return null;
+  }
+  return completed;
+}
+
 export async function readDiffSummary({
   workspaceId,
   workspace,
@@ -380,6 +866,7 @@ export async function readDiffSummary({
   host,
   shQuote,
   runProcessWithCodeTimeout,
+  lastStepBaselines,
 }: {
   workspaceId: string;
   workspace: any;
@@ -388,6 +875,7 @@ export async function readDiffSummary({
   host?: string;
   shQuote: (value: string) => string;
   runProcessWithCodeTimeout: RunProcessWithCodeTimeout;
+  lastStepBaselines?: LastStepBaselineStore;
 }) {
   const mode = diffMode(params);
   const base =
@@ -399,47 +887,79 @@ export async function readDiffSummary({
           runProcessWithCodeTimeout,
         })
       : undefined;
-  const result =
-    mode === "branch-main"
-      ? await runGitShellCommand({
+  const lastStepRange =
+    mode === "last-step"
+      ? await resolveLastStepRange({
+          workspaceId,
           root,
-          command: `diff --name-status --find-renames ${shQuote(base ?? "main")}...HEAD`,
+          baselines: lastStepBaselines,
           host,
           shQuote,
           runProcessWithCodeTimeout,
         })
-      : await runGitShellCommand({
-          root,
-          command: "status --porcelain=v1 --untracked-files=all",
-          host,
-          shQuote,
-          runProcessWithCodeTimeout,
-        });
+      : null;
+  let result = { code: 0, stdout: "", stderr: "" };
+  if (mode === "branch-main") {
+    result = await runGitShellCommand({
+      root,
+      command: `diff --name-status --find-renames ${shQuote(base ?? "main")}...HEAD`,
+      host,
+      shQuote,
+      runProcessWithCodeTimeout,
+    });
+  } else if (mode === "last-step" && lastStepRange) {
+    result = await runGitShellCommand({
+      root,
+      command: `diff --name-status --find-renames ${shQuote(lastStepRange.baseline)} ${shQuote(lastStepRange.current)}`,
+      host,
+      shQuote,
+      runProcessWithCodeTimeout,
+    });
+  } else if (mode === "working") {
+    result = await runGitShellCommand({
+      root,
+      command: "status --porcelain=v1 --untracked-files=all",
+      host,
+      shQuote,
+      runProcessWithCodeTimeout,
+    });
+  }
   if (result.code !== 0) {
     throw new Error(
       (
         result.stderr ||
         result.stdout ||
-        `git ${mode === "branch-main" ? "diff" : "status"} exited ${result.code}`
+        `git ${mode === "working" ? "status" : "diff"} exited ${result.code}`
       )
         .trim()
         .slice(0, 1000),
     );
   }
-  const entries =
-    mode === "branch-main"
-      ? parseBranchSummary(result.stdout)
-      : parseStatusSummary(result.stdout);
-  const [stats, generatedPaths] = await Promise.all([
-    collectStats({
+  let entries: GitDiffEntry[];
+  if (mode === "branch-main") {
+    entries = parseBranchSummary(result.stdout);
+  } else if (mode === "last-step") {
+    entries = parseBranchSummary(result.stdout, "last-step");
+  } else {
+    entries = parseStatusSummary(result.stdout);
+  }
+  let statsTask: Promise<Map<string, { additions: number; deletions: number }>>;
+  if (mode === "last-step" && !lastStepRange) {
+    statsTask = Promise.resolve(new Map());
+  } else {
+    statsTask = collectStats({
       root,
       mode,
-      base,
+      base: mode === "last-step" ? lastStepRange?.baseline : base,
+      target: lastStepRange?.current,
       entries,
       host,
       shQuote,
       runProcessWithCodeTimeout,
-    }),
+    });
+  }
+  const [stats, generatedPaths] = await Promise.all([
+    statsTask,
     collectGeneratedPaths({
       root,
       entries,
@@ -457,12 +977,23 @@ export async function readDiffSummary({
       ? { ...entryWithStats, generated: true }
       : entryWithStats;
   });
+  const lastStepSnapshotId =
+    mode === "last-step" && lastStepRange
+      ? lastStepBaselines?.rememberSnapshot(
+          workspaceId,
+          root,
+          lastStepRange.baseline,
+          lastStepRange.current,
+        )
+      : undefined;
   return {
     workspace_id: workspaceId,
     repo_name: workspace?.worktree?.repo_name ?? workspace?.label ?? "",
     root,
     mode,
-    base,
+    base: mode === "last-step" ? lastStepRange?.baseline : base,
+    baseline_available: mode !== "last-step" || lastStepRange !== null,
+    snapshot_id: lastStepSnapshotId,
     entries: entriesWithStats,
     counts: {
       staged: entriesWithStats.filter((entry) => entry.kind === "staged")
@@ -476,6 +1007,9 @@ export async function readDiffSummary({
       ).length,
       branch: entriesWithStats.filter((entry) => entry.kind === "branch")
         .length,
+      "last-step": entriesWithStats.filter(
+        (entry) => entry.kind === "last-step",
+      ).length,
     },
   };
 }
@@ -487,6 +1021,7 @@ export async function readDiffFile({
   host,
   shQuote,
   runProcessWithCodeTimeout,
+  lastStepBaselines,
 }: {
   workspaceId: string;
   root: string;
@@ -494,10 +1029,21 @@ export async function readDiffFile({
   host?: string;
   shQuote: (value: string) => string;
   runProcessWithCodeTimeout: RunProcessWithCodeTimeout;
+  lastStepBaselines?: LastStepBaselineStore;
 }) {
   const path = sanitizeExplorerPath(params.path);
   if (!path) throw new Error("git.diff_file requires path");
+  const oldPath = sanitizeExplorerPath(params.old_path);
+  const diffPaths = oldPath && oldPath !== path ? [oldPath, path] : [path];
+  const pathspec = diffPaths.map(shQuote).join(" ");
   const mode = diffMode(params);
+  const snapshotId =
+    typeof params.snapshot_id === "string" && params.snapshot_id
+      ? params.snapshot_id
+      : undefined;
+  if (mode === "last-step" && !snapshotId) {
+    throw new Error("last-step diff requires a fresh summary snapshot");
+  }
   const base =
     mode === "branch-main"
       ? await resolveMainBase({
@@ -507,31 +1053,38 @@ export async function readDiffFile({
           runProcessWithCodeTimeout,
         })
       : undefined;
-  const kind =
-    mode === "branch-main"
-      ? "branch"
-      : params.kind === "staged" ||
-          params.kind === "untracked" ||
-          params.kind === "conflicted"
-        ? params.kind
-        : "unstaged";
-  const gitCommand =
-    mode === "branch-main"
-      ? `diff --no-ext-diff --find-renames ${shQuote(base ?? "main")}...HEAD -- ${shQuote(path)}`
-      : kind === "staged"
-        ? `diff --cached --no-ext-diff -- ${shQuote(path)}`
-        : kind === "untracked"
-          ? `diff --no-ext-diff --no-index -- /dev/null ${shQuote(path)}`
-          : kind === "conflicted"
-            ? `diff --cc --no-ext-diff -- ${shQuote(path)}`
-            : `diff --no-ext-diff -- ${shQuote(path)}`;
-  const result = await runGitShellCommand({
-    root,
-    command: gitCommand,
-    host,
-    shQuote,
-    runProcessWithCodeTimeout,
-  });
+  const lastStepRange =
+    mode === "last-step"
+      ? await resolveLastStepRange({
+          workspaceId,
+          root,
+          baselines: lastStepBaselines,
+          snapshotId,
+          host,
+          shQuote,
+          runProcessWithCodeTimeout,
+        })
+      : null;
+  const kind = diffFileKind(mode, params.kind);
+  let gitCommand: string | null = null;
+  if (mode === "branch-main") {
+    gitCommand = `diff --no-ext-diff --find-renames ${shQuote(base ?? "main")}...HEAD -- ${pathspec}`;
+  } else if (mode === "last-step" && lastStepRange) {
+    gitCommand = `diff --no-ext-diff --find-renames ${shQuote(lastStepRange.baseline)} ${shQuote(lastStepRange.current)} -- ${pathspec}`;
+  } else if (mode === "working") {
+    gitCommand = workingDiffFileCommand(kind, path, pathspec, shQuote);
+  }
+
+  let result = { code: 0, stdout: "", stderr: "" };
+  if (gitCommand) {
+    result = await runGitShellCommand({
+      root,
+      command: gitCommand,
+      host,
+      shQuote,
+      runProcessWithCodeTimeout,
+    });
+  }
   const diffExitOk =
     kind === "untracked"
       ? result.code === 0 || result.code === 1

--- a/server/src/workspace/git-diff.ts
+++ b/server/src/workspace/git-diff.ts
@@ -806,30 +806,6 @@ async function resolveLastStepRange({
     if (!snapshot) {
       throw new Error("last-step snapshot expired; refresh Changes");
     }
-    const [baselineExists, currentExists] = await Promise.all([
-      treeExists({
-        root,
-        tree: snapshot.baseline,
-        host,
-        shQuote,
-        runProcessWithCodeTimeout,
-      }),
-      treeExists({
-        root,
-        tree: snapshot.current,
-        host,
-        shQuote,
-        runProcessWithCodeTimeout,
-      }),
-    ]);
-    if (!baselineExists) {
-      baselines?.deleteSnapshot(snapshotId);
-      throw new Error("last-step snapshot expired; refresh Changes");
-    }
-    if (!currentExists) {
-      baselines?.deleteSnapshot(snapshotId);
-      throw new Error("last-step snapshot expired; refresh Changes");
-    }
     return snapshot;
   }
 
@@ -1090,6 +1066,28 @@ export async function readDiffFile({
       ? result.code === 0 || result.code === 1
       : result.code === 0;
   if (!diffExitOk) {
+    if (mode === "last-step" && snapshotId && lastStepRange) {
+      const [baselineExists, currentExists] = await Promise.all([
+        treeExists({
+          root,
+          tree: lastStepRange.baseline,
+          host,
+          shQuote,
+          runProcessWithCodeTimeout,
+        }),
+        treeExists({
+          root,
+          tree: lastStepRange.current,
+          host,
+          shQuote,
+          runProcessWithCodeTimeout,
+        }),
+      ]);
+      if (!baselineExists || !currentExists) {
+        lastStepBaselines?.deleteSnapshot(snapshotId);
+        throw new Error("last-step snapshot expired; refresh Changes");
+      }
+    }
     throw new Error(
       (result.stderr || result.stdout || `git diff exited ${result.code}`)
         .trim()

--- a/server/src/workspace/git-diff.ts
+++ b/server/src/workspace/git-diff.ts
@@ -823,7 +823,7 @@ async function resolveLastStepRange({
       }),
     ]);
     if (!baselineExists) {
-      baselines?.delete(root);
+      baselines?.deleteSnapshot(snapshotId);
       throw new Error("last-step snapshot expired; refresh Changes");
     }
     if (!currentExists) {

--- a/server/src/workspace/last-step-turns.test.ts
+++ b/server/src/workspace/last-step-turns.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, test } from "bun:test";
+import { createLastStepTurnTracker } from "./last-step-turns";
+
+async function flushTransitions() {
+  for (let index = 0; index < 6; index += 1) await Promise.resolve();
+}
+
+function status(paneId: string, workspaceId: string, agentStatus: string) {
+  return {
+    event: "pane.agent_status_changed",
+    data: {
+      pane_id: paneId,
+      workspace_id: workspaceId,
+      agent_status: agentStatus,
+    },
+  };
+}
+
+describe("last-step turn tracking", () => {
+  test("captures starts and completes only workspace-wide activity periods", async () => {
+    const captures: string[] = [];
+    const completions: string[] = [];
+    const tracker = createLastStepTurnTracker({
+      captureWorkspaceBaseline: async (workspaceId) => {
+        captures.push(workspaceId);
+      },
+      completeWorkspaceStep: async (workspaceId) => {
+        completions.push(workspaceId);
+      },
+    });
+
+    tracker.handleHerdrEvent(status("p1", "w1", "working"));
+    tracker.handleHerdrEvent(status("p2", "w1", "working"));
+    await flushTransitions();
+    tracker.handleHerdrEvent(status("p1", "w1", "idle"));
+    tracker.handleHerdrEvent(status("p2", "w1", "done"));
+    await flushTransitions();
+    tracker.handleHerdrEvent(status("p1", "w1", "working"));
+    await flushTransitions();
+
+    expect(captures).toEqual(["w1", "w1"]);
+    expect(completions).toEqual(["w1"]);
+  });
+
+  test("seeds active workspaces from pane listings without capturing", async () => {
+    const captures: string[] = [];
+    const tracker = createLastStepTurnTracker({
+      captureWorkspaceBaseline: async (workspaceId) => {
+        captures.push(workspaceId);
+      },
+    });
+
+    tracker.reconcilePaneList({
+      panes: [
+        {
+          pane_id: "p1",
+          workspace_id: "w1",
+          agent: "pi",
+          agent_status: "working",
+        },
+      ],
+    });
+    tracker.handleHerdrEvent(status("p2", "w1", "working"));
+    tracker.handleHerdrEvent(status("p1", "w1", "idle"));
+    tracker.handleHerdrEvent(status("p2", "w1", "done"));
+    tracker.handleHerdrEvent(status("p1", "w1", "working"));
+    await Promise.resolve();
+
+    expect(captures).toEqual(["w1"]);
+  });
+
+  test("does not let a stale idle listing overwrite a newer working event", async () => {
+    const captures: string[] = [];
+    const tracker = createLastStepTurnTracker({
+      captureWorkspaceBaseline: async (workspaceId) => {
+        captures.push(workspaceId);
+      },
+    });
+    const idlePane = {
+      pane_id: "p1",
+      workspace_id: "w1",
+      agent: "pi",
+      agent_status: "idle",
+    };
+    tracker.reconcilePaneList({ panes: [idlePane] });
+    const listRevision = tracker.beginPaneList();
+    tracker.handleHerdrEvent(status("p1", "w1", "working"));
+    tracker.reconcilePaneList({ panes: [idlePane] }, listRevision);
+    tracker.handleHerdrEvent(status("p1", "w1", "working"));
+    await Promise.resolve();
+
+    expect(captures).toEqual(["w1"]);
+  });
+
+  test("does not let a stale working listing suppress the next turn", async () => {
+    const captures: string[] = [];
+    const tracker = createLastStepTurnTracker({
+      captureWorkspaceBaseline: async (workspaceId) => {
+        captures.push(workspaceId);
+      },
+    });
+    const workingPane = {
+      pane_id: "p1",
+      workspace_id: "w1",
+      agent: "pi",
+      agent_status: "working",
+    };
+    tracker.reconcilePaneList({ panes: [workingPane] });
+    const listRevision = tracker.beginPaneList();
+    tracker.handleHerdrEvent(status("p1", "w1", "idle"));
+    tracker.reconcilePaneList({ panes: [workingPane] }, listRevision);
+    tracker.handleHerdrEvent(status("p1", "w1", "working"));
+    await Promise.resolve();
+
+    expect(captures).toEqual(["w1"]);
+  });
+
+  test("captures a quiet-to-active transition observed by a later pane listing", async () => {
+    const captures: string[] = [];
+    const tracker = createLastStepTurnTracker({
+      captureWorkspaceBaseline: async (workspaceId) => {
+        captures.push(workspaceId);
+      },
+    });
+
+    tracker.reconcilePaneList({ panes: [] });
+    tracker.reconcilePaneList({
+      panes: [
+        {
+          pane_id: "p1",
+          workspace_id: "w1",
+          agent: "pi",
+          agent_status: "working",
+        },
+        {
+          pane_id: "p2",
+          workspace_id: "w1",
+          agent: "codex",
+          agent_status: "working",
+        },
+      ],
+    });
+    await Promise.resolve();
+
+    expect(captures).toEqual(["w1"]);
+  });
+
+  test("forgets closed panes when deciding whether a workspace is quiet", async () => {
+    const captures: string[] = [];
+    const tracker = createLastStepTurnTracker({
+      captureWorkspaceBaseline: async (workspaceId) => {
+        captures.push(workspaceId);
+      },
+    });
+
+    tracker.handleHerdrEvent(status("p1", "w1", "working"));
+    await flushTransitions();
+    tracker.handleHerdrEvent({
+      event: "pane.closed",
+      data: { pane_id: "p1", workspace_id: "w1" },
+    });
+    await flushTransitions();
+    tracker.handleHerdrEvent(status("p2", "w1", "working"));
+    await flushTransitions();
+
+    expect(captures).toEqual(["w1", "w1"]);
+  });
+
+  test("debounces transient idle flapping before snapshot work starts", async () => {
+    const captures: string[] = [];
+    const completions: string[] = [];
+    const tracker = createLastStepTurnTracker({
+      captureWorkspaceBaseline: async (workspaceId) => {
+        captures.push(workspaceId);
+      },
+      completeWorkspaceStep: async (workspaceId) => {
+        completions.push(workspaceId);
+      },
+      transitionDebounceMs: 20,
+    });
+
+    tracker.handleHerdrEvent(status("p1", "w1", "working"));
+    tracker.handleHerdrEvent(status("p1", "w1", "idle"));
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(captures).toEqual([]);
+    expect(completions).toEqual([]);
+
+    tracker.handleHerdrEvent(status("p1", "w1", "working"));
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    await flushTransitions();
+    expect(captures).toEqual(["w1"]);
+    await tracker.stop();
+  });
+
+  test("coalesces queued edges while one workspace snapshot is in flight", async () => {
+    const captures: string[] = [];
+    const completions: string[] = [];
+    let releaseCapture: () => void = () => undefined;
+    const captureGate = new Promise<void>((resolve) => {
+      releaseCapture = resolve;
+    });
+    const tracker = createLastStepTurnTracker({
+      captureWorkspaceBaseline: async (workspaceId) => {
+        captures.push(workspaceId);
+        await captureGate;
+      },
+      completeWorkspaceStep: async (workspaceId) => {
+        completions.push(workspaceId);
+      },
+    });
+
+    tracker.handleHerdrEvent(status("p1", "w1", "working"));
+    await flushTransitions();
+    tracker.handleHerdrEvent(status("p1", "w1", "idle"));
+    tracker.handleHerdrEvent(status("p1", "w1", "working"));
+    releaseCapture();
+    await flushTransitions();
+
+    expect(captures).toEqual(["w1"]);
+    expect(completions).toEqual([]);
+    await tracker.stop();
+  });
+
+  test("transfers a working pane between workspace activity periods", async () => {
+    const captures: string[] = [];
+    const completions: string[] = [];
+    const tracker = createLastStepTurnTracker({
+      captureWorkspaceBaseline: async (workspaceId) => {
+        captures.push(workspaceId);
+      },
+      completeWorkspaceStep: async (workspaceId) => {
+        completions.push(workspaceId);
+      },
+    });
+    tracker.reconcilePaneList({
+      panes: [
+        {
+          pane_id: "p1",
+          workspace_id: "old",
+          agent: "pi",
+          agent_status: "working",
+        },
+      ],
+    });
+
+    tracker.handleHerdrEvent({
+      event: "pane.moved",
+      data: { pane_id: "p1", workspace_id: "new" },
+    });
+    await flushTransitions();
+
+    expect(completions).toEqual(["old"]);
+    expect(captures).toEqual(["new"]);
+    await tracker.stop();
+  });
+
+  test("does not complete a closed workspace after its capture settles", async () => {
+    const completions: string[] = [];
+    let releaseCapture: () => void = () => undefined;
+    let signalCapture: () => void = () => undefined;
+    const captureStarted = new Promise<void>((resolve) => {
+      signalCapture = resolve;
+    });
+    const captureGate = new Promise<void>((resolve) => {
+      releaseCapture = resolve;
+    });
+    const tracker = createLastStepTurnTracker({
+      captureWorkspaceBaseline: async () => {
+        signalCapture();
+        await captureGate;
+      },
+      completeWorkspaceStep: async (workspaceId) => {
+        completions.push(workspaceId);
+      },
+    });
+
+    tracker.handleHerdrEvent(status("p1", "w1", "working"));
+    await captureStarted;
+    tracker.handleHerdrEvent({
+      event: "workspace.closed",
+      data: { workspace_id: "w1" },
+    });
+    releaseCapture();
+    await flushTransitions();
+
+    expect(completions).toEqual([]);
+    await tracker.stop();
+  });
+
+  test("reports capture failures without rejecting event handling", async () => {
+    const errors: string[] = [];
+    const tracker = createLastStepTurnTracker({
+      captureWorkspaceBaseline: async () => {
+        throw new Error("snapshot failed");
+      },
+      onCaptureError: (error, workspaceId) => {
+        errors.push(`${workspaceId}: ${error.message}`);
+      },
+    });
+
+    tracker.handleHerdrEvent(status("p1", "w1", "working"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(errors).toEqual(["w1: snapshot failed"]);
+  });
+});

--- a/server/src/workspace/last-step-turns.ts
+++ b/server/src/workspace/last-step-turns.ts
@@ -9,7 +9,6 @@ type EventEnvelope = {
 };
 
 type PendingTransition = {
-  active: boolean;
   timer: ReturnType<typeof setTimeout>;
 };
 
@@ -161,7 +160,7 @@ export function createLastStepTurnTracker(args: {
       pendingTransitions.delete(workspaceId);
       commitTransition(workspaceId, active);
     }, transitionDebounceMs);
-    pendingTransitions.set(workspaceId, { active, timer });
+    pendingTransitions.set(workspaceId, { timer });
   }
 
   function cancelWorkspace(workspaceId: string) {

--- a/server/src/workspace/last-step-turns.ts
+++ b/server/src/workspace/last-step-turns.ts
@@ -1,0 +1,372 @@
+type PaneActivity = {
+  workspaceId: string;
+  status: string;
+};
+
+type EventEnvelope = {
+  event?: unknown;
+  data?: unknown;
+};
+
+type PendingTransition = {
+  active: boolean;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+function eventName(event: unknown): string | null {
+  if (!event || typeof event !== "object" || Array.isArray(event)) return null;
+  const envelope = event as EventEnvelope;
+  if (typeof envelope.event === "string") return envelope.event;
+  if (
+    envelope.data &&
+    typeof envelope.data === "object" &&
+    !Array.isArray(envelope.data)
+  ) {
+    const type = (envelope.data as { type?: unknown }).type;
+    if (typeof type === "string") return type;
+  }
+  return null;
+}
+
+function eventData(event: unknown): Record<string, unknown> | null {
+  if (!event || typeof event !== "object" || Array.isArray(event)) return null;
+  const data = (event as EventEnvelope).data;
+  return data && typeof data === "object" && !Array.isArray(data)
+    ? (data as Record<string, unknown>)
+    : null;
+}
+
+export type LastStepTurnTracker = {
+  beginPaneList: () => number;
+  reconcilePaneList: (result: unknown, startedAtRevision?: number) => void;
+  handleHerdrEvent: (event: unknown) => void;
+  stop: () => Promise<void>;
+  clear: () => void;
+};
+
+/** Tracks debounced workspace quiet/active boundaries from per-pane status. */
+export function createLastStepTurnTracker(args: {
+  captureWorkspaceBaseline: (workspaceId: string) => Promise<void>;
+  completeWorkspaceStep?: (workspaceId: string) => Promise<void>;
+  onCaptureError?: (error: Error, workspaceId: string) => void;
+  onCompleteError?: (error: Error, workspaceId: string) => void;
+  transitionDebounceMs?: number;
+}): LastStepTurnTracker {
+  const transitionDebounceMs = args.transitionDebounceMs ?? 0;
+  const panes = new Map<string, PaneActivity>();
+  const paneEventRevisions = new Map<string, number>();
+  const closedWorkspaceRevisions = new Map<string, number>();
+  const stableActivity = new Map<string, boolean>();
+  const appliedActivity = new Map<string, boolean>();
+  const pendingTransitions = new Map<string, PendingTransition>();
+  const workers = new Map<string, Promise<void>>();
+  const workspaceGenerations = new Map<string, number>();
+  let activityRevision = 0;
+  let paneListSeeded = false;
+  let stopping = false;
+
+  function workspaceIsActive(workspaceId: string) {
+    for (const pane of panes.values()) {
+      if (pane.workspaceId === workspaceId && pane.status === "working") {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function reportTransitionError(
+    error: unknown,
+    workspaceId: string,
+    active: boolean,
+  ) {
+    const callback = active ? args.onCaptureError : args.onCompleteError;
+    if (!callback) return;
+    try {
+      callback(
+        error instanceof Error ? error : new Error(String(error)),
+        workspaceId,
+      );
+    } catch {
+      // Logging/observer callbacks are an event-delivery boundary and must not
+      // terminate the transition worker that provides snapshot backpressure.
+    }
+  }
+
+  function startWorker(workspaceId: string) {
+    if (stopping || workers.has(workspaceId)) return;
+    const generation = workspaceGenerations.get(workspaceId) ?? 0;
+    const task = (async () => {
+      while (!stopping) {
+        const desired = stableActivity.get(workspaceId) ?? false;
+        const applied = appliedActivity.get(workspaceId) ?? false;
+        if (desired === applied) return;
+        try {
+          if (desired) {
+            await args.captureWorkspaceBaseline(workspaceId);
+          } else {
+            await args.completeWorkspaceStep?.(workspaceId);
+          }
+        } catch (error) {
+          // Git/IO failures are translated exactly once at this event boundary;
+          // the failed edge is considered consumed so status flapping cannot
+          // create an unbounded retry queue.
+          reportTransitionError(error, workspaceId, desired);
+        }
+        if (
+          stopping ||
+          (workspaceGenerations.get(workspaceId) ?? 0) !== generation
+        ) {
+          return;
+        }
+        appliedActivity.set(workspaceId, desired);
+      }
+    })();
+    workers.set(workspaceId, task);
+    const finish = () => {
+      if (workers.get(workspaceId) === task) workers.delete(workspaceId);
+      if (
+        !stopping &&
+        (stableActivity.get(workspaceId) ?? false) !==
+          (appliedActivity.get(workspaceId) ?? false)
+      ) {
+        startWorker(workspaceId);
+      }
+    };
+    void task.then(finish, finish);
+  }
+
+  function commitTransition(workspaceId: string, active: boolean) {
+    if (stopping || workspaceIsActive(workspaceId) !== active) return;
+    if ((stableActivity.get(workspaceId) ?? false) === active) return;
+    stableActivity.set(workspaceId, active);
+    startWorker(workspaceId);
+  }
+
+  function observeWorkspace(workspaceId: string) {
+    if (stopping) return;
+    const active = workspaceIsActive(workspaceId);
+    const pending = pendingTransitions.get(workspaceId);
+    if (pending) {
+      clearTimeout(pending.timer);
+      pendingTransitions.delete(workspaceId);
+    }
+    if ((stableActivity.get(workspaceId) ?? false) === active) return;
+    if (transitionDebounceMs <= 0) {
+      commitTransition(workspaceId, active);
+      return;
+    }
+    const timer = setTimeout(() => {
+      const current = pendingTransitions.get(workspaceId);
+      if (!current || current.timer !== timer) return;
+      pendingTransitions.delete(workspaceId);
+      commitTransition(workspaceId, active);
+    }, transitionDebounceMs);
+    pendingTransitions.set(workspaceId, { active, timer });
+  }
+
+  function cancelWorkspace(workspaceId: string) {
+    workspaceGenerations.set(
+      workspaceId,
+      (workspaceGenerations.get(workspaceId) ?? 0) + 1,
+    );
+    const pending = pendingTransitions.get(workspaceId);
+    if (pending) clearTimeout(pending.timer);
+    pendingTransitions.delete(workspaceId);
+    stableActivity.delete(workspaceId);
+    appliedActivity.delete(workspaceId);
+  }
+
+  function resetState() {
+    for (const pending of pendingTransitions.values()) {
+      clearTimeout(pending.timer);
+    }
+    pendingTransitions.clear();
+    panes.clear();
+    paneEventRevisions.clear();
+    closedWorkspaceRevisions.clear();
+    stableActivity.clear();
+    appliedActivity.clear();
+    workers.clear();
+    workspaceGenerations.clear();
+    activityRevision = 0;
+    paneListSeeded = false;
+  }
+
+  return {
+    beginPaneList: () => activityRevision,
+    reconcilePaneList(result, startedAtRevision = activityRevision) {
+      if (stopping) return;
+      const listed =
+        result && typeof result === "object" && !Array.isArray(result)
+          ? (result as { panes?: unknown }).panes
+          : undefined;
+      if (!Array.isArray(listed)) return;
+      const next = new Map<string, PaneActivity>();
+      for (const pane of listed) {
+        if (!pane || typeof pane !== "object" || Array.isArray(pane)) continue;
+        const record = pane as {
+          pane_id?: unknown;
+          workspace_id?: unknown;
+          agent?: unknown;
+          agent_status?: unknown;
+        };
+        if (
+          typeof record.pane_id === "string" &&
+          typeof record.workspace_id === "string" &&
+          typeof record.agent === "string" &&
+          record.agent.length > 0 &&
+          typeof record.agent_status === "string"
+        ) {
+          next.set(record.pane_id, {
+            workspaceId: record.workspace_id,
+            status: record.agent_status,
+          });
+        }
+      }
+      const affectedWorkspaces = new Set<string>();
+      for (const pane of panes.values())
+        affectedWorkspaces.add(pane.workspaceId);
+      for (const [paneId, listedPane] of next) {
+        if (
+          (closedWorkspaceRevisions.get(listedPane.workspaceId) ?? 0) >
+          startedAtRevision
+        ) {
+          next.delete(paneId);
+          continue;
+        }
+        if ((paneEventRevisions.get(paneId) ?? 0) > startedAtRevision) {
+          const eventPane = panes.get(paneId);
+          if (eventPane) next.set(paneId, eventPane);
+          else next.delete(paneId);
+        }
+      }
+      for (const [paneId, eventPane] of panes) {
+        if (
+          !next.has(paneId) &&
+          (paneEventRevisions.get(paneId) ?? 0) > startedAtRevision
+        ) {
+          next.set(paneId, eventPane);
+        }
+      }
+      panes.clear();
+      for (const [paneId, pane] of next) {
+        panes.set(paneId, pane);
+        affectedWorkspaces.add(pane.workspaceId);
+      }
+      if (!paneListSeeded) {
+        for (const workspaceId of affectedWorkspaces) {
+          const active = workspaceIsActive(workspaceId);
+          stableActivity.set(workspaceId, active);
+          appliedActivity.set(workspaceId, active);
+        }
+      } else {
+        for (const workspaceId of affectedWorkspaces) {
+          observeWorkspace(workspaceId);
+        }
+      }
+      paneListSeeded = true;
+    },
+    handleHerdrEvent(event) {
+      if (stopping) return;
+      const name = eventName(event);
+      const data = eventData(event);
+      if (!name || !data) return;
+
+      if (name === "pane.agent_status_changed") {
+        const paneId = data.pane_id;
+        const workspaceId = data.workspace_id;
+        const status = data.agent_status;
+        if (
+          typeof paneId !== "string" ||
+          !paneId ||
+          typeof workspaceId !== "string" ||
+          !workspaceId ||
+          typeof status !== "string"
+        ) {
+          return;
+        }
+        const previous = panes.get(paneId);
+        activityRevision += 1;
+        paneEventRevisions.set(paneId, activityRevision);
+        closedWorkspaceRevisions.delete(workspaceId);
+        panes.set(paneId, { workspaceId, status });
+        if (previous && previous.workspaceId !== workspaceId) {
+          observeWorkspace(previous.workspaceId);
+        }
+        observeWorkspace(workspaceId);
+        return;
+      }
+
+      if (name === "pane.moved" || name === "pane_moved") {
+        const paneId = data.pane_id;
+        const workspaceId = data.workspace_id ?? data.new_workspace_id;
+        if (
+          typeof paneId !== "string" ||
+          !paneId ||
+          typeof workspaceId !== "string" ||
+          !workspaceId
+        ) {
+          return;
+        }
+        const previous = panes.get(paneId);
+        if (!previous || previous.workspaceId === workspaceId) return;
+        const status =
+          typeof data.agent_status === "string"
+            ? data.agent_status
+            : previous.status;
+        activityRevision += 1;
+        paneEventRevisions.set(paneId, activityRevision);
+        closedWorkspaceRevisions.delete(workspaceId);
+        panes.set(paneId, { workspaceId, status });
+        observeWorkspace(previous.workspaceId);
+        observeWorkspace(workspaceId);
+        return;
+      }
+
+      if (name === "pane.closed" || name === "pane_closed") {
+        const paneId = data.pane_id;
+        if (typeof paneId === "string") {
+          const pane = panes.get(paneId);
+          activityRevision += 1;
+          paneEventRevisions.set(paneId, activityRevision);
+          panes.delete(paneId);
+          if (pane) observeWorkspace(pane.workspaceId);
+        }
+        return;
+      }
+
+      if (name === "workspace.closed" || name === "workspace_closed") {
+        const workspaceId = data.workspace_id;
+        if (typeof workspaceId !== "string") return;
+        activityRevision += 1;
+        closedWorkspaceRevisions.set(workspaceId, activityRevision);
+        for (const [paneId, pane] of panes) {
+          if (pane.workspaceId === workspaceId) {
+            paneEventRevisions.set(paneId, activityRevision);
+            panes.delete(paneId);
+          }
+        }
+        cancelWorkspace(workspaceId);
+      }
+    },
+    async stop() {
+      if (stopping) {
+        await Promise.allSettled(workers.values());
+        return;
+      }
+      stopping = true;
+      for (const pending of pendingTransitions.values()) {
+        clearTimeout(pending.timer);
+      }
+      pendingTransitions.clear();
+      // Snapshot errors are already reported inside each worker; allSettled is
+      // used only at this shutdown boundary to drain every in-flight process.
+      await Promise.allSettled(workers.values());
+      resetState();
+    },
+    clear() {
+      stopping = true;
+      resetState();
+    },
+  };
+}

--- a/web/src/components/DiffViewerPanel.tsx
+++ b/web/src/components/DiffViewerPanel.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
   type ReactNode,
 } from "react";
 import {
@@ -27,7 +28,13 @@ import {
 import { connectionStorageKey } from "../connectionStorage";
 import { gitDiffCode, gitDiffCodeLabel } from "../gitDiffStatus";
 import {
+  lastStepCompletionKey,
+  readLastStepCompletion,
+  subscribeLastStepCompletion,
+} from "../lastStepCompletionStore";
+import {
   refreshGitDiffSummary,
+  retireGitDiffSummary,
   retireGitDiffSummaryResource,
   useGitDiffSummaryState,
 } from "../gitDiffSummaryStore";
@@ -71,7 +78,7 @@ type DiffCache = {
   error: string | null;
 };
 
-type DiffScope = "working" | "branch-main";
+type DiffScope = "working" | "branch-main" | "last-step";
 
 const diffCache = new Map<string, DiffCache>();
 const diffCacheRevisions = new Map<string, number>();
@@ -105,7 +112,9 @@ function loadDiffScope(
     (resourceKey
       ? localStorage.getItem(diffScopeStorageKey(connectionId))
       : null);
-  return value === "branch-main" ? "branch-main" : "working";
+  if (value === "branch-main") return "branch-main";
+  if (value === "last-step") return "last-step";
+  return "working";
 }
 
 function diffEntryKey(entry: GitDiffEntry) {
@@ -306,6 +315,7 @@ function diffFileRequestKey(
   scope: DiffScope,
   entry: GitDiffEntry,
   revision: number,
+  snapshotId?: string,
 ) {
   return connectionClientScopeKey(
     client,
@@ -314,6 +324,7 @@ function diffFileRequestKey(
     scope,
     diffEntryKey(entry),
     revision,
+    snapshotId ?? "live",
   );
 }
 
@@ -342,9 +353,14 @@ function readStoredSelection(
     const value = JSON.parse(raw) as Partial<GitDiffEntry>;
     if (
       typeof value.path === "string" &&
-      ["staged", "unstaged", "untracked", "conflicted", "branch"].includes(
-        value.kind ?? "",
-      ) &&
+      [
+        "staged",
+        "unstaged",
+        "untracked",
+        "conflicted",
+        "branch",
+        "last-step",
+      ].includes(value.kind ?? "") &&
       typeof value.status === "string"
     ) {
       return value as GitDiffEntry;
@@ -373,7 +389,7 @@ export function clearDiffViewerResourceCache(
   resourceKey: string,
   storage: Pick<Storage, "removeItem"> = localStorage,
 ) {
-  for (const scope of ["working", "branch-main"] as const) {
+  for (const scope of ["working", "branch-main", "last-step"] as const) {
     retireDiffCache(diffCacheKey(client, undefined, scope, resourceKey));
     storage.removeItem(
       diffSelectionStorageKey(client.connectionId, resourceKey, scope),
@@ -473,9 +489,15 @@ function requestDiffFile(
   scope: DiffScope,
   entry: GitDiffEntry,
   revision: number,
+  snapshotId?: string,
 ) {
   if (!client.isCurrent()) {
     return Promise.reject(new Error("connection changed during diff request"));
+  }
+  if (scope === "last-step" && !snapshotId) {
+    return Promise.reject(
+      new Error("last-step diff requires a fresh summary snapshot"),
+    );
   }
   const requestKey = diffFileRequestKey(
     client,
@@ -483,6 +505,7 @@ function requestDiffFile(
     scope,
     entry,
     revision,
+    snapshotId,
   );
   const running = diffFileRequests.get(requestKey);
   if (running) return running;
@@ -490,7 +513,9 @@ function requestDiffFile(
     workspace_id: workspaceId,
     mode: scope,
     path: entry.path,
+    old_path: entry.old_path,
     kind: entry.kind,
+    snapshot_id: snapshotId,
   }) as Promise<GitDiffFile>;
   diffFileRequests.set(
     requestKey,
@@ -547,6 +572,7 @@ export function prefetchDiffFilesInBatches(
   const key = diffCacheKey(client, workspaceId, scope, resourceKey);
   const revision = diffCacheRevision(key);
   const cached = readDiffCache(client, workspaceId, scope, resourceKey);
+  const snapshotId = cached.summary?.snapshot_id;
   const queue = entries.filter((entry) => !cached.files[diffEntryKey(entry)]);
   if (!queue.length) return Promise.resolve();
 
@@ -562,6 +588,7 @@ export function prefetchDiffFilesInBatches(
           scope,
           entry,
           revision,
+          snapshotId,
         );
         if (!client.isCurrent() || diffCacheRevision(key) !== revision) return;
         cacheDiffFile(
@@ -776,6 +803,28 @@ export const DiffViewerPanel = forwardRef<
     : focusedWorkspace;
   const cacheWorkspaceId = workspace?.workspace_id;
   const cacheResourceKey = resourceKey ?? cacheWorkspaceId;
+  const completionKey = lastStepCompletionKey(
+    connectionClient.connectionId,
+    cacheWorkspaceId,
+  );
+  const subscribeToCompletion = useCallback(
+    (listener: () => void) =>
+      subscribeLastStepCompletion(completionKey, listener),
+    [completionKey],
+  );
+  const readCompletion = useCallback(
+    () => readLastStepCompletion(completionKey),
+    [completionKey],
+  );
+  const completionRevision = useSyncExternalStore(
+    subscribeToCompletion,
+    readCompletion,
+    readCompletion,
+  );
+  const completionRevisionRef = useRef({
+    key: completionKey,
+    revision: completionRevision,
+  });
   const [diffScope, setDiffScope] = useState<DiffScope>(() =>
     loadDiffScope(connectionClient.connectionId, cacheResourceKey),
   );
@@ -938,6 +987,7 @@ export const DiffViewerPanel = forwardRef<
   const loadSummary = async (
     previousSelected = cache.selected,
     afterCurrent = false,
+    clearCurrent = false,
   ) => {
     if (!workspace?.workspace_id || !connectionClient.isCurrent()) return;
     const workspaceId = workspace.workspace_id;
@@ -947,7 +997,17 @@ export const DiffViewerPanel = forwardRef<
       diffCacheKey(connectionClient, workspaceId, scope, cacheResourceKey),
     );
     setFileLoadingKey(null);
-    updateCache({ error: null });
+    updateCache(
+      clearCurrent
+        ? {
+            summary: null,
+            selected: null,
+            files: {},
+            fileErrors: {},
+            error: null,
+          }
+        : { error: null },
+    );
     try {
       await refreshGitDiffSummary(
         connectionClient,
@@ -962,6 +1022,49 @@ export const DiffViewerPanel = forwardRef<
       }
     }
   };
+
+  useEffect(() => {
+    const previous = completionRevisionRef.current;
+    completionRevisionRef.current = {
+      key: completionKey,
+      revision: completionRevision,
+    };
+    if (
+      !cacheWorkspaceId ||
+      previous.key !== completionKey ||
+      previous.revision === completionRevision
+    ) {
+      return;
+    }
+
+    if (diffScopeRef.current === "last-step") {
+      retireGitDiffSummary(
+        connectionClient,
+        cacheWorkspaceId,
+        "last-step",
+        cacheResourceKey,
+      );
+      void loadSummary(cache.selected, false, true);
+      return;
+    }
+    retireDiffCache(
+      diffCacheKey(
+        connectionClient,
+        cacheWorkspaceId,
+        "last-step",
+        cacheResourceKey,
+      ),
+    );
+    retireGitDiffSummary(
+      connectionClient,
+      cacheWorkspaceId,
+      "last-step",
+      cacheResourceKey,
+    );
+    // Completion notifications are not debounced with pane-list refreshes, so
+    // rapid quiet-to-active edges cannot leave the prior step cached forever.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cacheWorkspaceId, completionKey, completionRevision]);
 
   const loadFile = async (
     entry: GitDiffEntry,
@@ -1030,6 +1133,7 @@ export const DiffViewerPanel = forwardRef<
         scope,
         entry,
         revision,
+        cache.summary?.snapshot_id,
       );
       if (
         !isCurrentContext(workspaceId, scope) ||
@@ -1308,6 +1412,14 @@ export const DiffViewerPanel = forwardRef<
       <div className="diff-scope-toggle" aria-label="Diff scope">
         <button
           type="button"
+          className={diffScope === "last-step" ? "is-active" : ""}
+          onClick={() => setDiffScope("last-step")}
+          aria-pressed={diffScope === "last-step"}
+        >
+          Last step
+        </button>
+        <button
+          type="button"
           className={diffScope === "working" ? "is-active" : ""}
           onClick={() => setDiffScope("working")}
           aria-pressed={diffScope === "working"}
@@ -1352,7 +1464,12 @@ export const DiffViewerPanel = forwardRef<
         ) : (
           <div className="diff-empty">
             <FileDiff size={18} />
-            <span>No changes</span>
+            <span>
+              {diffScope === "last-step" &&
+              cache.summary?.baseline_available === false
+                ? "No completed agent step yet"
+                : "No changes"}
+            </span>
           </div>
         )}
       </div>

--- a/web/src/components/FileExplorerDialog.test.ts
+++ b/web/src/components/FileExplorerDialog.test.ts
@@ -64,6 +64,7 @@ describe("file explorer git status", () => {
         untracked: 0,
         conflicted: 0,
         branch: 0,
+        "last-step": 0,
       },
     };
 
@@ -92,6 +93,7 @@ describe("file explorer git status", () => {
         untracked: 1,
         conflicted: 0,
         branch: 0,
+        "last-step": 0,
       },
     };
 

--- a/web/src/gitDiffSummaryStore.test.ts
+++ b/web/src/gitDiffSummaryStore.test.ts
@@ -5,6 +5,7 @@ import {
   gitDiffSummaryKey,
   readGitDiffSummary,
   refreshGitDiffSummary,
+  retireGitDiffSummary,
   retireGitDiffSummaryResource,
   subscribeGitDiffSummary,
 } from "./gitDiffSummaryStore";
@@ -20,6 +21,7 @@ function summary(workspaceId: string): GitDiffSummary {
       untracked: 0,
       conflicted: 0,
       branch: 0,
+      "last-step": 0,
     },
   };
 }
@@ -164,6 +166,32 @@ describe("shared git diff summaries", () => {
     await initial;
     await expect(queued).rejects.toThrow("retired");
     expect(calls).toBe(1);
+  });
+
+  test("does not publish an in-flight last-step request after an activity edge", async () => {
+    const resolvers: Array<(value: GitDiffSummary) => void> = [];
+    const client: ConnectionClient = {
+      connectionId: "last-step-edge",
+      generation: 1,
+      serverRuntimeGeneration: 1,
+      isCurrent: () => true,
+      acceptsServerGeneration: () => true,
+      call: () =>
+        new Promise<GitDiffSummary>((resolve) => resolvers.push(resolve)),
+    };
+    const key = gitDiffSummaryKey(client, "workspace", "last-step");
+    const stale = refreshGitDiffSummary(client, "workspace", "last-step");
+    retireGitDiffSummary(client, "workspace", "last-step");
+    const current = refreshGitDiffSummary(client, "workspace", "last-step");
+
+    resolvers[0]?.(summary("stale"));
+    await stale;
+    expect(readGitDiffSummary(key).summary).toBeNull();
+
+    const fresh = summary("fresh");
+    resolvers[1]?.(fresh);
+    await current;
+    expect(readGitDiffSummary(key).summary).toBe(fresh);
   });
 
   test("does not publish a request retired by resource cleanup", async () => {

--- a/web/src/gitDiffSummaryStore.ts
+++ b/web/src/gitDiffSummaryStore.ts
@@ -3,7 +3,7 @@ import type { ConnectionClient } from "./api";
 import type { GitDiffSummary } from "./types";
 import { connectionClientScopeKey } from "./useConnectionClient";
 
-export type GitDiffSummaryMode = "working" | "branch-main";
+export type GitDiffSummaryMode = "working" | "branch-main" | "last-step";
 
 export type GitDiffSummaryState = {
   summary: GitDiffSummary | null;
@@ -84,6 +84,20 @@ function keyMatchesResource(
   } catch {
     return false;
   }
+}
+
+export function retireGitDiffSummary(
+  client: Pick<ConnectionClient, "connectionId" | "generation">,
+  workspaceId: string,
+  mode: GitDiffSummaryMode,
+  resourceKey = workspaceId,
+) {
+  const key = gitDiffSummaryKey(client, workspaceId, mode, resourceKey);
+  states.delete(key);
+  requests.delete(key);
+  trailingRequests.delete(key);
+  activeTokens.delete(key);
+  notify(key);
 }
 
 export function retireGitDiffSummaryResource(

--- a/web/src/lastStepCompletionStore.test.ts
+++ b/web/src/lastStepCompletionStore.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import {
+  lastStepCompletionKey,
+  publishLastStepCompletion,
+  readLastStepCompletion,
+  subscribeLastStepCompletion,
+} from "./lastStepCompletionStore";
+
+test("publishes non-collapsible workspace completion revisions", () => {
+  const key = lastStepCompletionKey("local", "workspace");
+  const otherKey = lastStepCompletionKey("remote", "workspace");
+  let notifications = 0;
+  const unsubscribe = subscribeLastStepCompletion(key, () => {
+    notifications += 1;
+  });
+
+  publishLastStepCompletion("local", "workspace");
+  publishLastStepCompletion("local", "workspace");
+
+  expect(readLastStepCompletion(key)).toBe(2);
+  expect(readLastStepCompletion(otherKey)).toBe(0);
+  expect(notifications).toBe(2);
+  unsubscribe();
+});

--- a/web/src/lastStepCompletionStore.test.ts
+++ b/web/src/lastStepCompletionStore.test.ts
@@ -21,4 +21,8 @@ test("publishes non-collapsible workspace completion revisions", () => {
   expect(readLastStepCompletion(otherKey)).toBe(0);
   expect(notifications).toBe(2);
   unsubscribe();
+  expect(readLastStepCompletion(key)).toBe(0);
+
+  publishLastStepCompletion("local", "workspace");
+  expect(readLastStepCompletion(key)).toBe(0);
 });

--- a/web/src/lastStepCompletionStore.ts
+++ b/web/src/lastStepCompletionStore.ts
@@ -1,0 +1,32 @@
+const revisions = new Map<string, number>();
+const listeners = new Map<string, Set<() => void>>();
+
+export function lastStepCompletionKey(
+  connectionId: string,
+  workspaceId: string | undefined,
+) {
+  return `${connectionId}\u0000${workspaceId ?? ""}`;
+}
+
+export function publishLastStepCompletion(
+  connectionId: string,
+  workspaceId: string,
+) {
+  const key = lastStepCompletionKey(connectionId, workspaceId);
+  revisions.set(key, (revisions.get(key) ?? 0) + 1);
+  for (const listener of listeners.get(key) ?? []) listener();
+}
+
+export function readLastStepCompletion(key: string) {
+  return revisions.get(key) ?? 0;
+}
+
+export function subscribeLastStepCompletion(key: string, listener: () => void) {
+  const current = listeners.get(key) ?? new Set<() => void>();
+  current.add(listener);
+  listeners.set(key, current);
+  return () => {
+    current.delete(listener);
+    if (current.size === 0) listeners.delete(key);
+  };
+}

--- a/web/src/lastStepCompletionStore.ts
+++ b/web/src/lastStepCompletionStore.ts
@@ -13,8 +13,10 @@ export function publishLastStepCompletion(
   workspaceId: string,
 ) {
   const key = lastStepCompletionKey(connectionId, workspaceId);
+  const current = listeners.get(key);
+  if (!current) return;
   revisions.set(key, (revisions.get(key) ?? 0) + 1);
-  for (const listener of listeners.get(key) ?? []) listener();
+  for (const listener of current) listener();
 }
 
 export function readLastStepCompletion(key: string) {
@@ -27,6 +29,9 @@ export function subscribeLastStepCompletion(key: string, listener: () => void) {
   listeners.set(key, current);
   return () => {
     current.delete(listener);
-    if (current.size === 0) listeners.delete(key);
+    if (current.size === 0) {
+      listeners.delete(key);
+      revisions.delete(key);
+    }
   };
 }

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -12,6 +12,7 @@ import {
 } from "./connectionStorage";
 import { disposeTerminalConnection } from "./terminalConnection";
 import { isReconnectRetryableError } from "./reconnectRetry";
+import { publishLastStepCompletion } from "./lastStepCompletionStore";
 import {
   clearTerminalRelayViewports,
   forgetTerminalRelayViewportsExcept,
@@ -1759,6 +1760,15 @@ export const store = {
           event.connection_generation,
         )
       ) {
+        if (
+          event.event === "workspace.last_step_completed" &&
+          typeof event.data.workspace_id === "string"
+        ) {
+          publishLastStepCompletion(
+            event.connection_id,
+            event.data.workspace_id,
+          );
+        }
         scheduleRefresh();
       }
     });

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4992,7 +4992,7 @@ textarea:focus {
 }
 .diff-scope-toggle {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) 28px;
+  grid-template-columns: repeat(3, minmax(0, 1fr)) 28px;
   gap: 4px;
   margin-bottom: 10px;
   padding: 3px;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -166,7 +166,8 @@ export type GitDiffKind =
   | "unstaged"
   | "untracked"
   | "conflicted"
-  | "branch";
+  | "branch"
+  | "last-step";
 
 export interface GitDiffEntry {
   path: string;
@@ -182,8 +183,10 @@ export interface GitDiffSummary {
   workspace_id: string;
   repo_name?: string;
   root: string;
-  mode?: "working" | "branch-main";
+  mode?: "working" | "branch-main" | "last-step";
   base?: string;
+  baseline_available?: boolean;
+  snapshot_id?: string;
   entries: GitDiffEntry[];
   counts: Record<GitDiffKind, number>;
 }


### PR DESCRIPTION
## Summary

- add a **Last step** Changes scope for the most recently completed workspace-wide agent activity period
- capture complete worktree snapshots safely through temporary Git indexes, including staged, unstaged, committed-during-step, renamed, and untracked files
- keep the previous completed diff visible while the next step runs, then refresh atomically when that step completes
- handle multi-agent activity, dotted Herdr lifecycle events, pane moves, status flapping, SSH/linked worktrees, snapshot consistency, and shutdown races

## Verification

- `bun test` — 745 passed, 1 skipped
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `git diff --check`

Closes #37
