### PR TITLE
Harden Last step pane move handling

### DIFF
--- a/server/src/connections/agent-status-subscription.test.ts
+++ b/server/src/connections/agent-status-subscription.test.ts
@@ -237,6 +237,41 @@ test("rebuilds the subscription when a membership event changes the pane set", a
   await loop.stop();
 });
 
+test("rebuilds immediately when a pane move replaces the subscribed pane id", async () => {
+  let panes = [agentPane("w1:p1")];
+  const herdr = fakeHerdr({ panes: () => panes });
+  await herdr.ready;
+  const client = new HerdrClient(herdr.path);
+  const loop = createAgentStatusSubscriptionLoop({
+    herdr: client,
+    connectionId: "test",
+    retryDelayMs: 10,
+    rebuildDebounceMs: 5,
+    membershipPollMs: 10_000,
+  });
+
+  loop.start();
+  await waitFor(() => herdr.subscribeCalls.length === 1);
+
+  panes = [agentPane("w2:p2")];
+  loop.handleHerdrEvent({
+    event: "pane.moved",
+    data: {
+      type: "pane_moved",
+      previous_pane_id: "w1:p1",
+      previous_workspace_id: "w1",
+      pane: { pane_id: "w2:p2", workspace_id: "w2", agent: "pi" },
+    },
+  });
+
+  await waitFor(() => herdr.subscribeCalls.length === 2);
+  expect(herdr.subscribeCalls[1]?.subscriptions).toEqual([
+    { type: "pane.agent_status_changed", pane_id: "w2:p2" },
+  ]);
+
+  await loop.stop();
+});
+
 test("ignores unrelated events and membership events that do not change the set", async () => {
   const herdr = fakeHerdr({ panes: () => [agentPane("w1:p1")] });
   await herdr.ready;

--- a/server/src/connections/agent-status-subscription.ts
+++ b/server/src/connections/agent-status-subscription.ts
@@ -35,6 +35,7 @@ type Generation = {
 const MEMBERSHIP_EVENT_TYPES = new Set([
   "pane_agent_detected",
   "pane_closed",
+  "pane_moved",
   "tab_closed",
   "workspace_closed",
 ]);

--- a/server/src/workspace/git-diff.test.ts
+++ b/server/src/workspace/git-diff.test.ts
@@ -1147,6 +1147,52 @@ describe("last-step worktree snapshots", () => {
     }
   });
 
+  test("invalidates only one workspace sharing a repository root", async () => {
+    const root = await initRepository();
+    const baselines = baselineStore();
+    try {
+      await writeFile(join(root, "tracked.txt"), "baseline\n");
+      await baselines.captureWorkspace("expired", async () => root);
+      await baselines.completeWorkspace("expired");
+      await baselines.captureWorkspace("valid", async () => root);
+      await baselines.completeWorkspace("valid");
+
+      const expiredRange = await baselines.resolveCompleted("expired", root);
+      const validRange = await baselines.resolveCompleted("valid", root);
+      if (!expiredRange || !validRange) {
+        throw new Error("expected both completed workspace ranges");
+      }
+      const expiredSnapshot = baselines.rememberSnapshot(
+        "expired",
+        root,
+        expiredRange.baseline,
+        expiredRange.current,
+      );
+      const validSnapshot = baselines.rememberSnapshot(
+        "valid",
+        root,
+        validRange.baseline,
+        validRange.current,
+      );
+
+      baselines.invalidateWorkspace("expired", root);
+
+      expect(await baselines.resolveCompleted("expired", root)).toBeUndefined();
+      expect(await baselines.resolveCompleted("valid", root)).toEqual(
+        validRange,
+      );
+      expect(
+        baselines.resolveSnapshot("expired", root, expiredSnapshot),
+      ).toBeUndefined();
+      expect(baselines.resolveSnapshot("valid", root, validSnapshot)).toEqual(
+        validRange,
+      );
+    } finally {
+      await baselines.dispose();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test("preserves a valid baseline across transient cat-file failures", async () => {
     const root = await initRepository();
     let failCatFile = false;
@@ -1263,7 +1309,9 @@ describe("last-step worktree snapshots", () => {
       rememberSnapshot: () => "missing-snapshot",
       resolveSnapshot: () => undefined,
       deleteSnapshot: () => undefined,
-      delete: () => {
+      invalidateWorkspace: (workspaceId, invalidatedRoot) => {
+        expect(workspaceId).toBe("workspace");
+        expect(invalidatedRoot).toBe(root);
         deleted = true;
       },
       dispose: async () => undefined,

--- a/server/src/workspace/git-diff.ts
+++ b/server/src/workspace/git-diff.ts
@@ -46,7 +46,7 @@ export type LastStepBaselineStore = {
     snapshotId: string,
   ) => { baseline: string; current: string } | undefined;
   deleteSnapshot: (snapshotId: string) => void;
-  delete: (root: string) => void;
+  invalidateWorkspace: (workspaceId: string, root: string) => void;
   dispose: () => Promise<void>;
 };
 
@@ -554,13 +554,15 @@ export function createLastStepBaselineStore(
       return { baseline: snapshot.baseline, current: snapshot.current };
     },
     deleteSnapshot: (snapshotId) => snapshots.delete(snapshotId),
-    delete(root) {
-      deleteSnapshots((_workspaceId, snapshotRoot) => snapshotRoot === root);
-      for (const [workspaceId, range] of completedRanges) {
-        if (range.root === root) {
-          completedRanges.delete(workspaceId);
-          completedVersions.delete(workspaceId);
-        }
+    invalidateWorkspace(workspaceId, root) {
+      deleteSnapshots(
+        (snapshotWorkspaceId, snapshotRoot) =>
+          snapshotWorkspaceId === workspaceId && snapshotRoot === root,
+      );
+      const range = completedRanges.get(workspaceId);
+      if (range?.root === root) {
+        completedRanges.delete(workspaceId);
+        completedVersions.delete(workspaceId);
       }
     },
     dispose() {
@@ -825,7 +827,7 @@ async function resolveLastStepRange({
     }),
   ]);
   if (!baselineExists || !currentExists) {
-    baselines?.delete(root);
+    baselines?.invalidateWorkspace(workspaceId, root);
     return null;
   }
   return completed;


### PR DESCRIPTION
## Summary

- rebuild the per-pane agent status subscription immediately when `pane_moved` replaces a pane id, so Last step completion does not wait for the fallback membership poll
- scope missing-tree invalidation to the affected workspace and repository root instead of evicting valid Last step ranges and snapshots for every workspace sharing that root
- add regression coverage for moved-pane subscription rebuilds and workspace-scoped snapshot invalidation

## Verification

- `bun run precommit` (751 pass, 1 skip)
- `bun run build`
- `bun test server/src/connections/agent-status-subscription.test.ts server/src/workspace/git-diff.test.ts` (37 pass)
- LSP diagnostics for touched files
- `git diff --check`
