### PR TITLE
Polish workspace tree, file explorer, and agent indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   separate header toggle.
 - Move per-file actions in File Explorer into a single "..." menu anchored to
   the row.
+- Remove the worktree marker icon and corner glyph from workspace tree rows;
+  indentation alone conveys the hierarchy.
 
 ## 0.4.9 - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   the row.
 - Remove the worktree marker icon and corner glyph from workspace tree rows;
   indentation alone conveys the hierarchy.
+- Spell out the linked-worktree badge as "Worktree" in the inspector.
 
 ## 0.4.9 - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Preview PDFs and workspace-local Markdown images in File Explorer.
+- Show the agent's current directory next to agents in the workspace tree.
 
 ### Changed
 
@@ -15,6 +16,7 @@
 - Remove the worktree marker icon and corner glyph from workspace tree rows;
   indentation alone conveys the hierarchy.
 - Spell out the linked-worktree badge as "Worktree" in the inspector.
+- Move the agent status icon in tabs before the tab name.
 
 ## 0.4.9 - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Present the selected file name as the preview heading and move Changes into a
   separate header toggle.
+- Move per-file actions in File Explorer into a single "..." menu anchored to
+  the row.
 
 ## 0.4.9 - 2026-08-28
 

--- a/web/src/components/FileExplorerDialog.tsx
+++ b/web/src/components/FileExplorerDialog.tsx
@@ -10,8 +10,7 @@ import {
 import {
   ChevronDown,
   ChevronRight,
-  Copy,
-  Download,
+  Ellipsis,
   File,
   Folder,
   FolderOpen,
@@ -828,6 +827,12 @@ type FileExplorerEntryMenuState = {
   entry: FileExplorerEntry;
 };
 
+// Keep ENTRY_MENU_ITEM_COUNT in sync with the items rendered in
+// FileExplorerEntryMenu; the height estimate drives clamping and flip placement.
+const ENTRY_MENU_ITEM_COUNT = 3;
+const ENTRY_MENU_WIDTH = 220;
+const ENTRY_MENU_HEIGHT = ENTRY_MENU_ITEM_COUNT * 34 + 8;
+
 function FileExplorerEntryMenu({
   state,
   onClose,
@@ -898,6 +903,7 @@ function FileExplorerEntryMenu({
 
   const { entry } = state;
   const isDirectory = entry.type === "directory";
+  // Keep ENTRY_MENU_ITEM_COUNT in sync with this array.
   const items = [
     {
       label: isDirectory ? "Download directory" : "Download file",
@@ -914,16 +920,17 @@ function FileExplorerEntryMenu({
     },
   ];
   const menuMargin = 8;
-  const menuWidth = 220;
+  const menuWidth = ENTRY_MENU_WIDTH;
   const style: React.CSSProperties = {
     position: "fixed",
+    width: `min(${ENTRY_MENU_WIDTH}px, calc(100vw - 2 * ${menuMargin}px))`,
     left: Math.max(
       menuMargin,
       Math.min(state.x, window.innerWidth - menuWidth - menuMargin),
     ),
     top: Math.max(
       menuMargin,
-      Math.min(state.y, window.innerHeight - items.length * 34 - menuMargin),
+      Math.min(state.y, window.innerHeight - ENTRY_MENU_HEIGHT - menuMargin),
     ),
     zIndex: 1000,
   };
@@ -2081,33 +2088,24 @@ function FileExplorerContent({
               type="button"
               className="ghost file-action"
               tabIndex={-1}
-              title={
-                isDirectory ? "Download directory as tar.gz" : "Download file"
-              }
+              title="File actions"
+              aria-label="File actions"
+              aria-haspopup="menu"
               onClick={(e) => {
                 e.stopPropagation();
                 e.currentTarget
                   .closest<HTMLElement>(".file-row")
                   ?.focus({ preventScroll: true });
-                downloadEntry(entry);
+                const rect = e.currentTarget.getBoundingClientRect();
+                const below = rect.bottom + 4;
+                const y =
+                  below + ENTRY_MENU_HEIGHT <= window.innerHeight - 8
+                    ? below
+                    : Math.max(8, rect.top - 4 - ENTRY_MENU_HEIGHT);
+                openEntryMenu(entry, rect.right - ENTRY_MENU_WIDTH, y);
               }}
             >
-              <Download size={14} />
-            </button>
-            <button
-              type="button"
-              className="ghost file-action"
-              tabIndex={-1}
-              title="Copy absolute path"
-              onClick={(e) => {
-                e.stopPropagation();
-                e.currentTarget
-                  .closest<HTMLElement>(".file-row")
-                  ?.focus({ preventScroll: true });
-                void copyEntryPath(entry);
-              }}
-            >
-              <Copy size={14} />
+              <Ellipsis size={14} />
             </button>
           </span>
         </div>

--- a/web/src/components/TabBar.tsx
+++ b/web/src/components/TabBar.tsx
@@ -158,12 +158,6 @@ export function TabBar({
                 }}
                 title={t.tab_id}
               >
-                <TabLongPressTarget
-                  tab={t}
-                  onOpenMenu={(x, y) => setMenu({ tab: t, x, y })}
-                >
-                  <span className="tabbar-name">{name}</span>
-                </TabLongPressTarget>
                 {agentSummary ? (
                   <span
                     className="tabbar-agent-marker"
@@ -187,6 +181,12 @@ export function TabBar({
                     ) : null}
                   </span>
                 ) : null}
+                <TabLongPressTarget
+                  tab={t}
+                  onOpenMenu={(x, y) => setMenu({ tab: t, x, y })}
+                >
+                  <span className="tabbar-name">{name}</span>
+                </TabLongPressTarget>
                 <button
                   className="tabbar-close"
                   onClick={(e) => {

--- a/web/src/components/WorkspaceAgentRows.tsx
+++ b/web/src/components/WorkspaceAgentRows.tsx
@@ -10,6 +10,7 @@ import { agentClass, basename, shortId } from "../utils";
 import { shouldShowAgentStatusLabel } from "./agentSession";
 import { AgentStatusIcon } from "./AgentStatusIcon";
 import { observeClampedContextMenu } from "./contextMenuPosition";
+import { TREE_DEPTH_INDENT } from "./treeIndent";
 
 const LONG_PRESS_MS = 550;
 const LONG_PRESS_MOVE_PX = 10;
@@ -31,6 +32,11 @@ type AgentContextMenuGroup = {
   items: AgentContextMenuItem[];
   danger?: boolean;
 };
+
+function agentLocationName(pane: Pane): string {
+  const location = pane.foreground_cwd ?? pane.cwd;
+  return location ? basename(location.replace(/\\/g, "/")) : "";
+}
 
 export function AgentRow({
   pane,
@@ -68,13 +74,18 @@ export function AgentRow({
   };
   const showStatus = shouldShowAgentStatusLabel(pane.agent_status);
   const nested = variant === "nested";
+  const locationName = agentLocationName(pane);
 
   return (
     <div
       className={`agent-row ${nested ? "is-nested" : "is-standalone"} ${
         selected ? "is-selected" : ""
       } ${pane.focused ? "is-focused" : ""}`}
-      style={nested ? { marginLeft: 12 + depth * 12 } : undefined}
+      style={
+        nested
+          ? { marginLeft: TREE_DEPTH_INDENT + depth * TREE_DEPTH_INDENT }
+          : undefined
+      }
       role={nested ? "treeitem" : "button"}
       tabIndex={nested ? (selected ? 0 : -1) : 0}
       aria-level={nested ? depth + 1 : undefined}
@@ -172,6 +183,9 @@ export function AgentRow({
               : (workspaceLabel ?? pane.workspace_id)}
             {showPaneId ? (
               <span className="muted"> · {shortId(pane.pane_id)}</span>
+            ) : null}
+            {nested && locationName ? (
+              <span className="muted"> · {locationName}</span>
             ) : null}
           </span>
           {showStatus ? (
@@ -298,10 +312,7 @@ export function AgentContextMenu({
     zIndex: 1000,
   };
   const agentName = state.pane.agent ?? "Agent";
-  const agentLocation = state.pane.foreground_cwd ?? state.pane.cwd;
-  const agentLocationName = agentLocation
-    ? basename(agentLocation.replace(/\\/g, "/"))
-    : "";
+  const locationName = agentLocationName(state.pane);
 
   return (
     <div ref={ref} className="context-menu context-menu--grouped" style={style}>
@@ -310,7 +321,7 @@ export function AgentContextMenu({
         <strong title={agentName}>{agentName}</strong>
         <small>
           {state.pane.agent_status}
-          {agentLocationName ? ` · ${agentLocationName}` : ""}
+          {locationName ? ` · ${locationName}` : ""}
         </small>
       </div>
       {groups.map((group) => (

--- a/web/src/components/WorkspaceInspectorHost.tsx
+++ b/web/src/components/WorkspaceInspectorHost.tsx
@@ -377,7 +377,7 @@ export function WorkspaceInspectorHost({
             {checkoutLabel(workspace)}
             {workspace?.worktree?.is_linked_worktree ? (
               <span className="workspace-inspector-wt" title="Linked worktree">
-                <GitFork size={11} aria-hidden="true" /> WT
+                <GitFork size={11} aria-hidden="true" /> Worktree
               </span>
             ) : null}
           </span>

--- a/web/src/components/WorkspaceTree.tsx
+++ b/web/src/components/WorkspaceTree.tsx
@@ -5,13 +5,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { ContextMenu, type ContextMenuState } from "./ContextMenu";
 import { CreateWorkspaceDialog } from "./CreateWorkspaceDialog";
 import { buildWorkspaceHierarchy, worktreeCreationSource } from "../worktree";
-import {
-  ChevronDown,
-  ChevronRight,
-  GitBranch,
-  GitFork,
-  Pin,
-} from "lucide-react";
+import { ChevronDown, ChevronRight, GitBranch, Pin } from "lucide-react";
 import { WorktreeLifecycleDialog } from "./WorktreeLifecycleDialog";
 import {
   WORKSPACE_PINS_STORAGE_KEY,
@@ -57,6 +51,7 @@ import {
   treeKeyboardAction,
   workspaceTreeItemIsTabStop,
 } from "./treeKeyboard";
+import { TREE_DEPTH_INDENT } from "./treeIndent";
 
 const LONG_PRESS_MS = 550;
 const LONG_PRESS_MOVE_PX = 10;
@@ -582,9 +577,6 @@ function WorkspaceRow({
   const collapsed =
     hasNestedItems && isWorktreeGroupCollapsed(collapsedWorktreeGroupKeys, w);
   const pinned = isWorkspacePinned(pinnedWorkspaceKeys, w);
-  const worktreeMarkerRepoName =
-    w.worktree?.is_linked_worktree === true ? w.worktree.repo_name : null;
-  const compactWorktreeMarker = isChild && !pinned;
   const isPendingFocus =
     s.pendingFocusWorkspaceId === w.workspace_id && !w.focused;
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -643,7 +635,7 @@ function WorkspaceRow({
         } ${isChild ? "is-child" : ""} ${pinned ? "is-pinned" : ""} ${
           isPendingFocus ? "is-loading" : ""
         }`}
-        style={{ paddingLeft: 6 + depth * 12 }}
+        style={{ paddingLeft: 6 + depth * TREE_DEPTH_INDENT }}
         role="treeitem"
         tabIndex={
           workspaceTreeItemIsTabStop({
@@ -754,21 +746,9 @@ function WorkspaceRow({
             {collapsed ? <ChevronRight size={13} /> : <ChevronDown size={13} />}
           </button>
         ) : (
-          <span className="twisty">{isChild ? "⌞" : " "}</span>
+          <span className="twisty" aria-hidden="true" />
         )}
         <strong className="ws-label">{workspaceDisplayName(w)}</strong>
-        {worktreeMarkerRepoName ? (
-          <span
-            className={`workspace-worktree-marker ${
-              compactWorktreeMarker ? "is-compact" : ""
-            }`}
-            title={`Linked worktree · ${worktreeMarkerRepoName}`}
-            aria-label={`Linked worktree in ${worktreeMarkerRepoName}`}
-          >
-            <GitFork size={11} aria-hidden="true" />
-            {!compactWorktreeMarker ? <span aria-hidden="true">WT</span> : null}
-          </span>
-        ) : null}
         {pinned ? (
           <Pin
             className="workspace-pin"

--- a/web/src/components/treeIndent.ts
+++ b/web/src/components/treeIndent.ts
@@ -1,0 +1,2 @@
+/** Horizontal indent per depth level in the workspace tree. */
+export const TREE_DEPTH_INDENT = 12;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6045,6 +6045,9 @@ textarea:focus {
   white-space: nowrap;
 }
 .file-actions {
+  /* Pin to the last grid track so conditional columns (git status, meta,
+     spinner) never shift the actions button horizontally. */
+  grid-column: -2 / -1;
   display: inline-flex;
   gap: 3px;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2245,35 +2245,6 @@ textarea:focus {
 .tree-row.is-child strong {
   font-weight: 500;
 }
-.workspace-worktree-marker {
-  height: 16px;
-  max-width: 34px;
-  flex: 0 1 34px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 2px;
-  padding: 0 3px;
-  border: 1px solid color-mix(in srgb, var(--accent) 38%, var(--border));
-  border-radius: 5px;
-  background: color-mix(in srgb, var(--accent-soft) 48%, transparent);
-  color: color-mix(in srgb, var(--accent) 72%, var(--text));
-  font-size: 8px;
-  font-weight: 700;
-  line-height: 14px;
-  letter-spacing: 0.02em;
-}
-.workspace-worktree-marker svg {
-  flex: 0 0 auto;
-}
-.workspace-worktree-marker.is-compact {
-  width: 14px;
-  max-width: 14px;
-  flex-basis: 14px;
-  padding: 0;
-  border-color: transparent;
-  background: transparent;
-}
 .workspace-pin {
   flex: 0 0 auto;
   color: var(--muted);


### PR DESCRIPTION
## Summary

- File Explorer rows now expose Download / Copy path / Delete through a single `...` menu. The menu has a fixed width so it stays anchored to the button, the button stays right-aligned across rows regardless of git-status letters, and the menu flips up near the viewport bottom.
- Workspace tree rows drop the worktree marker icon and the corner glyph; indentation alone conveys the worktree hierarchy. The depth indent is now a shared constant used by workspace and agent rows.
- Inspector spells out the linked-worktree badge as `Worktree`.
- Agent rows in the tree show the agent's current directory, and tabs place the agent status icon before the tab name.

## Verification

- `bun run precommit` (format, lint, typecheck, 765 unit tests)
- `bun run build:web`; verified menu anchoring and row alignment against the dev server
- Screenshots omitted to avoid exposing local workspace paths
