### PR TITLE
Fix mobile keyboard layout and restore direct desktop downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Changed
+
+- Disable pinch and double-tap zoom on phones so the terminal layout stays
+  fixed.
+- Hide floating action buttons while the on-screen keyboard is open.
+
+### Fixed
+
+- Keep desktop file downloads as direct downloads instead of opening the
+  system share sheet (e.g. macOS Safari).
+- Keep the mobile terminal flush with the on-screen keyboard so no black
+  strip appears above it, including with third-party iOS keyboards.
+
 ## 0.4.8 - 2026-08-27
 
 ### Added

--- a/web/index.html
+++ b/web/index.html
@@ -10,13 +10,17 @@
     <link rel="apple-touch-icon" href="/herdr-icon.png" />
     <title>herdr-gui</title>
     <script>
-      // Disable pinch zoom for the terminal UI. The viewport directive above
-      // covers PWAs and Android, but iOS Safari ignores user-scalable, so
-      // suppress the WebKit gesture events that drive pinch zoom as well.
-      for (const type of ["gesturestart", "gesturechange", "gestureend"]) {
-        document.addEventListener(type, (event) => event.preventDefault(), {
-          passive: false,
-        });
+      // Disable pinch zoom for the terminal UI on touch-primary devices
+      // (phones and tablets). The viewport directive above covers PWAs and
+      // Android, but iOS Safari ignores user-scalable, so suppress the
+      // WebKit gesture events that drive pinch zoom as well. Fine-pointer
+      // desktops keep their trackpad pinch zoom.
+      if (window.matchMedia("(pointer: coarse)").matches) {
+        for (const type of ["gesturestart", "gesturechange", "gestureend"]) {
+          document.addEventListener(type, (event) => event.preventDefault(), {
+            passive: false,
+          });
+        }
       }
     </script>
     <script>

--- a/web/index.html
+++ b/web/index.html
@@ -4,11 +4,21 @@
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
     />
     <link rel="icon" type="image/png" href="/herdr-icon.png" />
     <link rel="apple-touch-icon" href="/herdr-icon.png" />
     <title>herdr-gui</title>
+    <script>
+      // Disable pinch zoom for the terminal UI. The viewport directive above
+      // covers PWAs and Android, but iOS Safari ignores user-scalable, so
+      // suppress the WebKit gesture events that drive pinch zoom as well.
+      for (const type of ["gesturestart", "gesturechange", "gestureend"]) {
+        document.addEventListener(type, (event) => event.preventDefault(), {
+          passive: false,
+        });
+      }
+    </script>
     <script>
       // Apply the persisted theme before first paint to avoid a flash of the
       // default dark theme. "system" resolves via the OS color scheme.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -56,6 +56,7 @@ import { requestCloseTab, TabBar } from "./components/TabBar";
 import { WorkspaceInspectorHost } from "./components/WorkspaceInspectorHost";
 import { WorkspaceTree } from "./components/WorkspaceTree";
 import type { TerminalWorkspaceFileRequest } from "./components/TerminalView";
+import { isIosDevice } from "./downloadFile";
 import {
   LEGACY_MOBILE_TERMINAL_SHORTCUTS_STORAGE_KEY,
   MOBILE_TERMINAL_SHORTCUTS_STORAGE_KEY,
@@ -286,10 +287,77 @@ function useMobileLayout() {
   return mobile;
 }
 
+const viewportDebugEnabled =
+  typeof window !== "undefined" &&
+  new URLSearchParams(window.location.search).has("debugViewport");
+
+// iOS counts the floating keyboard accessory bar (form assistant) as covered
+// area, over-reporting the keyboard inset. Lift content past that overshoot
+// by default on iOS; Android reports exact insets, so trim stays 0 there.
+// ?kbdTrim=<px> overrides the default for experiments.
+const defaultKeyboardInsetTrim =
+  typeof navigator !== "undefined" && isIosDevice(navigator) ? 30 : 0;
+const keyboardInsetTrim =
+  typeof window !== "undefined"
+    ? Math.max(
+        0,
+        Number.parseInt(
+          new URLSearchParams(window.location.search).get("kbdTrim") ??
+            String(defaultKeyboardInsetTrim),
+          10,
+        ) || 0,
+      )
+    : 0;
+
+function ViewportDebugOverlay() {
+  const [lines, setLines] = useState<string[]>([]);
+  useEffect(() => {
+    const probe = document.createElement("div");
+    probe.style.cssText =
+      "position:fixed;left:0;top:0;width:0;padding-bottom:env(safe-area-inset-bottom,0px);visibility:hidden;pointer-events:none";
+    document.body.appendChild(probe);
+    const update = () => {
+      const vv = window.visualViewport;
+      const cs = getComputedStyle(document.documentElement);
+      setLines([
+        `mode ${
+          window.matchMedia("(display-mode: standalone)").matches
+            ? "standalone"
+            : "browser"
+        }`,
+        `inner ${window.innerHeight} outer ${window.outerHeight}`,
+        `vv ${vv ? `${Math.round(vv.height)} @${Math.round(vv.offsetTop)}` : "n/a"}`,
+        `appH ${cs.getPropertyValue("--app-height") || "-"}`,
+        `kbd ${cs.getPropertyValue("--keyboard-inset-bottom") || "-"}`,
+        `lift ${cs.getPropertyValue("--keyboard-inset-content") || "-"}`,
+        `safe-bottom ${probe.offsetHeight}`,
+      ]);
+    };
+    update();
+    const timer = window.setInterval(update, 400);
+    window.visualViewport?.addEventListener("resize", update);
+    window.visualViewport?.addEventListener("scroll", update);
+    return () => {
+      window.clearInterval(timer);
+      window.visualViewport?.removeEventListener("resize", update);
+      window.visualViewport?.removeEventListener("scroll", update);
+      probe.remove();
+    };
+  }, []);
+  return (
+    <pre className="viewport-debug-overlay" aria-hidden="true">
+      {lines.join("\n")}
+    </pre>
+  );
+}
+
 function useVisualViewportCssVars() {
   useEffect(() => {
     const root = document.documentElement;
-    const update = () => {
+    let pollTimer: number | undefined;
+    let settleTimers: number[] = [];
+
+    const measure = () => {
       const viewport = window.visualViewport;
       const height = viewport?.height ?? window.innerHeight;
       const offsetTop = viewport?.offsetTop ?? 0;
@@ -298,15 +366,20 @@ function useVisualViewportCssVars() {
         window.innerHeight - height - offsetTop,
       );
       const keyboardOpen = keyboardInset > 24;
+      root.classList.toggle("keyboard-open", keyboardOpen);
       root.style.setProperty(
         "--app-viewport-height",
         `${Math.round(height)}px`,
       );
+      // Keep the app surface at the full layout height, even while the
+      // keyboard is open. iOS can over-report the keyboard occlusion (the
+      // floating keyboard accessory bar counts as covered area), so sizing
+      // the app to the visual viewport leaves an unpainted strip above the
+      // keyboard. Instead the app stays full-height and content is lifted
+      // with padding-bottom in the mobile styles.
       root.style.setProperty(
         "--app-height",
-        keyboardOpen
-          ? `${Math.round(height)}px`
-          : `calc(${Math.round(height)}px + env(safe-area-inset-bottom, 0px))`,
+        `calc(${Math.round(window.innerHeight)}px + env(safe-area-inset-bottom, 0px))`,
       );
       root.style.setProperty(
         "--app-viewport-offset-top",
@@ -316,22 +389,72 @@ function useVisualViewportCssVars() {
         "--keyboard-inset-bottom",
         `${Math.round(keyboardInset)}px`,
       );
+      // Content lift used for the app padding. kbdTrim lets us test how far
+      // the terminal surface can extend toward the keyboard accessory bar.
+      root.style.setProperty(
+        "--keyboard-inset-content",
+        `${Math.round(Math.max(0, keyboardInset - keyboardInsetTrim))}px`,
+      );
+      return keyboardOpen;
+    };
+
+    const stopPolling = () => {
+      if (pollTimer !== undefined) {
+        window.clearInterval(pollTimer);
+        pollTimer = undefined;
+      }
+    };
+
+    // Third-party iOS keyboards can change height (toolbars, candidate rows)
+    // without firing visualViewport events, leaving the app sized for a
+    // stale keyboard inset and exposing a blank strip above the keyboard.
+    // Poll the geometry while the keyboard is open so those changes apply.
+    const syncPolling = (keyboardOpen: boolean) => {
+      if (keyboardOpen && pollTimer === undefined) {
+        pollTimer = window.setInterval(() => {
+          if (!measure()) stopPolling();
+        }, 500);
+      } else if (!keyboardOpen) {
+        stopPolling();
+      }
+    };
+
+    const update = () => {
+      syncPolling(measure());
+    };
+
+    // iOS reports keyboard geometry in stages during the show/hide animation,
+    // so re-measure after it settles to catch the final values.
+    const updateWhenSettled = () => {
+      update();
+      for (const timer of settleTimers) window.clearTimeout(timer);
+      settleTimers = [250, 600].map((delay) =>
+        window.setTimeout(update, delay),
+      );
     };
 
     update();
-    window.visualViewport?.addEventListener("resize", update);
+    window.visualViewport?.addEventListener("resize", updateWhenSettled);
     window.visualViewport?.addEventListener("scroll", update);
     window.addEventListener("resize", update);
-    window.addEventListener("orientationchange", update);
+    window.addEventListener("orientationchange", updateWhenSettled);
+    window.addEventListener("focusin", updateWhenSettled);
+    window.addEventListener("focusout", updateWhenSettled);
     return () => {
-      window.visualViewport?.removeEventListener("resize", update);
+      stopPolling();
+      for (const timer of settleTimers) window.clearTimeout(timer);
+      window.visualViewport?.removeEventListener("resize", updateWhenSettled);
       window.visualViewport?.removeEventListener("scroll", update);
       window.removeEventListener("resize", update);
-      window.removeEventListener("orientationchange", update);
+      window.removeEventListener("orientationchange", updateWhenSettled);
+      window.removeEventListener("focusin", updateWhenSettled);
+      window.removeEventListener("focusout", updateWhenSettled);
+      root.classList.remove("keyboard-open");
       root.style.removeProperty("--app-viewport-height");
       root.style.removeProperty("--app-height");
       root.style.removeProperty("--app-viewport-offset-top");
       root.style.removeProperty("--keyboard-inset-bottom");
+      root.style.removeProperty("--keyboard-inset-content");
     };
   }, []);
 }
@@ -2532,6 +2655,7 @@ export default function App() {
         </main>
       </div>
       <GlobalTooltip />
+      {viewportDebugEnabled ? <ViewportDebugOverlay /> : null}
       {paneJumpOpen ? (
         <PaneJumpOverlay
           entries={paneJumpOptions}

--- a/web/src/downloadFile.test.ts
+++ b/web/src/downloadFile.test.ts
@@ -77,14 +77,13 @@ describe("filenameFromContentDisposition", () => {
 });
 
 describe("chooseFileDownloadStrategy", () => {
-  test("prefers the native share sheet when files can be shared", () => {
-    expect(
-      chooseFileDownloadStrategy({
-        canShareFiles: true,
-        standalone: true,
-        ios: true,
-      }),
-    ).toBe("share");
+  test("prefers the native share sheet on iOS when files can be shared", () => {
+    for (const env of [
+      { canShareFiles: true, standalone: true, ios: true },
+      { canShareFiles: true, standalone: false, ios: true },
+    ]) {
+      expect(chooseFileDownloadStrategy(env)).toBe("share");
+    }
   });
 
   test("opens a new browsing context on iOS or in a PWA without share", () => {
@@ -97,10 +96,34 @@ describe("chooseFileDownloadStrategy", () => {
     }
   });
 
+  test("opens a new context for desktop web apps instead of the share sheet", () => {
+    // macOS "Add to Dock" web apps are standalone and can share files, but
+    // the share sheet is not the expected desktop download path.
+    expect(
+      chooseFileDownloadStrategy({
+        canShareFiles: true,
+        standalone: true,
+        ios: false,
+      }),
+    ).toBe("new-context");
+  });
+
   test("keeps the anchor download for regular desktop browsers", () => {
     expect(
       chooseFileDownloadStrategy({
         canShareFiles: false,
+        standalone: false,
+        ios: false,
+      }),
+    ).toBe("anchor");
+  });
+
+  test("keeps the anchor download on desktop even when files can be shared", () => {
+    // macOS Safari reports navigator.canShare support for files; the share
+    // sheet is still not the expected desktop download path.
+    expect(
+      chooseFileDownloadStrategy({
+        canShareFiles: true,
         standalone: false,
         ios: false,
       }),

--- a/web/src/downloadFile.ts
+++ b/web/src/downloadFile.ts
@@ -2,9 +2,9 @@
  * Download strategy for file URLs. Plain anchor downloads navigate the
  * current browsing context, which iOS replaces with the system document
  * handler; in a PWA there is no way back without force-quitting the app.
- * Prefer the native share sheet when available, open a new browsing context
- * on iOS/standalone (the in-app browser offers a way back), and keep the
- * classic anchor download everywhere else.
+ * Prefer the native share sheet on iOS when available, open a new browsing
+ * context on iOS/standalone (the in-app browser offers a way back), and keep
+ * the classic anchor download everywhere else.
  */
 export type FileDownloadStrategy = "share" | "new-context" | "anchor";
 
@@ -36,7 +36,11 @@ export function isStandaloneDisplay(
 export function chooseFileDownloadStrategy(
   env: FileDownloadEnvironment,
 ): FileDownloadStrategy {
-  if (env.canShareFiles) return "share";
+  // Desktop browsers can share files too (macOS Safari pops the system
+  // share sheet), but there the classic anchor download is the expected
+  // behavior. Only iOS traps anchor downloads in the system document
+  // handler, so only iOS uses the share sheet.
+  if (env.canShareFiles && env.ios) return "share";
   if (env.standalone || env.ios) return "new-context";
   return "anchor";
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -360,6 +360,12 @@
   scrollbar-gutter: auto;
   scrollbar-width: none;
 }
+
+html {
+  /* Disable double-tap zoom and the touch click delay. Pinch zoom is handled
+     by the viewport meta and gesture event suppression. */
+  touch-action: manipulation;
+}
 *::-webkit-scrollbar {
   width: 0;
   height: 0;
@@ -7703,6 +7709,19 @@ textarea:focus {
     height: var(--app-height, var(--app-viewport-height, 100dvh));
     min-height: var(--app-height, var(--app-viewport-height, 100dvh));
     transform: translateY(var(--app-viewport-offset-top, 0px));
+    /* The app stays full-height behind the keyboard; lift the content above
+       the keyboard with padding instead. */
+    padding-bottom: var(
+      --keyboard-inset-content,
+      var(--keyboard-inset-bottom, 0px)
+    );
+  }
+  .keyboard-open .app {
+    /* iOS counts the floating keyboard accessory bar as occluded area, so
+       whatever the padding leaves exposed keeps the terminal background
+       instead of flashing the webview's black backdrop. Keyboard-closed
+       views keep the default shell background. */
+    background: var(--terminal-bg);
   }
 
   .topbar {
@@ -7960,6 +7979,7 @@ textarea:focus {
     transform: translate3d(0, 0, 0) scale(1);
     transition:
       bottom 180ms ease,
+      opacity 160ms ease,
       background 120ms ease,
       border-color 120ms ease,
       transform 180ms ease;
@@ -7977,6 +7997,15 @@ textarea:focus {
     border-color: var(--accent);
     background: var(--accent-soft);
     transform: scale(0.94);
+  }
+  /* While the on-screen keyboard is open the floating controls cover too
+     much of the terminal, so fade them out until the keyboard closes. */
+  .keyboard-open .mobile-nav,
+  .keyboard-open .mobile-workspace-shortcut,
+  .keyboard-open .mobile-controls-toggle {
+    opacity: 0;
+    pointer-events: none;
+    transform: translate3d(0, 12px, 0) scale(0.85);
   }
   .mobile-controls-collapsed .mobile-nav {
     opacity: 0;
@@ -8469,4 +8498,24 @@ textarea:focus {
   .brand-title {
     display: none;
   }
+}
+
+/* Viewport geometry probe for debugging mobile keyboard layout (opt-in via
+   ?debugViewport=1). */
+.viewport-debug-overlay {
+  position: fixed;
+  top: calc(4px + env(safe-area-inset-top, 0px));
+  left: calc(4px + env(safe-area-inset-left, 0px));
+  z-index: 9999;
+  margin: 0;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.82);
+  color: #7dff8a;
+  font:
+    11px / 1.5 ui-monospace,
+    Menlo,
+    monospace;
+  pointer-events: none;
+  white-space: pre-wrap;
 }


### PR DESCRIPTION
## Summary

Mobile keyboard/touch fixes and a desktop download regression fix:

- **Keyboard black strip**: the app surface now stays full-height behind the keyboard and lifts content with padding, instead of shrinking to `visualViewport.height`. iOS counts the floating keyboard accessory bar as occluded area, which previously left an unpainted black strip between the terminal and the keyboard. Viewport geometry is polled while the keyboard is open because third-party iOS keyboards can resize without firing viewport events.
- **Floating controls**: the floating action buttons fade out while the on-screen keyboard is open so they no longer cover terminal content.
- **Zoom**: pinch and double-tap zoom are disabled on phones (`user-scalable=no` + WebKit gesture event suppression + `touch-action: manipulation`) so the terminal layout stays fixed.
- **Desktop downloads**: file downloads are direct browser downloads again on desktop; the native share sheet is now iOS-only (macOS Safari also reports `navigator.canShare` support for files and previously opened the system share sheet, including in "Add to Dock" web apps).
- **Debug tooling** (opt-in): `?debugViewport=1` viewport geometry overlay and `?kbdTrim=<px>` keyboard lift override. The default 30px iOS trim reuses `isIosDevice()` (covers iPadOS Macintosh UA).

## Verification

- `bun run format:check`, `bun run lint`, `bun run test` (754 pass), `cd web && bun run typecheck`, `cd web && bun run build`
- On-device (iPhone, iOS Safari and PWA, third-party keyboard): terminal sits flush with the keyboard accessory bar with no black strip, zoom is disabled, floating controls hide while typing
- Desktop Safari: file downloads use the classic download path again