### PR TITLE
Add a mobile tab switcher sheet with nav badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Add a mobile tab switcher: a Tabs button with a count badge in the mobile
+  nav opens a bottom sheet for creating, switching, and closing tabs when the
+  tab strip is hidden.
 - Preview PDFs and workspace-local Markdown images in File Explorer.
 - Show the agent's current directory next to agents in the workspace tree.
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import {
   LoaderCircle,
   MoreHorizontal,
   PanelTop,
+  SquareStack,
   SquareTerminal,
   X,
 } from "lucide-react";
@@ -52,6 +53,7 @@ import {
 } from "./components/FileExplorerDialog";
 import { type ActiveFilePreviewSelection } from "./components/FilePreviewContent";
 import { GlobalTooltip } from "./components/GlobalTooltip";
+import { MobileTabSheet } from "./components/MobileTabSheet";
 import { requestCloseTab, TabBar } from "./components/TabBar";
 import { WorkspaceInspectorHost } from "./components/WorkspaceInspectorHost";
 import { WorkspaceTree } from "./components/WorkspaceTree";
@@ -1006,6 +1008,7 @@ export default function App() {
     useState<MobileTerminalSideShortcuts>(loadMobileTerminalSideShortcuts);
   const [sidebarHidden, setSidebarHidden] = useState(false);
   const [mobileControlsCollapsed, setMobileControlsCollapsed] = useState(false);
+  const [mobileTabSheetOpen, setMobileTabSheetOpen] = useState(false);
   const [paneJumpOpen, setPaneJumpOpen] = useState(false);
   const [paneJumpIndex, setPaneJumpIndex] = useState(0);
   const paneJumpCtrlDownRef = useRef(false);
@@ -1031,6 +1034,15 @@ export default function App() {
   );
   const resourceRuntimeKeyRef = useRef(resourceUiKey);
   const focusedWorkspace = s.workspaces.find((w) => w.focused);
+  const focusedWorkspaceTabCount = focusedWorkspace
+    ? s.tabs.filter((tab) => tab.workspace_id === focusedWorkspace.workspace_id)
+        .length
+    : 0;
+  useEffect(() => {
+    // Drop the sheet when its context disappears so it cannot resurface
+    // unprompted on the next mobile layout or focused workspace.
+    if (!mobile || !focusedWorkspace) setMobileTabSheetOpen(false);
+  }, [mobile, focusedWorkspace]);
   const activePaneId = activePaneIdForSnapshot(s);
   const activePane = activePaneId
     ? s.panes.find((pane) => pane.pane_id === activePaneId)
@@ -2377,6 +2389,24 @@ export default function App() {
         </button>
         <button
           type="button"
+          className={mobileTabSheetOpen ? "active" : ""}
+          title="Tabs"
+          aria-label="Show tabs"
+          aria-pressed={mobileTabSheetOpen}
+          tabIndex={mobileControlsCollapsed ? -1 : 0}
+          disabled={!focusedWorkspace}
+          onClick={() => setMobileTabSheetOpen((value) => !value)}
+        >
+          <SquareStack size={16} />
+          {focusedWorkspaceTabCount > 0 ? (
+            <span className="mobile-nav-badge" aria-hidden="true">
+              {focusedWorkspaceTabCount}
+            </span>
+          ) : null}
+          <span className="mobile-nav-label">Tabs</span>
+        </button>
+        <button
+          type="button"
           className={mobileView === "files" ? "active" : ""}
           title="Files"
           aria-label="Show workspace files"
@@ -2415,6 +2445,11 @@ export default function App() {
           <span className="mobile-nav-label">History</span>
         </button>
       </nav>
+      <MobileTabSheet
+        open={mobile && mobileTabSheetOpen}
+        onClose={() => setMobileTabSheetOpen(false)}
+        onShowSession={activateTerminalSurface}
+      />
       <button
         type="button"
         className={`mobile-workspace-shortcut ${

--- a/web/src/components/MobileTabSheet.tsx
+++ b/web/src/components/MobileTabSheet.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import { Plus, X } from "lucide-react";
+import { shallowEqual, store, useStoreSelector } from "../store";
+import { AgentStatusIcon } from "./AgentStatusIcon";
+import { CloseButton } from "./CloseButton";
+import { summarizeTabAgents } from "./agentSession";
+import { focusDialogElement } from "./dialogFocus";
+import { requestCloseTab, tabName } from "./TabBar";
+
+/**
+ * Bottom-sheet tab switcher for narrow layouts. The tab strip hides itself on
+ * mobile when a workspace has a single tab, so this sheet is the touch
+ * affordance for creating, switching, and closing tabs there.
+ */
+export function MobileTabSheet({
+  open,
+  onClose,
+  onShowSession,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onShowSession: () => void;
+}) {
+  const s = useStoreSelector(
+    (state) => ({
+      panes: state.panes,
+      tabs: state.tabs,
+      workspaces: state.workspaces,
+    }),
+    shallowEqual,
+  );
+  const sheetRef = useRef<HTMLDivElement>(null);
+  const onCloseRef = useRef(onClose);
+
+  onCloseRef.current = onClose;
+
+  const focusedWs = s.workspaces.find((w) => w.focused);
+  const tabs = focusedWs
+    ? s.tabs
+        .filter((t) => t.workspace_id === focusedWs.workspace_id)
+        .sort((a, b) => a.number - b.number)
+    : [];
+
+  useEffect(() => {
+    if (!open) return;
+    const cancelFocus = focusDialogElement(sheetRef.current);
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      // Let stacked dialogs (e.g. the close-tab confirmation) handle Escape.
+      if (
+        document.querySelector(
+          ".modal-backdrop:not(.mobile-tab-sheet-backdrop)",
+        )
+      )
+        return;
+      event.preventDefault();
+      event.stopPropagation();
+      onCloseRef.current();
+    };
+    window.addEventListener("keydown", onKeyDown, { capture: true });
+    return () => {
+      cancelFocus();
+      window.removeEventListener("keydown", onKeyDown, { capture: true });
+    };
+  }, [open]);
+
+  if (!open || !focusedWs) return null;
+
+  return createPortal(
+    <div
+      className="modal-backdrop mobile-tab-sheet-backdrop"
+      onMouseDown={onClose}
+    >
+      <div
+        ref={sheetRef}
+        className="mobile-tab-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Tabs"
+        tabIndex={-1}
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div className="mobile-tab-sheet-head">
+          <h3>Tabs</h3>
+          <CloseButton label="Close tab switcher" onClick={onClose} />
+        </div>
+        <div className="mobile-tab-sheet-list" role="list">
+          {tabs.map((t) => {
+            const name = tabName(t);
+            const agentSummary = summarizeTabAgents(s.panes, t.tab_id);
+            return (
+              <div
+                key={t.tab_id}
+                role="listitem"
+                className={`mobile-tab-sheet-row ${t.focused ? "is-active" : ""}`}
+              >
+                <button
+                  type="button"
+                  className="mobile-tab-sheet-focus"
+                  onClick={() => {
+                    store.focusTab(t.tab_id);
+                    onClose();
+                    onShowSession();
+                  }}
+                >
+                  {agentSummary ? (
+                    <span
+                      className="tabbar-agent-marker"
+                      aria-label={`${agentSummary.primaryAgent}, status ${agentSummary.status}`}
+                    >
+                      <AgentStatusIcon
+                        agent={agentSummary.primaryAgent}
+                        status={agentSummary.status}
+                      />
+                      {agentSummary.additionalAgents > 0 ? (
+                        <span className="tabbar-agent-more">
+                          +{agentSummary.additionalAgents}
+                        </span>
+                      ) : null}
+                    </span>
+                  ) : null}
+                  <span className="mobile-tab-sheet-name">{name}</span>
+                </button>
+                <button
+                  type="button"
+                  className="mobile-tab-sheet-close"
+                  aria-label={`Close ${name}`}
+                  title={`Close ${name}`}
+                  onClick={() => requestCloseTab(t.tab_id)}
+                >
+                  <X size={14} />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+        <button
+          type="button"
+          className="mobile-tab-sheet-new"
+          onClick={() => {
+            store.createTab(focusedWs.workspace_id);
+            onClose();
+            onShowSession();
+          }}
+        >
+          <Plus size={15} />
+          <span>New Tab</span>
+        </button>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/web/src/components/TabBar.tsx
+++ b/web/src/components/TabBar.tsx
@@ -17,7 +17,7 @@ interface TabMenuState {
   y: number;
 }
 
-function tabName(tab?: Tab) {
+export function tabName(tab?: Tab) {
   if (!tab) return "";
   return tab.label && tab.label !== String(tab.number)
     ? tab.label

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7846,6 +7846,7 @@ textarea:focus {
     backdrop-filter: blur(14px);
   }
   .mobile-nav button {
+    position: relative;
     width: 32px;
     min-width: 32px;
     height: 32px;
@@ -7876,6 +7877,113 @@ textarea:focus {
     color: var(--muted);
     opacity: 0.38;
     cursor: default;
+  }
+  .mobile-nav-badge {
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    min-width: 15px;
+    height: 15px;
+    padding: 0 4px;
+    border-radius: 999px;
+    background: var(--text-strong);
+    color: var(--panel);
+    font-size: 9px;
+    font-weight: 800;
+    line-height: 15px;
+    text-align: center;
+    pointer-events: none;
+  }
+  .mobile-tab-sheet-backdrop {
+    align-items: flex-end;
+    justify-content: center;
+    padding: 0;
+  }
+  .mobile-tab-sheet {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 100%;
+    max-height: min(62dvh, 430px);
+    padding: 12px 12px calc(12px + env(safe-area-inset-bottom, 0px));
+    background: var(--panel);
+    border-top: 1px solid var(--border);
+    border-radius: 16px 16px 0 0;
+    box-shadow: var(--shadow-lg);
+    outline: none;
+  }
+  .mobile-tab-sheet-head {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .mobile-tab-sheet-head h3 {
+    margin: 0;
+    font-size: 14px;
+  }
+  .mobile-tab-sheet-list {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: 4px;
+    min-height: 0;
+    overflow-y: auto;
+  }
+  .mobile-tab-sheet-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+  .mobile-tab-sheet-focus {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 9px 10px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--bg);
+    color: var(--text);
+    font-size: 13px;
+    text-align: left;
+  }
+  .mobile-tab-sheet-row.is-active .mobile-tab-sheet-focus {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+    color: var(--text-strong);
+  }
+  .mobile-tab-sheet-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .mobile-tab-sheet-close {
+    width: 34px;
+    height: 34px;
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: transparent;
+    color: var(--muted);
+  }
+  .mobile-tab-sheet-new {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 10px;
+    border: 1px dashed var(--border);
+    border-radius: 10px;
+    background: transparent;
+    color: var(--text-strong);
+    font-size: 13px;
   }
   .mobile-workspace-shortcut {
     position: fixed;


### PR DESCRIPTION
## Summary

- Add a Tabs button with a count badge to the mobile nav. It opens a bottom-sheet tab switcher for creating, switching, and closing tabs, so single-tab workspaces can create tabs while the tab strip is hidden on mobile.
- Tab rows show the existing agent status markers; closing a tab routes through the existing close confirmation dialog.
- Selecting or creating a tab dismisses the sheet and returns to the session view.

## Verification

- `bun run format:check`, `bun run lint`, `bun run typecheck`, `bun run test` (765 pass)
- `bun run build:web`
- Manual: in a mobile viewport (max-width 768px) with a single-tab workspace, open Tabs from the mobile nav and tap New Tab; close a tab from the sheet and confirm the standard Close Tab dialog appears and keeps keyboard focus.