### PR TITLE
Preview PDFs and Markdown images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- Preview PDF files in File Explorer and load workspace-local images in rendered
+  Markdown previews, including paths relative to the Markdown document.
+
 ## 0.4.9 - 2026-08-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Preview PDF files in File Explorer and load workspace-local images in rendered
   Markdown previews, including paths relative to the Markdown document.
 
+### Changed
+
+- Present the selected file name as the preview heading and move Changes into a
+  separate header toggle.
+
 ## 0.4.9 - 2026-08-28
 
 ### Changed

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1023,6 +1023,7 @@ async function handleConnectionHttpRequest(
         response = await connection.files.downloadWorkspaceFile({
           workspace_id: url.searchParams.get("workspace_id"),
           path: url.searchParams.get("path"),
+          inline: url.searchParams.get("inline") === "1",
         });
       } catch (error) {
         response = new Response((error as Error).message, { status: 400 });

--- a/server/src/workspace/file-paths.test.ts
+++ b/server/src/workspace/file-paths.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   downloadContentDisposition,
+  inlineContentDisposition,
   relativeExplorerPath,
   sanitizeExplorerPath,
   sanitizePreviewPath,
@@ -49,5 +50,8 @@ describe("workspace file path helpers", () => {
     const header = downloadContentDisposition("测试 file.txt");
     expect(header).toContain('filename="__ file.txt"');
     expect(header).toContain("filename*=UTF-8''%E6%B5%8B%E8%AF%95%20file.txt");
+    expect(inlineContentDisposition("guide.pdf")).toBe(
+      "inline; filename=\"guide.pdf\"; filename*=UTF-8''guide.pdf",
+    );
   });
 });

--- a/server/src/workspace/file-paths.ts
+++ b/server/src/workspace/file-paths.ts
@@ -61,7 +61,18 @@ export function relativePreviewPath(rootReal: string, targetReal: string) {
   return relative(rootReal, targetReal).split(sep).join("/");
 }
 
-export function downloadContentDisposition(filename: string) {
+function contentDisposition(
+  filename: string,
+  disposition: "attachment" | "inline",
+) {
   const fallback = filename.replace(/[^\x20-\x7e]|["\r\n]/g, "_") || "download";
-  return `attachment; filename="${fallback}"; filename*=UTF-8''${encodeURIComponent(filename)}`;
+  return `${disposition}; filename="${fallback}"; filename*=UTF-8''${encodeURIComponent(filename)}`;
+}
+
+export function downloadContentDisposition(filename: string) {
+  return contentDisposition(filename, "attachment");
+}
+
+export function inlineContentDisposition(filename: string) {
+  return contentDisposition(filename, "inline");
 }

--- a/server/src/workspace/files.test.ts
+++ b/server/src/workspace/files.test.ts
@@ -106,6 +106,7 @@ describe("workspace file handlers", () => {
   test("returns download responses with safe headers", async () => {
     await withTempDir(async (root) => {
       await writeFile(join(root, "测试.txt"), "hello");
+      await writeFile(join(root, "guide.pdf"), "%PDF-1.7");
       const handlers = createFileHandlers({
         herdr: {
           call: async (method: string) => {
@@ -140,6 +141,25 @@ describe("workspace file handlers", () => {
         encodeURIComponent("测试.txt"),
       );
       expect(await response.text()).toBe("hello");
+
+      const inlineResponse = await handlers.downloadWorkspaceFile({
+        workspace_id: "w1",
+        path: "guide.pdf",
+        inline: true,
+      });
+      expect(inlineResponse.headers.get("content-type")).toBe(
+        "application/pdf",
+      );
+      expect(inlineResponse.headers.get("content-disposition")).toContain(
+        "inline;",
+      );
+      expect(inlineResponse.headers.get("cache-control")).toBe(
+        "private, no-store",
+      );
+      expect(inlineResponse.headers.get("x-content-type-options")).toBe(
+        "nosniff",
+      );
+      expect(await inlineResponse.text()).toBe("%PDF-1.7");
     });
   });
 

--- a/server/src/workspace/files.ts
+++ b/server/src/workspace/files.ts
@@ -3,6 +3,7 @@ import { sshCommandArgv } from "../bridge/ssh-command";
 import { checkoutPath as getCheckoutPath } from "./utils";
 import {
   downloadContentDisposition,
+  inlineContentDisposition,
   sanitizeExplorerPath,
   sanitizePreviewPath,
   sanitizeUploadFilename,
@@ -31,6 +32,7 @@ import {
   type LastStepBaselineStore,
 } from "./git-diff";
 import { GIT_DIFF_TIMEOUT_MS } from "./file-constants";
+import { inlinePreviewMimeForPath } from "./preview";
 
 const MAX_FILE_RESOLUTION_CANDIDATES = 32;
 const MAX_FILE_RESOLUTION_PATH_LENGTH = 4096;
@@ -237,14 +239,21 @@ export function createFileHandlers({
           shQuote,
         })
       : await downloadLocalFile(checkoutPath, path);
-    return new Response(download.body, {
-      headers: {
-        "content-type": download.contentType,
-        "content-length": String(download.size),
-        "content-disposition": downloadContentDisposition(download.filename),
-        "x-file-path": encodeURIComponent(download.path),
-      },
-    });
+    const inlineMime =
+      params.inline === true ? inlinePreviewMimeForPath(download.path) : null;
+    const headers: Record<string, string> = {
+      "content-type": inlineMime ?? download.contentType,
+      "content-length": String(download.size),
+      "content-disposition": inlineMime
+        ? inlineContentDisposition(download.filename)
+        : downloadContentDisposition(download.filename),
+      "x-file-path": encodeURIComponent(download.path),
+    };
+    if (inlineMime) {
+      headers["cache-control"] = "private, no-store";
+      headers["x-content-type-options"] = "nosniff";
+    }
+    return new Response(download.body, { headers });
   }
 
   async function uploadFile(params: Record<string, unknown>, request: Request) {

--- a/server/src/workspace/preview.test.ts
+++ b/server/src/workspace/preview.test.ts
@@ -3,6 +3,7 @@ import { PREVIEW_IMAGE_MAX_BYTES, PREVIEW_MAX_BYTES } from "./file-constants";
 import {
   decodePreviewBuffer,
   imageMimeForPath,
+  inlinePreviewMimeForPath,
   previewLimitForPath,
   trimIncompleteUtf8Tail,
 } from "./preview";
@@ -12,6 +13,13 @@ describe("workspace preview helpers", () => {
     expect(imageMimeForPath("image.PNG")).toBe("image/png");
     expect(imageMimeForPath("photo.jpeg")).toBe("image/jpeg");
     expect(imageMimeForPath("archive.tar")).toBeNull();
+  });
+
+  test("detects MIME types allowed for inline previews", () => {
+    expect(inlinePreviewMimeForPath("docs/guide.PDF")).toBe("application/pdf");
+    expect(inlinePreviewMimeForPath("images/demo.webp")).toBe("image/webp");
+    expect(inlinePreviewMimeForPath("page.html")).toBeNull();
+    expect(inlinePreviewMimeForPath("vector.svg")).toBeNull();
   });
 
   test("chooses larger limits only for previewable images", () => {

--- a/server/src/workspace/preview.ts
+++ b/server/src/workspace/preview.ts
@@ -44,6 +44,11 @@ export function imageMimeForPath(path: string) {
   }
 }
 
+export function inlinePreviewMimeForPath(path: string) {
+  if (path.toLowerCase().endsWith(".pdf")) return "application/pdf";
+  return imageMimeForPath(path);
+}
+
 export function previewLimitForPath(path: string, size: number) {
   return imageMimeForPath(path) && size <= PREVIEW_IMAGE_MAX_BYTES
     ? PREVIEW_IMAGE_MAX_BYTES

--- a/web/src/components/FileExplorerDialog.test.ts
+++ b/web/src/components/FileExplorerDialog.test.ts
@@ -187,19 +187,23 @@ describe("connection-scoped file previews", () => {
       return preview(text);
     });
 
-    await expect(
-      requestFilePreview("same", "same.txt", { client: scopedClient }),
-    ).resolves.toMatchObject({ text: "before" });
+    const initial = await requestFilePreview("same", "same.txt", {
+      client: scopedClient,
+    });
+    expect(initial).toMatchObject({ text: "before" });
+    expect(typeof initial.resource_revision).toBe("number");
     text = "after";
     await expect(
       requestFilePreview("same", "same.txt", { client: scopedClient }),
     ).resolves.toMatchObject({ text: "before" });
-    await expect(
-      requestFilePreview("same", "same.txt", {
-        client: scopedClient,
-        refresh: true,
-      }),
-    ).resolves.toMatchObject({ text: "after" });
+    const refreshed = await requestFilePreview("same", "same.txt", {
+      client: scopedClient,
+      refresh: true,
+    });
+    expect(refreshed).toMatchObject({ text: "after" });
+    expect(refreshed.resource_revision).toBeGreaterThan(
+      initial.resource_revision ?? 0,
+    );
     expect(calls).toBe(2);
   });
 

--- a/web/src/components/FileExplorerDialog.tsx
+++ b/web/src/components/FileExplorerDialog.tsx
@@ -107,6 +107,7 @@ const previewRequests = new Map<string, Promise<FilePreview>>();
 const previewRequestRevisions = new Map<string, number>();
 const MAX_PREVIEW_CACHE_BYTES = 16 * 1024 * 1024;
 let previewCacheBytes = 0;
+let previewResourceRevision = 0;
 const FILE_TREE_INDENT = 10;
 const FILE_TREE_BASE_INDENT = 6;
 const FILE_SHOW_HIDDEN_PREFIX = "fileExplorerShowHidden:";
@@ -579,8 +580,13 @@ export function requestFilePreview(
       if (previewRequestRevisions.get(key) !== revision) {
         throw new Error("file preview request superseded");
       }
-      writeCachedPreview(key, preview);
-      return preview;
+      previewResourceRevision += 1;
+      const versionedPreview = {
+        ...preview,
+        resource_revision: previewResourceRevision,
+      };
+      writeCachedPreview(key, versionedPreview);
+      return versionedPreview;
     })
     .finally(() => {
       if (previewRequests.get(key) === scopedTask) {

--- a/web/src/components/FilePreviewContent.tsx
+++ b/web/src/components/FilePreviewContent.tsx
@@ -1,6 +1,7 @@
 import {
   useEffect,
   useId,
+  useMemo,
   useRef,
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
@@ -9,6 +10,11 @@ import {
 } from "react";
 import type { EditorView as CodeMirrorEditorView } from "@codemirror/view";
 import type { FileExplorerEntry, FilePreview } from "../types";
+import { useConnectionClient } from "../useConnectionClient";
+import {
+  resolveWorkspaceMarkdownImageUrl,
+  workspaceFileUrl,
+} from "../workspaceFileUrl";
 import { MarkdownPreview } from "./markdown";
 import { MermaidDiagram } from "./MermaidDiagram";
 import { highlightCodeTokens } from "./syntaxHighlighting";
@@ -25,6 +31,8 @@ export type FilePreviewSelectionMeta = {
 };
 
 type AppTheme = "dark" | "light";
+
+const PDF_INLINE_PREVIEW_MAX_BYTES = 25 * 1024 * 1024;
 
 type CodeMirrorPreviewDeps = Awaited<
   ReturnType<typeof importCodeMirrorPreviewDeps>
@@ -78,6 +86,10 @@ function isMermaidPath(path: string) {
   return lower.endsWith(".mmd") || lower.endsWith(".mermaid");
 }
 
+function isPdfPath(path: string) {
+  return path.toLowerCase().endsWith(".pdf");
+}
+
 function currentDocumentTheme(): AppTheme {
   return document.documentElement.dataset.theme === "light" ? "light" : "dark";
 }
@@ -123,6 +135,7 @@ export function FilePreviewContent({
   changesKey?: string;
   onOpenChanges?: () => void;
 }) {
+  const connectionClient = useConnectionClient();
   const previewSectionRef = useRef<HTMLElement | null>(null);
   const editorViewRef = useRef<CodeMirrorEditorView | null>(null);
   const fileTabRef = useRef<HTMLButtonElement | null>(null);
@@ -140,8 +153,41 @@ export function FilePreviewContent({
   const hasPreviewText = previewText !== null;
   const hasMarkdownPreview = hasPreviewText && isMarkdownPath(previewPath);
   const hasMermaidPreview = hasPreviewText && isMermaidPath(previewPath);
+  const hasPdfPreview = Boolean(preview && isPdfPath(previewPath));
+  const pdfTooLarge =
+    hasPdfPreview && (preview?.size ?? 0) > PDF_INLINE_PREVIEW_MAX_BYTES;
   const hasRichPreview = hasMarkdownPreview || hasMermaidPreview;
   const renderRichPreview = hasRichPreview && previewMode === "rendered";
+  const inlinePreviewUrl = useMemo(() => {
+    if (!preview?.workspace_id || !previewPath) return null;
+    return workspaceFileUrl(
+      connectionClient,
+      preview.workspace_id,
+      previewPath,
+      { inline: true, revision: preview.resource_revision },
+    );
+  }, [
+    connectionClient,
+    preview?.resource_revision,
+    preview?.workspace_id,
+    previewPath,
+  ]);
+  const markdownImageUrlResolver = useMemo(() => {
+    if (!preview?.workspace_id || !previewPath) return undefined;
+    return (source: string) =>
+      resolveWorkspaceMarkdownImageUrl(
+        source,
+        previewPath,
+        connectionClient,
+        preview.workspace_id,
+        preview.resource_revision,
+      );
+  }, [
+    connectionClient,
+    preview?.resource_revision,
+    preview?.workspace_id,
+    previewPath,
+  ]);
   const changesAvailable =
     changesContent !== undefined && !!changesKey && !!onOpenChanges;
   const showingChanges = detailTab === "changes" && changesAvailable;
@@ -301,18 +347,41 @@ export function FilePreviewContent({
               />
             </div>
           ) : null}
-          {!loading && !error && preview?.binary && !preview.image_data_url ? (
+          {!loading &&
+          !error &&
+          hasPdfPreview &&
+          !pdfTooLarge &&
+          inlinePreviewUrl ? (
+            <iframe
+              className="file-preview-pdf"
+              src={inlinePreviewUrl}
+              title={`PDF preview: ${entry?.name ?? previewPath}`}
+            />
+          ) : null}
+          {!loading && !error && pdfTooLarge ? (
+            <div className="file-preview-state">
+              PDF is too large to preview. Use Download from the file menu.
+            </div>
+          ) : null}
+          {!loading &&
+          !error &&
+          preview?.binary &&
+          !preview.image_data_url &&
+          !hasPdfPreview ? (
             <div className="file-preview-state">
               Binary file cannot be previewed.
             </div>
           ) : null}
-          {!loading && !error && preview?.truncated ? (
+          {!loading && !error && preview?.truncated && !hasPdfPreview ? (
             <div className="file-preview-banner">
               Preview truncated at 512 KB.
             </div>
           ) : null}
           {!loading && !error && hasMarkdownPreview && renderRichPreview ? (
-            <MarkdownPreview text={previewText} />
+            <MarkdownPreview
+              text={previewText}
+              imageUrlResolver={markdownImageUrlResolver}
+            />
           ) : null}
           {!loading && !error && hasMermaidPreview && renderRichPreview ? (
             <MermaidDiagram
@@ -320,7 +389,11 @@ export function FilePreviewContent({
               className="file-preview-mermaid"
             />
           ) : null}
-          {!loading && !error && hasPreviewText && !renderRichPreview ? (
+          {!loading &&
+          !error &&
+          hasPreviewText &&
+          !renderRichPreview &&
+          !hasPdfPreview ? (
             <CodeMirrorPreview
               text={previewText}
               path={previewPath}

--- a/web/src/components/FilePreviewContent.tsx
+++ b/web/src/components/FilePreviewContent.tsx
@@ -1,10 +1,8 @@
 import {
   useEffect,
-  useId,
   useMemo,
   useRef,
   useState,
-  type KeyboardEvent as ReactKeyboardEvent,
   type MutableRefObject,
   type ReactNode,
 } from "react";
@@ -138,9 +136,6 @@ export function FilePreviewContent({
   const connectionClient = useConnectionClient();
   const previewSectionRef = useRef<HTMLElement | null>(null);
   const editorViewRef = useRef<CodeMirrorEditorView | null>(null);
-  const fileTabRef = useRef<HTMLButtonElement | null>(null);
-  const changesTabRef = useRef<HTMLButtonElement | null>(null);
-  const tabId = useId();
   const onOpenChangesRef = useRef(onOpenChanges);
   onOpenChangesRef.current = onOpenChanges;
   const [previewMode, setPreviewMode] = useState<"rendered" | "raw">(
@@ -191,29 +186,6 @@ export function FilePreviewContent({
   const changesAvailable =
     changesContent !== undefined && !!changesKey && !!onOpenChanges;
   const showingChanges = detailTab === "changes" && changesAvailable;
-  const fileTabId = `${tabId}-file-tab`;
-  const changesTabId = `${tabId}-changes-tab`;
-  const filePanelId = `${tabId}-file-panel`;
-  const changesPanelId = `${tabId}-changes-panel`;
-
-  const handleDetailTabKeyDown = (
-    event: ReactKeyboardEvent<HTMLButtonElement>,
-  ) => {
-    if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) {
-      return;
-    }
-    event.preventDefault();
-    const nextTab =
-      !changesAvailable || event.key === "Home"
-        ? "file"
-        : event.key === "End"
-          ? "changes"
-          : showingChanges
-            ? "file"
-            : "changes";
-    setDetailTab(nextTab);
-    (nextTab === "file" ? fileTabRef : changesTabRef).current?.focus();
-  };
 
   useEffect(() => {
     setPreviewMode("rendered");
@@ -259,70 +231,54 @@ export function FilePreviewContent({
     >
       <div className="file-preview-head">
         <div className="file-preview-title-row">
-          <div className="file-preview-tabs" role="tablist">
-            <button
-              ref={fileTabRef}
-              id={fileTabId}
-              type="button"
-              role="tab"
-              className={showingChanges ? "" : "is-active"}
-              aria-selected={!showingChanges}
-              aria-controls={filePanelId}
-              tabIndex={showingChanges ? -1 : 0}
-              onClick={() => setDetailTab("file")}
-              onKeyDown={handleDetailTabKeyDown}
-            >
-              {entry?.name ?? "Preview"}
-            </button>
+          <div className="file-preview-title" title={entry?.name}>
+            {entry?.name ?? "Preview"}
+          </div>
+          <div className="file-preview-head-actions">
+            {!showingChanges && hasRichPreview ? (
+              <button
+                type="button"
+                className="file-preview-mode-toggle"
+                onClick={() =>
+                  setPreviewMode((mode) =>
+                    mode === "rendered" ? "raw" : "rendered",
+                  )
+                }
+              >
+                {previewMode === "rendered" ? "Raw" : "Rendered"}
+              </button>
+            ) : null}
             {changesAvailable ? (
               <button
-                ref={changesTabRef}
-                id={changesTabId}
                 type="button"
-                role="tab"
-                className={showingChanges ? "is-active" : ""}
-                aria-selected={showingChanges}
-                aria-controls={changesPanelId}
-                tabIndex={showingChanges ? 0 : -1}
-                onClick={() => setDetailTab("changes")}
-                onKeyDown={handleDetailTabKeyDown}
+                className="file-preview-changes-toggle"
+                aria-pressed={showingChanges}
+                title={showingChanges ? "Show file preview" : "Show changes"}
+                onClick={() =>
+                  setDetailTab(showingChanges ? "file" : "changes")
+                }
               >
                 Changes
               </button>
             ) : null}
           </div>
-          {!showingChanges && hasRichPreview ? (
-            <button
-              type="button"
-              className="file-preview-mode-toggle"
-              onClick={() =>
-                setPreviewMode((mode) =>
-                  mode === "rendered" ? "raw" : "rendered",
-                )
-              }
-            >
-              {previewMode === "rendered" ? "Raw" : "Rendered"}
-            </button>
-          ) : null}
         </div>
         {entry ? <span>{entry.path}</span> : null}
       </div>
 
       {showingChanges ? (
         <div
-          id={changesPanelId}
           className="file-preview-changes"
-          role="tabpanel"
-          aria-labelledby={changesTabId}
+          role="region"
+          aria-label={`Changes for ${entry?.name ?? "selected file"}`}
         >
           {changesContent}
         </div>
       ) : (
         <div
-          id={filePanelId}
           className="file-preview-file-content"
-          role="tabpanel"
-          aria-labelledby={fileTabId}
+          role="region"
+          aria-label={`Preview of ${entry?.name ?? "selected file"}`}
         >
           {!entry ? (
             <div className="file-preview-state">

--- a/web/src/components/markdown.tsx
+++ b/web/src/components/markdown.tsx
@@ -58,7 +58,15 @@ export function isSafeMarkdownUrl(value: string) {
   return ["http:", "https:", "mailto:"].includes(protocolMatch[0]);
 }
 
-export function sanitizeMarkdownHtml(html: string) {
+type MarkdownRenderOptions = {
+  breaks?: boolean;
+  imageUrlResolver?: (source: string) => string | null;
+};
+
+export function sanitizeMarkdownHtml(
+  html: string,
+  options: Pick<MarkdownRenderOptions, "imageUrlResolver"> = {},
+) {
   const doc = new DOMParser().parseFromString(html, "text/html");
   const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_ELEMENT);
   const elements: Element[] = [];
@@ -103,11 +111,19 @@ export function sanitizeMarkdownHtml(html: string) {
         element.removeAttribute(attr.name);
         continue;
       }
-      if (
-        (name === "href" || name === "src") &&
-        !isSafeMarkdownUrl(attr.value)
-      ) {
-        element.removeAttribute(attr.name);
+      if (name === "href" || name === "src") {
+        if (!isSafeMarkdownUrl(attr.value)) {
+          element.removeAttribute(attr.name);
+          continue;
+        }
+        if (name === "src" && tag === "img" && options.imageUrlResolver) {
+          const resolved = options.imageUrlResolver(attr.value);
+          if (!resolved || !isSafeMarkdownUrl(resolved)) {
+            element.removeAttribute(attr.name);
+          } else {
+            element.setAttribute(attr.name, resolved);
+          }
+        }
       }
     }
 
@@ -122,7 +138,7 @@ export function sanitizeMarkdownHtml(html: string) {
 
 export function renderMarkdown(
   text: string,
-  options: { breaks?: boolean } = {},
+  options: MarkdownRenderOptions = {},
 ) {
   const html = marked.parse(text, {
     async: false,
@@ -132,19 +148,24 @@ export function renderMarkdown(
     breaks: options.breaks ?? false,
     gfm: true,
   });
-  return sanitizeMarkdownHtml(String(html));
+  return sanitizeMarkdownHtml(String(html), options);
 }
 
 export function MarkdownPreview({
   text,
   className = "",
   breaks = false,
+  imageUrlResolver,
 }: {
   text: string;
   className?: string;
   breaks?: boolean;
+  imageUrlResolver?: (source: string) => string | null;
 }) {
-  const html = useMemo(() => renderMarkdown(text, { breaks }), [text, breaks]);
+  const html = useMemo(
+    () => renderMarkdown(text, { breaks, imageUrlResolver }),
+    [text, breaks, imageUrlResolver],
+  );
   const articleRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
@@ -169,7 +190,13 @@ export function MarkdownPreview({
             figure.className = "mermaid-diagram";
             figure.setAttribute("role", "img");
             figure.setAttribute("aria-label", "Mermaid diagram");
-            figure.innerHTML = rendered.svg;
+            const svgDocument = new DOMParser().parseFromString(
+              rendered.svg,
+              "image/svg+xml",
+            );
+            const svg = svgDocument.documentElement;
+            if (svg.tagName.toLowerCase() !== "svg") continue;
+            figure.replaceChildren(document.importNode(svg, true));
             pre.replaceWith(figure);
           } else {
             const note = document.createElement("div");

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4774,6 +4774,13 @@ textarea:focus {
   border-radius: 6px;
   box-shadow: 0 0 0 1px var(--border);
 }
+.file-preview-pdf {
+  flex: 1 1 auto;
+  width: 100%;
+  min-height: 0;
+  border: 0;
+  background: var(--panel);
+}
 .file-preview-code {
   flex: 1 1 auto;
   min-height: 0;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4670,43 +4670,23 @@ textarea:focus {
   justify-content: space-between;
   gap: 10px;
 }
-.file-preview-tabs {
+.file-preview-title {
   min-width: 0;
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
-  padding: 2px;
-  border: 1px solid var(--viewer-border);
-  border-radius: 7px;
-  background: var(--viewer-content-bg);
-}
-.file-preview-tabs button {
-  min-width: 0;
-  height: 24px;
   overflow: hidden;
-  padding: 0 8px;
-  border: none;
-  border-radius: 5px;
-  background: transparent;
-  color: var(--muted);
-  font-size: 11px;
+  color: var(--text-strong);
+  font-size: 13px;
   font-weight: 700;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.file-preview-tabs button:first-child {
-  max-width: min(34vw, 260px);
-}
-.file-preview-tabs button:hover,
-.file-preview-tabs button.is-active {
-  background: var(--accent-soft);
-  color: var(--text-strong);
-}
-.file-preview-tabs button.is-active {
-  box-shadow: inset 0 0 0 1px var(--accent);
-}
-.file-preview-mode-toggle {
+.file-preview-head-actions {
   flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.file-preview-mode-toggle,
+.file-preview-changes-toggle {
   height: 24px;
   padding: 0 8px;
   border-radius: 7px;
@@ -4714,6 +4694,14 @@ textarea:focus {
   color: var(--text);
   font-size: 11px;
   font-weight: 700;
+}
+.file-preview-changes-toggle:hover,
+.file-preview-changes-toggle[aria-pressed="true"] {
+  background: var(--accent-soft);
+  color: var(--text-strong);
+}
+.file-preview-changes-toggle[aria-pressed="true"] {
+  box-shadow: inset 0 0 0 1px var(--accent);
 }
 .file-preview-head span {
   min-width: 0;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -159,6 +159,7 @@ export interface FilePreview {
   mime_type?: string;
   image_data_url?: string;
   truncated: boolean;
+  resource_revision?: number;
 }
 
 export type GitDiffKind =

--- a/web/src/workspaceFileUrl.test.ts
+++ b/web/src/workspaceFileUrl.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import {
+  resolveWorkspaceMarkdownImagePath,
+  resolveWorkspaceMarkdownImageUrl,
+  workspaceFileUrl,
+} from "./workspaceFileUrl";
+
+const client = {
+  connectionId: "remote dev",
+  serverRuntimeGeneration: 7,
+};
+
+describe("workspace file URLs", () => {
+  test("builds generation-bound inline resource URLs", () => {
+    expect(workspaceFileUrl(client, "workspace 1", "docs/a b.pdf")).toBe(
+      "/api/connections/remote%20dev/file/download?connection_generation=7&workspace_id=workspace+1&path=docs%2Fa+b.pdf",
+    );
+    expect(
+      workspaceFileUrl(client, "workspace 1", "docs/a b.pdf", {
+        inline: true,
+        revision: 3,
+      }),
+    ).toEndWith("&inline=1&resource_revision=3");
+  });
+
+  test("resolves Markdown images relative to the document", () => {
+    expect(
+      resolveWorkspaceMarkdownImagePath(
+        "../assets/demo%20image.png",
+        "docs/guide/readme.md",
+      ),
+    ).toBe("docs/assets/demo image.png");
+    expect(
+      resolveWorkspaceMarkdownImagePath("/assets/logo.png", "docs/readme.md"),
+    ).toBe("assets/logo.png");
+    expect(
+      resolveWorkspaceMarkdownImagePath(
+        "../../../secret.png",
+        "docs/readme.md",
+      ),
+    ).toBeNull();
+  });
+
+  test("keeps remote images and maps local images to the workspace endpoint", () => {
+    expect(
+      resolveWorkspaceMarkdownImageUrl(
+        "https://example.com/image.png",
+        "README.md",
+        client,
+        "w1",
+      ),
+    ).toBe("https://example.com/image.png");
+    expect(
+      resolveWorkspaceMarkdownImageUrl(
+        "images/screenshot.png",
+        "docs/README.md",
+        client,
+        "w1",
+        4,
+      ),
+    ).toContain(
+      "path=docs%2Fimages%2Fscreenshot.png&inline=1&resource_revision=4",
+    );
+  });
+});

--- a/web/src/workspaceFileUrl.ts
+++ b/web/src/workspaceFileUrl.ts
@@ -1,0 +1,86 @@
+import type { ConnectionClient } from "./api";
+import { connectionHttpPath } from "./connectionHttp";
+
+type FileUrlClient = Pick<
+  ConnectionClient,
+  "connectionId" | "serverRuntimeGeneration"
+>;
+
+export function workspaceFileUrl(
+  client: FileUrlClient,
+  workspaceId: string,
+  path: string,
+  options: { inline?: boolean; revision?: number } = {},
+) {
+  const url = new URL(
+    connectionHttpPath(
+      client.connectionId,
+      "/file/download",
+      client.serverRuntimeGeneration,
+    ),
+    "http://herdr.local",
+  );
+  url.searchParams.set("workspace_id", workspaceId);
+  url.searchParams.set("path", path);
+  if (options.inline) url.searchParams.set("inline", "1");
+  if (options.revision !== undefined) {
+    url.searchParams.set("resource_revision", String(options.revision));
+  }
+  return `${url.pathname}${url.search}`;
+}
+
+/**
+ * Resolve a Markdown image reference against its workspace-relative document.
+ * Undefined means the source is not workspace-local; null means it attempted to
+ * address a local path but could not be resolved inside the workspace root.
+ */
+export function resolveWorkspaceMarkdownImagePath(
+  source: string,
+  markdownPath: string,
+): string | null | undefined {
+  const trimmed = source.trim();
+  if (!trimmed || trimmed.startsWith("//") || trimmed.startsWith("#")) {
+    return undefined;
+  }
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return undefined;
+
+  const encodedPath = trimmed.split(/[?#]/, 1)[0] ?? "";
+  let resourcePath: string;
+  try {
+    resourcePath = decodeURIComponent(encodedPath).replace(/\\/g, "/");
+  } catch {
+    return null;
+  }
+  if (!resourcePath) return null;
+
+  const parts = resourcePath.startsWith("/")
+    ? []
+    : markdownPath.replace(/\\/g, "/").split("/").slice(0, -1);
+  for (const part of resourcePath.split("/")) {
+    if (!part || part === ".") continue;
+    if (part.includes("\0")) return null;
+    if (part === "..") {
+      if (parts.length === 0) return null;
+      parts.pop();
+      continue;
+    }
+    parts.push(part);
+  }
+  return parts.length > 0 ? parts.join("/") : null;
+}
+
+export function resolveWorkspaceMarkdownImageUrl(
+  source: string,
+  markdownPath: string,
+  client: FileUrlClient,
+  workspaceId: string,
+  revision?: number,
+) {
+  const path = resolveWorkspaceMarkdownImagePath(source, markdownPath);
+  if (path === undefined) return source;
+  if (path === null) return null;
+  return workspaceFileUrl(client, workspaceId, path, {
+    inline: true,
+    revision,
+  });
+}


### PR DESCRIPTION
## Summary

- preview PDF files inline in File Explorer using the browser PDF viewer
- resolve workspace-local Markdown images relative to the Markdown document, including SSH-backed workspaces
- keep inline resources fresh and private with revisioned URLs and no-store responses
- cap automatic PDF previews at 25 MiB to avoid buffering large remote files

## Verification

- `bun run precommit` (758 passed, 0 failed; 1 skipped)
- `bun run build:web`
- focused preview regression suite (28 passed)
- pi-lens diagnostics: no issues