### PR TITLE
Fix Last step tracking of moved panes and harden snapshots

### DIFF
--- a/server/src/connections/agent-status-subscription.ts
+++ b/server/src/connections/agent-status-subscription.ts
@@ -1,4 +1,5 @@
 import type { HerdrClient } from "../bridge/herdr-client";
+import { herdrEventName } from "../utils/herdr-events";
 
 /**
  * Herdr emits `pane.agent_status_changed` only through parameterized per-pane
@@ -37,23 +38,6 @@ const MEMBERSHIP_EVENT_TYPES = new Set([
   "tab_closed",
   "workspace_closed",
 ]);
-
-function herdrEventName(event: unknown): string | null {
-  if (!event || typeof event !== "object" || Array.isArray(event)) return null;
-  const envelope = event as {
-    event?: unknown;
-    data?: unknown;
-  };
-  if (typeof envelope.event === "string" && envelope.event) {
-    return envelope.event;
-  }
-  const data = envelope.data;
-  if (data && typeof data === "object" && !Array.isArray(data)) {
-    const type = (data as { type?: unknown }).type;
-    if (typeof type === "string" && type) return type;
-  }
-  return null;
-}
 
 export function agentPaneIdsFromPaneList(result: unknown): string[] {
   const panes = (result as { panes?: unknown } | null)?.panes;

--- a/server/src/utils/herdr-events.ts
+++ b/server/src/utils/herdr-events.ts
@@ -1,0 +1,20 @@
+/**
+ * Extracts the Herdr event name from a subscription envelope. Herdr emits
+ * `{ event, data }` where `data.type` mirrors the event name, so accept both.
+ */
+export function herdrEventName(event: unknown): string | null {
+  if (!event || typeof event !== "object" || Array.isArray(event)) return null;
+  const envelope = event as {
+    event?: unknown;
+    data?: unknown;
+  };
+  if (typeof envelope.event === "string" && envelope.event) {
+    return envelope.event;
+  }
+  const data = envelope.data;
+  if (data && typeof data === "object" && !Array.isArray(data)) {
+    const type = (data as { type?: unknown }).type;
+    if (typeof type === "string" && type) return type;
+  }
+  return null;
+}

--- a/server/src/workspace/git-diff.test.ts
+++ b/server/src/workspace/git-diff.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtemp, rename, rm, writeFile } from "node:fs/promises";
+import { access, mkdtemp, rename, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { RunProcessWithCodeTimeout } from "./file-types";
@@ -227,6 +227,128 @@ describe("last-step worktree snapshots", () => {
     expect(command).toContain("trap cleanup EXIT HUP INT TERM");
   });
 
+  test("tracks worktree changes across snapshots with a reusable index", async () => {
+    const root = await initRepository();
+    const indexDir = await mkdtemp(join(tmpdir(), "herdr-git-index-test-"));
+    const indexFile = join(indexDir, "index");
+    try {
+      await writeFile(join(root, "tracked.txt"), "one\n");
+      const first = await snapshotWorktreeTree({
+        root,
+        indexFile,
+        shQuote,
+        runProcessWithCodeTimeout,
+      });
+      await access(indexFile);
+      expect((await stat(indexFile)).mode & 0o777).toBe(0o600);
+
+      await writeFile(join(root, "tracked.txt"), "two\n");
+      const second = await snapshotWorktreeTree({
+        root,
+        indexFile,
+        shQuote,
+        runProcessWithCodeTimeout,
+      });
+      expect(second).not.toBe(first);
+      expect((await stat(indexFile)).mode & 0o777).toBe(0o600);
+
+      await writeFile(join(root, "untracked.txt"), "new\n");
+      const third = await snapshotWorktreeTree({
+        root,
+        indexFile,
+        shQuote,
+        runProcessWithCodeTimeout,
+      });
+      const thirdFiles = await git(root, "ls-tree", "-r", "--name-only", third);
+      expect(thirdFiles.trim().split("\n").sort()).toEqual([
+        "tracked.txt",
+        "untracked.txt",
+      ]);
+
+      await rm(join(root, "tracked.txt"));
+      const fourth = await snapshotWorktreeTree({
+        root,
+        indexFile,
+        shQuote,
+        runProcessWithCodeTimeout,
+      });
+      const fourthFiles = await git(
+        root,
+        "ls-tree",
+        "-r",
+        "--name-only",
+        fourth,
+      );
+      expect(fourthFiles.trim()).toBe("untracked.txt");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+      await rm(indexDir, { recursive: true, force: true });
+    }
+  });
+
+  test("removes reusable snapshot indexes during disposal", async () => {
+    const root = await initRepository();
+    const commands: string[] = [];
+    const runner: RunProcessWithCodeTimeout = async (argv, timeoutMs) => {
+      commands.push(argv.join(" "));
+      return runProcessWithCodeTimeout(argv, timeoutMs);
+    };
+    try {
+      await writeFile(join(root, "tracked.txt"), "baseline\n");
+      const baselines = createLastStepBaselineStore({
+        shQuote,
+        runProcessWithCodeTimeout: runner,
+      });
+      await baselines.captureWorkspace("workspace", async () => root);
+      await baselines.completeWorkspace("workspace");
+      await baselines.dispose();
+      const removals = commands.filter((command) =>
+        command.includes("rm -f '/tmp/herdr-git-index-"),
+      );
+      expect(removals.length).toBeGreaterThan(0);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("rebuilds the reusable snapshot index after a failed snapshot", async () => {
+    const root = await initRepository();
+    const commands: string[] = [];
+    let failSnapshots = true;
+    const runner: RunProcessWithCodeTimeout = async (argv, timeoutMs) => {
+      const joined = argv.join(" ");
+      commands.push(joined);
+      if (failSnapshots && joined.includes("herdr-git-index-")) {
+        return { code: 1, stdout: "", stderr: "snapshot failed" };
+      }
+      return runProcessWithCodeTimeout(argv, timeoutMs);
+    };
+    try {
+      await writeFile(join(root, "tracked.txt"), "baseline\n");
+      const baselines = createLastStepBaselineStore({
+        shQuote,
+        runProcessWithCodeTimeout: runner,
+      });
+      await expect(
+        baselines.captureWorkspace("workspace", async () => root),
+      ).rejects.toThrow("snapshot failed");
+      failSnapshots = false;
+      const baseline = await baselines.captureWorkspace(
+        "workspace",
+        async () => root,
+      );
+      expect(baseline).toMatch(/^[0-9a-f]{40,64}$/);
+      expect(
+        commands.some((command) =>
+          command.includes("rm -f '/tmp/herdr-git-index-"),
+        ),
+      ).toBe(true);
+      await baselines.dispose();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test("includes commits and untracked files made after the baseline", async () => {
     const root = await initRepository();
     try {
@@ -438,9 +560,15 @@ describe("last-step worktree snapshots", () => {
       const firstCompletion = baselines.completeWorkspace("workspace");
       await firstCompletionStarted;
 
-      await baselines.captureWorkspace("workspace", async () => root);
-      await writeFile(join(root, "tracked.txt"), "second step\n");
+      // Snapshots for one root are serialized, so this capture is queued
+      // behind the in-flight completion snapshot until its gate opens.
+      const secondCapture = baselines.captureWorkspace(
+        "workspace",
+        async () => root,
+      );
       releaseFirstCompletion();
+      await secondCapture;
+      await writeFile(join(root, "tracked.txt"), "second step\n");
       expect(await firstCompletion).toBe(true);
 
       const whileSecondIsActive = await readDiffSummary({
@@ -697,7 +825,11 @@ describe("last-step worktree snapshots", () => {
     try {
       await writeFile(join(root, "tracked.txt"), "baseline\n");
       const baselines = baselineStore();
-      const baseline = await baselines.capture(root);
+      const baseline = await snapshotWorktreeTree({
+        root,
+        shQuote,
+        runProcessWithCodeTimeout,
+      });
       const validSnapshot = baselines.rememberSnapshot(
         "workspace",
         root,
@@ -729,7 +861,6 @@ describe("last-step worktree snapshots", () => {
         expiredError = error;
       }
       expect((expiredError as Error).message).toContain("snapshot expired");
-      expect(await baselines.resolve("workspace", root)).toBe(baseline);
       expect(
         baselines.resolveSnapshot("workspace", root, validSnapshot),
       ).toEqual({ baseline, current: baseline });
@@ -761,7 +892,6 @@ describe("last-step worktree snapshots", () => {
         baselineError = error;
       }
       expect((baselineError as Error).message).toContain("snapshot expired");
-      expect(await baselines.resolve("workspace", root)).toBe(baseline);
       expect(
         baselines.resolveSnapshot("workspace", root, validSnapshot),
       ).toEqual({ baseline, current: baseline });
@@ -807,8 +937,9 @@ describe("last-step worktree snapshots", () => {
       });
       const older = baselines.captureWorkspace("older", async () => root);
       await firstStarted;
+      // Snapshots for one root are serialized, so this capture is queued
+      // behind the older one and must survive its failure.
       const newer = baselines.captureWorkspace("newer", async () => root);
-      await newer;
       releaseFirst();
       let olderError: unknown;
       try {
@@ -817,7 +948,13 @@ describe("last-step worktree snapshots", () => {
         olderError = error;
       }
       expect((olderError as Error).message).toContain("older capture failed");
-      expect(typeof (await baselines.resolve("newer", root))).toBe("string");
+      const newerBaseline = await newer;
+      expect(newerBaseline).toMatch(/^[0-9a-f]{40,64}$/);
+      expect(await baselines.completeWorkspace("newer")).toBe(true);
+      expect(await baselines.resolveCompleted("newer", root)).toEqual({
+        baseline: newerBaseline,
+        current: newerBaseline,
+      });
     } finally {
       releaseFirst();
       await rm(root, { recursive: true, force: true });
@@ -1100,7 +1237,9 @@ describe("last-step worktree snapshots", () => {
       expect((captureError as Error & { code?: string }).code).toBe(
         "LAST_STEP_STORE_DISPOSED",
       );
-      expect(await baselines.resolve("workspace", root)).toBeUndefined();
+      expect(
+        await baselines.resolveCompleted("workspace", root),
+      ).toBeUndefined();
       await expect(
         baselines.captureWorkspace("workspace", async () => root),
       ).rejects.toMatchObject({ code: "LAST_STEP_STORE_DISPOSED" });
@@ -1115,10 +1254,8 @@ describe("last-step worktree snapshots", () => {
     let deleted = false;
     const missingTree = "0".repeat(40);
     const baselines: LastStepBaselineStore = {
-      capture: async () => missingTree,
       captureWorkspace: async () => missingTree,
       completeWorkspace: async () => false,
-      resolve: async () => missingTree,
       resolveCompleted: async () => ({
         baseline: missingTree,
         current: missingTree,
@@ -1130,7 +1267,6 @@ describe("last-step worktree snapshots", () => {
         deleted = true;
       },
       dispose: async () => undefined,
-      clear: () => undefined,
     };
     try {
       const summary = await readDiffSummary({

--- a/server/src/workspace/git-diff.ts
+++ b/server/src/workspace/git-diff.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { sshCommandArgv } from "../bridge/ssh-command";
 import {
   GIT_DIFF_MAX_BYTES,
@@ -25,13 +25,11 @@ function lastStepStoreDisposedError() {
 }
 
 export type LastStepBaselineStore = {
-  capture: (root: string) => Promise<string>;
   captureWorkspace: (
     workspaceId: string,
     resolveRoot: () => Promise<string>,
   ) => Promise<string>;
   completeWorkspace: (workspaceId: string) => Promise<boolean>;
-  resolve: (workspaceId: string, root: string) => Promise<string | undefined>;
   resolveCompleted: (
     workspaceId: string,
     root: string,
@@ -50,13 +48,7 @@ export type LastStepBaselineStore = {
   deleteSnapshot: (snapshotId: string) => void;
   delete: (root: string) => void;
   dispose: () => Promise<void>;
-  clear: () => void;
 };
-
-type WorkspaceBaselineState =
-  | { status: "pending"; promise: Promise<string>; version: number }
-  | { status: "ready"; root: string; baseline: string; version: number }
-  | { status: "unavailable"; version: number };
 
 type WorkspaceActivityCycle = {
   version: number;
@@ -299,11 +291,36 @@ function runGitShellCommand({
 
 export async function snapshotWorktreeTree({
   root,
+  indexFile,
   host,
   shQuote,
   runProcessWithCodeTimeout,
-}: { root: string } & GitCommandContext): Promise<string> {
-  const command = `
+}: { root: string; indexFile?: string } & GitCommandContext): Promise<string> {
+  // With a throwaway index, `git add -A` has no stat cache and content-hashes
+  // every file in the worktree. Passing a reusable indexFile keeps the cache
+  // warm so repeat snapshots only re-hash files whose stat changed. Callers
+  // passing indexFile must serialize calls sharing it; the script removes a
+  // stale index lock left behind by a killed git process.
+  const command = indexFile
+    ? `
+set -eu
+export GIT_INDEX_FILE=${shQuote(indexFile)}
+rm -f "$GIT_INDEX_FILE.lock"
+if [ ! -f "$GIT_INDEX_FILE" ]; then
+  if git -C ${shQuote(root)} rev-parse --verify --quiet 'HEAD^{commit}' >/dev/null; then
+    git -C ${shQuote(root)} read-tree HEAD
+  else
+    git -C ${shQuote(root)} read-tree --empty
+  fi
+fi
+git -C ${shQuote(root)} add -A
+git -C ${shQuote(root)} write-tree
+# Every git index write, including the cache-tree update from write-tree,
+# re-creates the file with umask permissions; keep the long-lived reusable
+# index owner-only on multi-user hosts.
+chmod 600 "$GIT_INDEX_FILE"
+`
+    : `
 set -eu
 index_file=$(mktemp "\${TMPDIR:-/tmp}/herdr-git-index.XXXXXX")
 cleanup() { rm -f "$index_file" "$index_file.lock"; }
@@ -336,9 +353,7 @@ git -C ${shQuote(root)} write-tree
 export function createLastStepBaselineStore(
   context: GitCommandContext,
 ): LastStepBaselineStore {
-  const baselines = new Map<string, string>();
-  const captureVersions = new Map<string, number>();
-  const workspaceStates = new Map<string, WorkspaceBaselineState>();
+  const workspaceVersions = new Map<string, number>();
   const completedRanges = new Map<
     string,
     { root: string; baseline: string; current: string }
@@ -350,6 +365,9 @@ export function createLastStepBaselineStore(
     { workspaceId: string; root: string; baseline: string; current: string }
   >();
   const inFlight = new Set<Promise<unknown>>();
+  const snapshotQueues = new Map<string, Promise<unknown>>();
+  // Isolates the reusable snapshot indexes of other stores on the same host.
+  const storeId = randomUUID();
   let disposed = false;
   let disposeTask: Promise<void> | null = null;
 
@@ -365,9 +383,7 @@ export function createLastStepBaselineStore(
   }
 
   function clearState() {
-    baselines.clear();
-    captureVersions.clear();
-    workspaceStates.clear();
+    workspaceVersions.clear();
     completedRanges.clear();
     completedVersions.clear();
     activityCycles.clear();
@@ -384,75 +400,81 @@ export function createLastStepBaselineStore(
     }
   }
 
-  async function captureRoot(root: string, invalidateSnapshots = true) {
-    assertActive();
-    const version = (captureVersions.get(root) ?? 0) + 1;
-    captureVersions.set(root, version);
-    baselines.delete(root);
-    if (invalidateSnapshots) {
-      deleteSnapshots((_workspaceId, snapshotRoot) => snapshotRoot === root);
+  // A fixed literal path is required so cleanups can run without an extra
+  // round trip; /tmp is the same fallback the one-shot snapshot script uses.
+  function snapshotIndexFile(root: string) {
+    const key = createHash("sha256").update(root).digest("hex").slice(0, 16);
+    return `/tmp/herdr-git-index-${storeId}-${key}`;
+  }
+
+  // Serializes snapshots per root so concurrent captures never contend on
+  // the shared reusable index lock.
+  function enqueueForRoot<T>(root: string, task: () => Promise<T>): Promise<T> {
+    const prior = snapshotQueues.get(root) ?? Promise.resolve();
+    const turn = prior.then(task);
+    // The chain carries only the settlement so a failed turn cannot reject
+    // later turns; callers still receive the original rejection.
+    snapshotQueues.set(
+      root,
+      turn.then(
+        () => undefined,
+        () => undefined,
+      ),
+    );
+    return turn;
+  }
+
+  function removeSnapshotIndex(root: string) {
+    const indexFile = snapshotIndexFile(root);
+    const command = `rm -f ${context.shQuote(indexFile)} ${context.shQuote(`${indexFile}.lock`)}`;
+    return context.runProcessWithCodeTimeout(
+      context.host
+        ? sshCommandArgv(context.host, command)
+        : ["sh", "-lc", command],
+      GIT_DIFF_TIMEOUT_MS,
+    );
+  }
+
+  async function snapshotRoot(root: string): Promise<string> {
+    try {
+      return await enqueueForRoot(root, () =>
+        snapshotWorktreeTree({
+          root,
+          indexFile: snapshotIndexFile(root),
+          ...context,
+        }),
+      );
+    } catch (error) {
+      // A failed snapshot can leave the reusable index stale (e.g. referring
+      // to pruned objects), so queue its removal behind any serialized
+      // snapshot for this root and let the next capture rebuild it cold.
+      // Removal is best-effort: a failure only leaves a small file in /tmp.
+      void enqueueForRoot(root, () => removeSnapshotIndex(root)).catch(
+        () => undefined,
+      );
+      throw error;
     }
-    const tree = await snapshotWorktreeTree({ root, ...context });
-    assertActive();
-    if (captureVersions.get(root) === version) baselines.set(root, tree);
-    return { tree, version };
   }
 
   return {
-    async capture(root) {
-      const captured = await track(captureRoot(root));
-      return captured.tree;
-    },
     captureWorkspace(workspaceId, resolveRoot) {
       if (disposed) return Promise.reject(lastStepStoreDisposedError());
       const priorCycle = activityCycles.get(workspaceId);
-      const version = (workspaceStates.get(workspaceId)?.version ?? 0) + 1;
-      let resolvedRoot: string | undefined;
-      let rootCaptureVersion: number | undefined;
+      const version = (workspaceVersions.get(workspaceId) ?? 0) + 1;
+      workspaceVersions.set(workspaceId, version);
       const capture = track(
         (async () => {
-          try {
-            resolvedRoot = await resolveRoot();
-            const captured = await captureRoot(resolvedRoot, false);
-            rootCaptureVersion = captured.version;
-            if (activityCycles.get(workspaceId)?.version === version) {
-              workspaceStates.set(workspaceId, {
-                status: "ready",
-                root: resolvedRoot,
-                baseline: captured.tree,
-                version,
-              });
-            }
-            return { root: resolvedRoot, baseline: captured.tree };
-          } catch (error) {
-            if (activityCycles.get(workspaceId)?.version === version) {
-              if (
-                resolvedRoot &&
-                rootCaptureVersion !== undefined &&
-                captureVersions.get(resolvedRoot) === rootCaptureVersion
-              ) {
-                baselines.delete(resolvedRoot);
-                captureVersions.delete(resolvedRoot);
-              }
-              workspaceStates.set(workspaceId, {
-                status: "unavailable",
-                version,
-              });
-            }
-            throw error;
-          }
+          const root = await resolveRoot();
+          assertActive();
+          const baseline = await snapshotRoot(root);
+          assertActive();
+          return { root, baseline };
         })(),
       );
       const cycle = { version, capture };
       activityCycles.set(workspaceId, cycle);
       if (priorCycle?.completion) priorCycle.nextCapture = capture;
-      const promise = capture.then((result) => result.baseline);
-      workspaceStates.set(workspaceId, {
-        status: "pending",
-        promise,
-        version,
-      });
-      return promise;
+      return capture.then((result) => result.baseline);
     },
     completeWorkspace(workspaceId) {
       if (disposed) return Promise.reject(lastStepStoreDisposedError());
@@ -466,10 +488,7 @@ export function createLastStepBaselineStore(
         } catch {
           return false;
         }
-        let current = await snapshotWorktreeTree({
-          root: captured.root,
-          ...context,
-        });
+        let current = await snapshotRoot(captured.root);
         if (cycle.nextCapture) {
           try {
             const next = await cycle.nextCapture;
@@ -497,23 +516,6 @@ export function createLastStepBaselineStore(
       })();
       cycle.completion = track(task);
       return cycle.completion;
-    },
-    async resolve(workspaceId, root) {
-      if (disposed) return undefined;
-      let state = workspaceStates.get(workspaceId);
-      if (state?.status === "pending") {
-        try {
-          await state.promise;
-        } catch {
-          return undefined;
-        }
-        state = workspaceStates.get(workspaceId);
-      }
-      if (state?.status === "unavailable") return undefined;
-      if (state?.status === "ready") {
-        return state.root === root ? state.baseline : undefined;
-      }
-      return baselines.get(root);
     },
     async resolveCompleted(workspaceId, root) {
       if (disposed) return undefined;
@@ -553,17 +555,7 @@ export function createLastStepBaselineStore(
     },
     deleteSnapshot: (snapshotId) => snapshots.delete(snapshotId),
     delete(root) {
-      baselines.delete(root);
       deleteSnapshots((_workspaceId, snapshotRoot) => snapshotRoot === root);
-      captureVersions.delete(root);
-      for (const [workspaceId, state] of workspaceStates) {
-        if (state.status === "ready" && state.root === root) {
-          workspaceStates.set(workspaceId, {
-            status: "unavailable",
-            version: state.version,
-          });
-        }
-      }
       for (const [workspaceId, range] of completedRanges) {
         if (range.root === root) {
           completedRanges.delete(workspaceId);
@@ -579,11 +571,16 @@ export function createLastStepBaselineStore(
         // shutdown boundary only drains every task before final state clearing.
         await Promise.allSettled(Array.from(inFlight));
         clearState();
+        // Drop every reusable snapshot index this store created; removals
+        // are best-effort for the same reason as in snapshotRoot.
+        await Promise.allSettled(
+          Array.from(snapshotQueues.keys(), (root) =>
+            removeSnapshotIndex(root),
+          ),
+        );
+        snapshotQueues.clear();
       })();
       return disposeTask;
-    },
-    clear() {
-      clearState();
     },
   };
 }

--- a/server/src/workspace/last-step-turns.test.ts
+++ b/server/src/workspace/last-step-turns.test.ts
@@ -244,13 +244,60 @@ describe("last-step turn tracking", () => {
     });
 
     tracker.handleHerdrEvent({
-      event: "pane.moved",
-      data: { pane_id: "p1", workspace_id: "new" },
+      event: "pane_moved",
+      data: {
+        type: "pane_moved",
+        previous_pane_id: "p1",
+        previous_workspace_id: "old",
+        previous_tab_id: "old:tab1",
+        pane: {
+          pane_id: "p2",
+          workspace_id: "new",
+          agent_status: "working",
+        },
+      },
     });
     await flushTransitions();
 
     expect(completions).toEqual(["old"]);
     expect(captures).toEqual(["new"]);
+
+    tracker.handleHerdrEvent(status("p2", "new", "done"));
+    await flushTransitions();
+
+    expect(completions).toEqual(["old", "new"]);
+    await tracker.stop();
+  });
+
+  test("follows pane id changes for moves within one workspace", async () => {
+    const completions: string[] = [];
+    const tracker = createLastStepTurnTracker({
+      captureWorkspaceBaseline: async () => {},
+      completeWorkspaceStep: async (workspaceId) => {
+        completions.push(workspaceId);
+      },
+    });
+
+    tracker.handleHerdrEvent(status("p1", "w1", "working"));
+    await flushTransitions();
+    tracker.handleHerdrEvent({
+      event: "pane_moved",
+      data: {
+        type: "pane_moved",
+        previous_pane_id: "p1",
+        previous_workspace_id: "w1",
+        previous_tab_id: "w1:tab1",
+        pane: {
+          pane_id: "p2",
+          workspace_id: "w1",
+          agent_status: "working",
+        },
+      },
+    });
+    tracker.handleHerdrEvent(status("p2", "w1", "done"));
+    await flushTransitions();
+
+    expect(completions).toEqual(["w1"]);
     await tracker.stop();
   });
 

--- a/server/src/workspace/last-step-turns.ts
+++ b/server/src/workspace/last-step-turns.ts
@@ -1,3 +1,5 @@
+import { herdrEventName } from "../utils/herdr-events";
+
 type PaneActivity = {
   workspaceId: string;
   status: string;
@@ -12,21 +14,6 @@ type PendingTransition = {
   timer: ReturnType<typeof setTimeout>;
 };
 
-function eventName(event: unknown): string | null {
-  if (!event || typeof event !== "object" || Array.isArray(event)) return null;
-  const envelope = event as EventEnvelope;
-  if (typeof envelope.event === "string") return envelope.event;
-  if (
-    envelope.data &&
-    typeof envelope.data === "object" &&
-    !Array.isArray(envelope.data)
-  ) {
-    const type = (envelope.data as { type?: unknown }).type;
-    if (typeof type === "string") return type;
-  }
-  return null;
-}
-
 function eventData(event: unknown): Record<string, unknown> | null {
   if (!event || typeof event !== "object" || Array.isArray(event)) return null;
   const data = (event as EventEnvelope).data;
@@ -40,7 +27,6 @@ export type LastStepTurnTracker = {
   reconcilePaneList: (result: unknown, startedAtRevision?: number) => void;
   handleHerdrEvent: (event: unknown) => void;
   stop: () => Promise<void>;
-  clear: () => void;
 };
 
 /** Tracks debounced workspace quiet/active boundaries from per-pane status. */
@@ -267,7 +253,7 @@ export function createLastStepTurnTracker(args: {
     },
     handleHerdrEvent(event) {
       if (stopping) return;
-      const name = eventName(event);
+      const name = herdrEventName(event);
       const data = eventData(event);
       if (!name || !data) return;
 
@@ -297,9 +283,25 @@ export function createLastStepTurnTracker(args: {
       }
 
       if (name === "pane.moved" || name === "pane_moved") {
-        const paneId = data.pane_id;
-        const workspaceId = data.workspace_id ?? data.new_workspace_id;
+        // Wire shape: { previous_pane_id, previous_workspace_id,
+        // previous_tab_id, pane: PaneInfo, created_workspace?, created_tab?,
+        // closed_workspace_id?, closed_tab_id? }. A move can allocate a new
+        // pane id, so activity tracking must follow both ids.
+        const previousPaneId = data.previous_pane_id;
+        const previousWorkspaceId = data.previous_workspace_id;
+        const pane =
+          data.pane &&
+          typeof data.pane === "object" &&
+          !Array.isArray(data.pane)
+            ? (data.pane as Record<string, unknown>)
+            : null;
+        const paneId = pane?.pane_id;
+        const workspaceId = pane?.workspace_id;
         if (
+          typeof previousPaneId !== "string" ||
+          !previousPaneId ||
+          typeof previousWorkspaceId !== "string" ||
+          !previousWorkspaceId ||
           typeof paneId !== "string" ||
           !paneId ||
           typeof workspaceId !== "string" ||
@@ -307,18 +309,22 @@ export function createLastStepTurnTracker(args: {
         ) {
           return;
         }
-        const previous = panes.get(paneId);
-        if (!previous || previous.workspaceId === workspaceId) return;
+        const previous = panes.get(previousPaneId);
         const status =
-          typeof data.agent_status === "string"
-            ? data.agent_status
-            : previous.status;
+          typeof pane.agent_status === "string"
+            ? pane.agent_status
+            : (previous?.status ?? "unknown");
         activityRevision += 1;
+        paneEventRevisions.set(previousPaneId, activityRevision);
+        panes.delete(previousPaneId);
         paneEventRevisions.set(paneId, activityRevision);
         closedWorkspaceRevisions.delete(workspaceId);
         panes.set(paneId, { workspaceId, status });
-        observeWorkspace(previous.workspaceId);
-        observeWorkspace(workspaceId);
+        observeWorkspace(previousWorkspaceId);
+        if (previous && previous.workspaceId !== previousWorkspaceId) {
+          observeWorkspace(previous.workspaceId);
+        }
+        if (workspaceId !== previousWorkspaceId) observeWorkspace(workspaceId);
         return;
       }
 
@@ -361,10 +367,6 @@ export function createLastStepTurnTracker(args: {
       // Snapshot errors are already reported inside each worker; allSettled is
       // used only at this shutdown boundary to drain every in-flight process.
       await Promise.allSettled(workers.values());
-      resetState();
-    },
-    clear() {
-      stopping = true;
       resetState();
     },
   };


### PR DESCRIPTION
## Summary

- Parse the real `pane_moved` event payload (`previous_pane_id` / `previous_workspace_id` plus the nested `pane` info) so Last step tracking follows panes moved across workspaces, including moves that allocate a new pane id. The handler previously read fields that never exist on the wire, so a moved pane kept its source workspace active until the next status event and the destination workspace missed the baseline for work already in progress.
- Reuse a per-worktree snapshot index for Last step baselines. Snapshots are serialized per repo root and the index is rebuilt cold after a failure, so repeat snapshots only re-hash files whose stat changed instead of content-hashing the whole worktree. The index is removed on dispose and kept owner-only (git creates it with umask permissions otherwise), which matters on multi-user remote hosts. One-shot callers keep using a throwaway temporary index.
- Trim unused baseline-store surface (`capture`, `resolve`, `clear`, and state that was written but never read outside tests) and the turn tracker's dead `clear()`, and share one Herdr event-name helper between the turn tracker and the agent-status subscription loop.

## Verification

- `bun run format:check`
- `bun run lint`
- `cd server && bun run typecheck` and `cd web && bun run typecheck`
- `bun run test` (749 pass, 1 skip)
- `cd web && bun run build`