### PR TITLE
Grant pull-requests write to the label workflow

### DIFF
--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -7,7 +7,9 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  # Labeling a pull request through the issues endpoint requires pull-requests
+  # write; issues write alone is rejected with HTTP 403.
+  pull-requests: write
 
 jobs:
   label:


### PR DESCRIPTION
## Summary

- The label workflow fails on newly opened, unlabeled PRs: the POST to the issues labels endpoint returns HTTP 403 (Resource not accessible by integration). Labeling a pull request via that endpoint requires pull-requests write; issues write alone is not sufficient.
- Widen the workflow token to pull-requests: write and document the reason inline.

## Verification

- Replay: merge, then rerun the failed job on #67 — it should apply the release-note label (or keep the manually applied one) and pass.