### PR TITLE
Add mobile terminal composer for reliable IME input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### Added
+
+- Add a mobile terminal composer: a pen toggle opens a bottom-docked panel
+  that also hosts the configurable terminal shortcut keys alongside an editor
+  where IME, dictation, selection editing, and multiline paste work natively.
+  Insert places the draft in the terminal without executing; Send adds
+  exactly one Enter. Drafts stay in memory per connection and pane and are
+  never persisted.
+- Add image support to the mobile composer: pasted clipboard images and the
+  image picker upload once through the existing endpoint and insert the
+  returned path at the caret; the path reaches the terminal only on Insert or
+  Send.
+- Warn before closing a pane, tab, or workspace that still holds an unsent
+  composer draft; confirming discards the draft.
+
 ## 0.4.10 - 2026-08-29
 
 ### Added

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import {
   LoaderCircle,
   MoreHorizontal,
   PanelTop,
+  SquarePen,
   SquareStack,
   SquareTerminal,
   X,
@@ -37,7 +38,6 @@ import {
 import { AgentIcon } from "./components/AgentIcon";
 import { paneHasAgentHistory } from "./components/agentSession";
 import { CloseButton } from "./components/CloseButton";
-import { clearDiffContentResourceState } from "./components/diffContentState";
 import { CommandCombobox } from "./components/CommandCombobox";
 import { CONFIG_MENU_ID, ConfigMenu } from "./components/ConfigMenu";
 import { ConnectionSwitcher } from "./components/ConnectionSwitcher";
@@ -46,6 +46,7 @@ import {
   clearDiffViewerResourceCache,
   prefetchDiffViewerWorkspace,
 } from "./components/DiffViewerPanel";
+import { clearDiffContentResourceState } from "./components/diffContentState";
 import {
   clearFileExplorerResourceCache,
   prefetchFileExplorerWorkspace,
@@ -55,9 +56,9 @@ import { type ActiveFilePreviewSelection } from "./components/FilePreviewContent
 import { GlobalTooltip } from "./components/GlobalTooltip";
 import { MobileTabSheet } from "./components/MobileTabSheet";
 import { requestCloseTab, TabBar } from "./components/TabBar";
+import type { TerminalWorkspaceFileRequest } from "./components/TerminalView";
 import { WorkspaceInspectorHost } from "./components/WorkspaceInspectorHost";
 import { WorkspaceTree } from "./components/WorkspaceTree";
-import type { TerminalWorkspaceFileRequest } from "./components/TerminalView";
 import { isIosDevice } from "./downloadFile";
 import {
   LEGACY_MOBILE_TERMINAL_SHORTCUTS_STORAGE_KEY,
@@ -91,34 +92,40 @@ import {
 } from "./store";
 import { adjacentTabId, tabShortcutAction } from "./tabShortcuts";
 import { copyTextFromUserGesture } from "./terminalClipboard";
+import {
+  activateTerminalComposerDraftScope,
+  readTerminalComposerDraft,
+  subscribeTerminalComposerDraft,
+  terminalComposerDraftKey,
+} from "./terminalComposer";
 import { terminalMountKey } from "./terminalConnection";
 import type { FileExplorerEntry, Pane } from "./types";
 import {
   connectionClientScopeKey,
   useConnectionClient,
 } from "./useConnectionClient";
+import { agentClass } from "./utils";
 import {
-  inspectorMaximumSize,
-  isWorkspaceInspectorShortcut,
   INSPECTOR_MIN_BOTTOM,
   INSPECTOR_MIN_RIGHT,
+  type InspectorDock,
+  type InspectorView,
+  inspectorMaximumSize,
+  isWorkspaceInspectorShortcut,
   readInspectorPreferences,
   readResourceFileSelection,
   relativePathWithinCheckout,
+  resolveWorkspaceForScope,
   resourceOwnerKey,
   resourceScopeForWorkspace,
   resourceStateKey,
-  resolveWorkspaceForScope,
   sameResourceOwner,
-  writeInspectorPreferences,
-  writeResourceFileSelection,
-  type InspectorDock,
-  type InspectorView,
   WORKSPACE_INSPECTOR_REQUEST_EVENT,
   type WorkspaceInspectorRequest,
   type WorkspaceInspectorState,
+  writeInspectorPreferences,
+  writeResourceFileSelection,
 } from "./workspaceResource";
-import { agentClass } from "./utils";
 
 const MIN_SIDEBAR = 180;
 const MAX_SIDEBAR = 560;
@@ -136,6 +143,8 @@ type TerminalViewProps = {
   showMobileKeys?: boolean;
   mobileShortcuts?: MobileTerminalShortcutRows;
   mobileSideShortcuts?: MobileTerminalSideShortcuts;
+  composerOpen?: boolean;
+  onComposerOpenChange?: (open: boolean) => void;
   agentHistoryOpen?: boolean;
   onAgentHistoryOpenChange?: (open: boolean) => void;
   onOpenWorkspaceFile?: (request: TerminalWorkspaceFileRequest) => void;
@@ -469,6 +478,14 @@ function isEditableElement(target: EventTarget | null) {
   return target.isContentEditable;
 }
 
+function blurActiveInput(event: React.PointerEvent<HTMLButtonElement>) {
+  if (document.activeElement instanceof HTMLElement) {
+    document.activeElement.blur();
+  }
+  const button = event.currentTarget;
+  window.setTimeout(() => button.blur(), 0);
+}
+
 function tabShortcutIndex(e: KeyboardEvent) {
   if (!e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return null;
   if (/^[1-9]$/.test(e.key)) return Number(e.key) - 1;
@@ -723,12 +740,16 @@ function resizeTargetForSplit(
 function TerminalPaneLayout({
   mobileShortcuts,
   mobileSideShortcuts,
+  composerOpen,
+  onComposerOpenChange,
   agentHistoryOpen,
   onAgentHistoryOpenChange,
   onOpenWorkspaceFile,
 }: {
   mobileShortcuts: MobileTerminalShortcutRows;
   mobileSideShortcuts: MobileTerminalSideShortcuts;
+  composerOpen: boolean;
+  onComposerOpenChange: (open: boolean) => void;
   agentHistoryOpen: boolean;
   onAgentHistoryOpenChange: (open: boolean) => void;
   onOpenWorkspaceFile: (request: TerminalWorkspaceFileRequest) => void;
@@ -775,6 +796,8 @@ function TerminalPaneLayout({
         key={mountKeyForPane(activePaneId)}
         mobileShortcuts={mobileShortcuts}
         mobileSideShortcuts={mobileSideShortcuts}
+        composerOpen={composerOpen}
+        onComposerOpenChange={onComposerOpenChange}
         agentHistoryOpen={agentHistoryOpen}
         onAgentHistoryOpenChange={onAgentHistoryOpenChange}
         onOpenWorkspaceFile={onOpenWorkspaceFile}
@@ -792,12 +815,6 @@ function TerminalPaneLayout({
         (activeIndex - 1 + visiblePanes.length) % visiblePanes.length
       ];
     const nextPane = visiblePanes[(activeIndex + 1) % visiblePanes.length];
-    const blurActiveInput = () => {
-      if (document.activeElement instanceof HTMLElement) {
-        document.activeElement.blur();
-      }
-    };
-
     return (
       <div className="pane-switcher-layout" aria-label="Terminal pane switcher">
         <div className="pane-switcher">
@@ -833,6 +850,8 @@ function TerminalPaneLayout({
           paneId={activePaneId}
           mobileShortcuts={mobileShortcuts}
           mobileSideShortcuts={mobileSideShortcuts}
+          composerOpen={composerOpen}
+          onComposerOpenChange={onComposerOpenChange}
           agentHistoryOpen={agentHistoryOpen}
           onAgentHistoryOpenChange={onAgentHistoryOpenChange}
           onOpenWorkspaceFile={onOpenWorkspaceFile}
@@ -935,6 +954,8 @@ function TerminalPaneLayout({
               showMobileKeys={isActive}
               mobileShortcuts={mobileShortcuts}
               mobileSideShortcuts={mobileSideShortcuts}
+              composerOpen={isActive ? composerOpen : false}
+              onComposerOpenChange={isActive ? onComposerOpenChange : undefined}
               agentHistoryOpen={isActive ? agentHistoryOpen : false}
               onAgentHistoryOpenChange={onAgentHistoryOpenChange}
               onOpenWorkspaceFile={onOpenWorkspaceFile}
@@ -975,6 +996,8 @@ function TerminalPaneLayout({
 export default function App() {
   const s = useStoreSelector(
     (state) => ({
+      activeConnectionId: state.activeConnectionId,
+      connectionGeneration: state.connectionGeneration,
       lastRefresh: state.lastRefresh,
       layout: state.layout,
       notice: state.notice,
@@ -993,6 +1016,12 @@ export default function App() {
   const connectionClient = useConnectionClient();
   useVisualViewportCssVars();
   const mobile = useMobileLayout();
+  useEffect(() => {
+    activateTerminalComposerDraftScope(
+      s.activeConnectionId,
+      s.connectionGeneration,
+    );
+  }, [s.activeConnectionId, s.connectionGeneration]);
   const [sidebarWidth, setSidebarWidth] = useState(loadSidebarWidth);
   const [mobileView, setMobileView] = useState<MobileView>("session");
   const [theme, setTheme] = useState<Theme>(() => loadTheme());
@@ -1009,6 +1038,10 @@ export default function App() {
   const [sidebarHidden, setSidebarHidden] = useState(false);
   const [mobileControlsCollapsed, setMobileControlsCollapsed] = useState(false);
   const [mobileTabSheetOpen, setMobileTabSheetOpen] = useState(false);
+  const [openTerminalComposerDraftKey, setOpenTerminalComposerDraftKey] =
+    useState<string | null>(null);
+  const [terminalComposerHasDraft, setTerminalComposerHasDraft] =
+    useState(false);
   const [paneJumpOpen, setPaneJumpOpen] = useState(false);
   const [paneJumpIndex, setPaneJumpIndex] = useState(0);
   const paneJumpCtrlDownRef = useRef(false);
@@ -1039,14 +1072,47 @@ export default function App() {
         .length
     : 0;
   useEffect(() => {
-    // Drop the sheet when its context disappears so it cannot resurface
-    // unprompted on the next mobile layout or focused workspace.
+    // Drop mobile-only controls when their context disappears so they cannot
+    // stay active invisibly or resurface when the mobile layout returns.
     if (!mobile || !focusedWorkspace) setMobileTabSheetOpen(false);
+    if (!mobile) setOpenTerminalComposerDraftKey(null);
   }, [mobile, focusedWorkspace]);
   const activePaneId = activePaneIdForSnapshot(s);
   const activePane = activePaneId
     ? s.panes.find((pane) => pane.pane_id === activePaneId)
     : undefined;
+  const activeTerminalComposerDraftKey =
+    activePaneId && activePane?.terminal_id
+      ? terminalComposerDraftKey(
+          s.activeConnectionId,
+          s.connectionGeneration,
+          activePaneId,
+        )
+      : null;
+  const terminalComposerOpen =
+    mobile &&
+    activeTerminalComposerDraftKey !== null &&
+    openTerminalComposerDraftKey === activeTerminalComposerDraftKey;
+  const setTerminalComposerOpen = useCallback(
+    (open: boolean) => {
+      setOpenTerminalComposerDraftKey(
+        open ? activeTerminalComposerDraftKey : null,
+      );
+    },
+    [activeTerminalComposerDraftKey],
+  );
+  useEffect(() => {
+    if (!activeTerminalComposerDraftKey) {
+      setTerminalComposerHasDraft(false);
+      return;
+    }
+    const update = (draft: string) => setTerminalComposerHasDraft(draft !== "");
+    update(readTerminalComposerDraft(activeTerminalComposerDraftKey));
+    return subscribeTerminalComposerDraft(
+      activeTerminalComposerDraftKey,
+      update,
+    );
+  }, [activeTerminalComposerDraftKey]);
   const paneJumpOptions = useMemo(
     () =>
       paneJumpEntries(
@@ -2389,24 +2455,6 @@ export default function App() {
         </button>
         <button
           type="button"
-          className={mobileTabSheetOpen ? "active" : ""}
-          title="Tabs"
-          aria-label="Show tabs"
-          aria-pressed={mobileTabSheetOpen}
-          tabIndex={mobileControlsCollapsed ? -1 : 0}
-          disabled={!focusedWorkspace}
-          onClick={() => setMobileTabSheetOpen((value) => !value)}
-        >
-          <SquareStack size={16} />
-          {focusedWorkspaceTabCount > 0 ? (
-            <span className="mobile-nav-badge" aria-hidden="true">
-              {focusedWorkspaceTabCount}
-            </span>
-          ) : null}
-          <span className="mobile-nav-label">Tabs</span>
-        </button>
-        <button
-          type="button"
           className={mobileView === "files" ? "active" : ""}
           title="Files"
           aria-label="Show workspace files"
@@ -2460,32 +2508,105 @@ export default function App() {
         aria-pressed={mobileView === "workspaces"}
         aria-hidden={mobileControlsCollapsed}
         tabIndex={mobileControlsCollapsed ? -1 : 0}
+        onPointerDown={blurActiveInput}
         onClick={openWorkspaces}
       >
         <PanelTop size={17} />
       </button>
-      <button
-        type="button"
-        className="mobile-controls-toggle"
-        aria-label={
-          mobileControlsCollapsed
-            ? "Show mobile controls"
-            : "Hide mobile controls"
-        }
-        title={
-          mobileControlsCollapsed
-            ? "Show mobile controls"
-            : "Hide mobile controls"
-        }
-        aria-pressed={mobileControlsCollapsed}
-        onClick={() => setMobileControlsCollapsed((value) => !value)}
-      >
-        {mobileControlsCollapsed ? (
-          <MoreHorizontal size={17} />
-        ) : (
-          <X size={17} />
-        )}
-      </button>
+      <div className="mobile-terminal-controls">
+        <nav
+          className="mobile-nav mobile-terminal-tools"
+          aria-label={
+            activeTerminalComposerDraftKey
+              ? "Tabs and terminal composer"
+              : "Tabs"
+          }
+          aria-hidden={mobileControlsCollapsed}
+        >
+          <button
+            type="button"
+            className={mobileTabSheetOpen ? "active" : ""}
+            title="Tabs"
+            aria-label="Show tabs"
+            aria-pressed={mobileTabSheetOpen}
+            tabIndex={mobileControlsCollapsed ? -1 : 0}
+            disabled={!focusedWorkspace}
+            onPointerDown={blurActiveInput}
+            onClick={() => {
+              const open = !mobileTabSheetOpen;
+              setMobileTabSheetOpen(open);
+              if (open) setTerminalComposerOpen(false);
+            }}
+          >
+            <SquareStack size={16} />
+            {focusedWorkspaceTabCount > 0 ? (
+              <span className="mobile-nav-badge" aria-hidden="true">
+                {focusedWorkspaceTabCount}
+              </span>
+            ) : null}
+            <span className="mobile-nav-label">Tabs</span>
+          </button>
+          {activeTerminalComposerDraftKey ? (
+            <button
+              type="button"
+              className={terminalComposerOpen ? "active" : ""}
+              title={
+                terminalComposerOpen
+                  ? "Close terminal composer"
+                  : "Open terminal composer"
+              }
+              aria-label={`${
+                terminalComposerOpen
+                  ? "Close terminal composer"
+                  : "Open terminal composer"
+              }${terminalComposerHasDraft ? ", unsent draft" : ""}`}
+              aria-pressed={terminalComposerOpen}
+              tabIndex={mobileControlsCollapsed ? -1 : 0}
+              onPointerDown={blurActiveInput}
+              onClick={() => {
+                const open = !terminalComposerOpen;
+                if (open) {
+                  setMobileTabSheetOpen(false);
+                  activateTerminalSurface();
+                }
+                setTerminalComposerOpen(open);
+              }}
+            >
+              <SquarePen size={16} />
+              {terminalComposerHasDraft && !terminalComposerOpen ? (
+                <span
+                  className="mobile-composer-draft-dot"
+                  aria-hidden="true"
+                />
+              ) : null}
+              <span className="mobile-nav-label">Composer</span>
+            </button>
+          ) : null}
+        </nav>
+        <button
+          type="button"
+          className="mobile-controls-toggle"
+          aria-label={
+            mobileControlsCollapsed
+              ? "Show mobile controls"
+              : "Hide mobile controls"
+          }
+          title={
+            mobileControlsCollapsed
+              ? "Show mobile controls"
+              : "Hide mobile controls"
+          }
+          aria-pressed={mobileControlsCollapsed}
+          onPointerDown={blurActiveInput}
+          onClick={() => setMobileControlsCollapsed((value) => !value)}
+        >
+          {mobileControlsCollapsed ? (
+            <MoreHorizontal size={17} />
+          ) : (
+            <X size={17} />
+          )}
+        </button>
+      </div>
 
       {s.updateInfo?.update_available || s.notice ? (
         <div className="toast-viewport" aria-live="polite">
@@ -2626,6 +2747,8 @@ export default function App() {
               <TerminalPaneLayout
                 mobileShortcuts={mobileTerminalShortcuts}
                 mobileSideShortcuts={mobileTerminalSideShortcuts}
+                composerOpen={terminalComposerOpen}
+                onComposerOpenChange={setTerminalComposerOpen}
                 agentHistoryOpen={agentHistoryOpen}
                 onAgentHistoryOpenChange={setAgentHistoryInspectorOpen}
                 onOpenWorkspaceFile={handleTerminalWorkspaceFile}

--- a/web/src/components/CommandCombobox.tsx
+++ b/web/src/components/CommandCombobox.tsx
@@ -19,6 +19,11 @@ import {
   X,
 } from "lucide-react";
 import { shallowEqual, store, useStoreSelector } from "../store";
+import {
+  clearTerminalComposerDrafts,
+  terminalComposerCloseWarning,
+  terminalComposerDraftPaneIds,
+} from "../terminalComposer";
 import type { FileExplorerEntry, Pane, Tab, Workspace } from "../types";
 import { basename, shortId } from "../utils";
 import { luckyWorktreeBranchName } from "../luckyName";
@@ -236,6 +241,8 @@ export function CommandCombobox({
 }) {
   const s = useStoreSelector(
     (state) => ({
+      activeConnectionId: state.activeConnectionId,
+      connectionGeneration: state.connectionGeneration,
       layout: state.layout,
       panes: state.panes,
       selectedPaneId: state.selectedPaneId,
@@ -265,6 +272,21 @@ export function CommandCombobox({
   const [pendingClosePane, setPendingClosePane] = useState<Pane | null>(null);
   const [pendingRemoveWorktree, setPendingRemoveWorktree] =
     useState<Workspace | null>(null);
+
+  const composerDraftWarningFor = (paneIds: string[]) =>
+    terminalComposerCloseWarning(
+      terminalComposerDraftPaneIds(
+        s.activeConnectionId,
+        s.connectionGeneration,
+        paneIds,
+      ).length,
+    );
+  const clearComposerDraftsFor = (paneIds: string[]) =>
+    clearTerminalComposerDrafts(
+      s.activeConnectionId,
+      s.connectionGeneration,
+      paneIds,
+    );
 
   const focusedWorkspace = s.workspaces.find((w) => w.focused);
   const activeTab =
@@ -1027,7 +1049,14 @@ export function CommandCombobox({
         title="Close Workspace"
         message={
           pendingCloseWorkspace
-            ? `Close workspace "${workspaceName(pendingCloseWorkspace)}"?`
+            ? `Close workspace "${workspaceName(pendingCloseWorkspace)}"?${composerDraftWarningFor(
+                s.panes
+                  .filter(
+                    (pane) =>
+                      pane.workspace_id === pendingCloseWorkspace.workspace_id,
+                  )
+                  .map((pane) => pane.pane_id),
+              )}`
             : "Close this workspace?"
         }
         confirmLabel="Close"
@@ -1035,6 +1064,14 @@ export function CommandCombobox({
         onClose={() => setPendingCloseWorkspace(null)}
         onConfirm={() => {
           if (pendingCloseWorkspace) {
+            clearComposerDraftsFor(
+              s.panes
+                .filter(
+                  (pane) =>
+                    pane.workspace_id === pendingCloseWorkspace.workspace_id,
+                )
+                .map((pane) => pane.pane_id),
+            );
             store.closeWorkspace(pendingCloseWorkspace.workspace_id);
           }
         }}
@@ -1044,14 +1081,25 @@ export function CommandCombobox({
         title="Close Tab"
         message={
           pendingCloseTab
-            ? `Close "${tabName(pendingCloseTab)}"?`
+            ? `Close "${tabName(pendingCloseTab)}"?${composerDraftWarningFor(
+                s.panes
+                  .filter((pane) => pane.tab_id === pendingCloseTab.tab_id)
+                  .map((pane) => pane.pane_id),
+              )}`
             : "Close this tab?"
         }
         confirmLabel="Close"
         danger
         onClose={() => setPendingCloseTab(null)}
         onConfirm={() => {
-          if (pendingCloseTab) store.closeTab(pendingCloseTab.tab_id);
+          if (pendingCloseTab) {
+            clearComposerDraftsFor(
+              s.panes
+                .filter((pane) => pane.tab_id === pendingCloseTab.tab_id)
+                .map((pane) => pane.pane_id),
+            );
+            store.closeTab(pendingCloseTab.tab_id);
+          }
         }}
       />
       <ConfirmDialog
@@ -1059,14 +1107,19 @@ export function CommandCombobox({
         title="Close Pane"
         message={
           pendingClosePane
-            ? `Close pane "${shortId(pendingClosePane.pane_id)}"?`
+            ? `Close pane "${shortId(pendingClosePane.pane_id)}"?${composerDraftWarningFor(
+                [pendingClosePane.pane_id],
+              )}`
             : "Close this pane?"
         }
         confirmLabel="Close"
         danger
         onClose={() => setPendingClosePane(null)}
         onConfirm={() => {
-          if (pendingClosePane) store.closePane(pendingClosePane.pane_id);
+          if (pendingClosePane) {
+            clearComposerDraftsFor([pendingClosePane.pane_id]);
+            store.closePane(pendingClosePane.pane_id);
+          }
         }}
       />
       <ConfirmDialog

--- a/web/src/components/ContextMenu.tsx
+++ b/web/src/components/ContextMenu.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { Workspace } from "../types";
 import { store, useStoreSelector } from "../store";
+import {
+  clearTerminalComposerDrafts,
+  terminalComposerCloseWarning,
+  terminalComposerDraftPaneIds,
+} from "../terminalComposer";
 import { luckyWorktreeBranchName } from "../luckyName";
 import { ConfirmDialog, TextInputDialog } from "./ModalDialogs";
 import { WorktreeHooksDialog } from "./WorktreeHooksDialog";
@@ -69,6 +74,13 @@ export function ContextMenu({
   onClose: () => void;
 }) {
   const workspaces = useStoreSelector((state) => state.workspaces);
+  const activeConnectionId = useStoreSelector(
+    (state) => state.activeConnectionId,
+  );
+  const connectionGeneration = useStoreSelector(
+    (state) => state.connectionGeneration,
+  );
+  const panes = useStoreSelector((state) => state.panes);
   const ref = useRef<HTMLDivElement>(null);
   const [dialog, setDialog] = useState<DialogState | null>(null);
   const [openWorktreeWorkspaceId, setOpenWorktreeWorkspaceId] = useState<
@@ -177,7 +189,15 @@ export function ContextMenu({
         title="Close Workspace"
         message={
           dialog?.type === "close-workspace"
-            ? `Close workspace "${dialog.label}"?`
+            ? `Close workspace "${dialog.label}"?${terminalComposerCloseWarning(
+                terminalComposerDraftPaneIds(
+                  activeConnectionId,
+                  connectionGeneration,
+                  panes
+                    .filter((pane) => pane.workspace_id === dialog.workspaceId)
+                    .map((pane) => pane.pane_id),
+                ).length,
+              )}`
             : ""
         }
         confirmLabel="Close"
@@ -185,6 +205,13 @@ export function ContextMenu({
         onClose={() => setDialog(null)}
         onConfirm={() => {
           if (dialog?.type === "close-workspace") {
+            clearTerminalComposerDrafts(
+              activeConnectionId,
+              connectionGeneration,
+              panes
+                .filter((pane) => pane.workspace_id === dialog.workspaceId)
+                .map((pane) => pane.pane_id),
+            );
             store.closeWorkspace(dialog.workspaceId);
           }
         }}

--- a/web/src/components/TabBar.tsx
+++ b/web/src/components/TabBar.tsx
@@ -5,6 +5,11 @@ import { PanelRight } from "lucide-react";
 import type { Tab } from "../types";
 import { AgentStatusIcon } from "./AgentStatusIcon";
 import { ConfirmDialog, TextInputDialog } from "./ModalDialogs";
+import {
+  clearTerminalComposerDrafts,
+  terminalComposerCloseWarning,
+  terminalComposerDraftPaneIds,
+} from "../terminalComposer";
 import { summarizeTabAgents } from "./agentSession";
 
 const LONG_PRESS_MS = 550;
@@ -50,6 +55,8 @@ export function TabBar({
 }) {
   const s = useStoreSelector(
     (state) => ({
+      activeConnectionId: state.activeConnectionId,
+      connectionGeneration: state.connectionGeneration,
       panes: state.panes,
       tabs: state.tabs,
       workspaces: state.workspaces,
@@ -67,6 +74,16 @@ export function TabBar({
     .sort((a, b) => a.number - b.number);
   const pendingCloseTab = s.tabs.find((t) => t.tab_id === pendingCloseTabId);
   const pendingCloseTabName = tabName(pendingCloseTab);
+  const pendingCloseTabPaneIds = s.panes
+    .filter((pane) => pane.tab_id === pendingCloseTabId)
+    .map((pane) => pane.pane_id);
+  const pendingCloseDraftWarning = terminalComposerCloseWarning(
+    terminalComposerDraftPaneIds(
+      s.activeConnectionId,
+      s.connectionGeneration,
+      pendingCloseTabPaneIds,
+    ).length,
+  );
   const showTabStrip = !!focusedWs && (!mobile || tabs.length > 1);
   const gitStatus = focusedWs?.worktree?.git_status;
   const changedCount = gitStatus
@@ -105,16 +122,23 @@ export function TabBar({
       <ConfirmDialog
         open={!!pendingCloseTabId}
         title="Close Tab"
-        message={
+        message={`${
           pendingCloseTabName
             ? `Close "${pendingCloseTabName}"?`
             : "Close this tab?"
-        }
+        }${pendingCloseDraftWarning}`}
         confirmLabel="Close"
         danger
         onClose={() => setPendingCloseTabId(null)}
         onConfirm={() => {
-          if (pendingCloseTabId) store.closeTab(pendingCloseTabId);
+          if (pendingCloseTabId) {
+            clearTerminalComposerDrafts(
+              s.activeConnectionId,
+              s.connectionGeneration,
+              pendingCloseTabPaneIds,
+            );
+            store.closeTab(pendingCloseTabId);
+          }
         }}
       />
       <TextInputDialog

--- a/web/src/components/TerminalComposer.tsx
+++ b/web/src/components/TerminalComposer.tsx
@@ -1,15 +1,38 @@
-import { useEffect, useRef, useState, type CSSProperties } from "react";
-import { CornerDownLeft, CornerDownRight, ImagePlus, X } from "lucide-react";
 import {
-  clearTerminalComposerDraft,
-  readTerminalComposerDraft,
-  terminalComposerInsertAtCaret,
-  writeTerminalComposerDraft,
-} from "../terminalComposer";
+  CircleHelp,
+  CornerDownLeft,
+  CornerDownRight,
+  ImagePlus,
+  Keyboard,
+  X,
+} from "lucide-react";
+import { type CSSProperties, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import {
-  mobileTerminalShortcutOption,
   type MobileTerminalShortcut,
+  mobileTerminalShortcutOption,
 } from "../mobileTerminalShortcuts";
+import {
+  beginTerminalComposerSubmission,
+  beginTerminalComposerUpload,
+  clearTerminalComposerDraft,
+  finishTerminalComposerSubmission,
+  finishTerminalComposerUpload,
+  insertIntoTerminalComposerDraft,
+  readTerminalComposerDraft,
+  readTerminalComposerSelection,
+  subscribeTerminalComposerDraft,
+  subscribeTerminalComposerSubmission,
+  subscribeTerminalComposerUpload,
+  terminalComposerSubmissionPending,
+  terminalComposerUploadCount,
+  writeTerminalComposerDraft,
+  writeTerminalComposerSelection,
+} from "../terminalComposer";
+import { MessageDialog } from "./ModalDialogs";
+
+const TERMINAL_COMPOSER_HELP =
+  "Input Composer uses your phone’s native editor for reliable IME, dictation, multiline text, and cursor editing before anything is sent to the terminal. Adding an image opens the system file picker, which takes focus from the composer and may dismiss the keyboard. After you choose an image, its uploaded path is inserted into the draft; tap the text area to reopen the keyboard if needed.";
 
 /**
  * Bottom-docked mobile terminal composer. A plain textarea owns all editing
@@ -47,21 +70,37 @@ export function TerminalComposer({
   onError: (message: string) => void;
 }) {
   const [text, setText] = useState(() => readTerminalComposerDraft(draftKey));
-  const [submitting, setSubmitting] = useState(false);
-  const [uploadCount, setUploadCount] = useState(0);
+  const [submissionPending, setSubmissionPending] = useState(() =>
+    terminalComposerSubmissionPending(draftKey),
+  );
+  const [uploadCount, setUploadCount] = useState(() =>
+    terminalComposerUploadCount(draftKey),
+  );
+  const [composing, setComposing] = useState(false);
+  const [helpOpen, setHelpOpen] = useState(false);
+  const [shortcutsOpen, setShortcutsOpen] = useState(true);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const pendingCaretRef = useRef<number | null>(null);
-  // Latest draft text, mirrored synchronously on every write path so async
-  // upload continuations never read a stale render closure.
-  const textRef = useRef(text);
+  const composingRef = useRef(false);
+  const activeDraftKeyRef = useRef(draftKey);
+  activeDraftKeyRef.current = draftKey;
 
-  // Load the incoming pane's draft. Writes happen in the change handler, so
-  // a key change never carries the previous pane's text into the new key.
+  // Load the incoming pane's draft and subscribe to updates from async work
+  // that may outlive an earlier composer mount for this pane.
   useEffect(() => {
-    const draft = readTerminalComposerDraft(draftKey);
-    textRef.current = draft;
-    setText(draft);
+    const applyDraft = (draft: string) => setText(draft);
+    applyDraft(readTerminalComposerDraft(draftKey));
+    return subscribeTerminalComposerDraft(draftKey, applyDraft);
+  }, [draftKey]);
+
+  useEffect(() => {
+    setSubmissionPending(terminalComposerSubmissionPending(draftKey));
+    return subscribeTerminalComposerSubmission(draftKey, setSubmissionPending);
+  }, [draftKey]);
+
+  useEffect(() => {
+    setUploadCount(terminalComposerUploadCount(draftKey));
+    return subscribeTerminalComposerUpload(draftKey, setUploadCount);
   }, [draftKey]);
 
   // Focus on open so the virtual keyboard appears, with the caret parked at
@@ -73,6 +112,7 @@ export function TerminalComposer({
     textarea.focus({ preventScroll: true });
     const end = textarea.value.length;
     textarea.setSelectionRange(end, end);
+    writeTerminalComposerSelection(draftKey, end, end);
   }, []);
 
   // Autosize within the CSS max-height.
@@ -83,44 +123,41 @@ export function TerminalComposer({
     textarea.style.height = `${textarea.scrollHeight}px`;
   }, [text]);
 
-  // Restore the caret after a programmatic insertion (e.g. an uploaded image
-  // path), which collapses the selection to the end otherwise.
+  // Restore the shared selection after a programmatic insertion. The shared
+  // value belongs to the draft key, so an upload started by an older mount can
+  // place its path at the current mount's completion-time caret.
   useEffect(() => {
-    if (pendingCaretRef.current === null) return;
     const textarea = textareaRef.current;
-    if (!textarea) return;
-    const caret = pendingCaretRef.current;
-    pendingCaretRef.current = null;
-    textarea.focus({ preventScroll: true });
-    textarea.setSelectionRange(caret, caret);
-  }, [text]);
+    const selection = readTerminalComposerSelection(draftKey);
+    if (!textarea || !selection) return;
+    if (!helpOpen) textarea.focus({ preventScroll: true });
+    textarea.setSelectionRange(selection.start, selection.end);
+  }, [draftKey, helpOpen, text]);
 
   // No visualViewport lift here: the app shell already lifts its content
   // above the keyboard with --keyboard-inset-content padding (App.tsx
   // useVisualViewportCssVars), and the CSS bottom calc adds the small iOS
   // trim back so the floating form accessory bar clears the action row. A
   // full second lift would push the composer a keyboard height too high.
-  const updateText = (value: string) => {
-    textRef.current = value;
-    setText(value);
-    writeTerminalComposerDraft(draftKey, value);
+  const updateText = (textarea: HTMLTextAreaElement) => {
+    setText(textarea.value);
+    writeTerminalComposerDraft(draftKey, textarea.value);
+    writeTerminalComposerSelection(
+      draftKey,
+      textarea.selectionStart,
+      textarea.selectionEnd,
+    );
   };
 
-  const insertAtCaret = (insertion: string) => {
-    const currentText = textRef.current;
-    const textarea = textareaRef.current;
-    const selectionStart = textarea
-      ? textarea.selectionStart
-      : currentText.length;
-    const selectionEnd = textarea ? textarea.selectionEnd : selectionStart;
-    const next = terminalComposerInsertAtCaret(
-      currentText,
-      selectionStart,
-      selectionEnd,
+  const insertAtCaret = (targetDraftKey: string, insertion: string) => {
+    const textarea =
+      activeDraftKeyRef.current === targetDraftKey ? textareaRef.current : null;
+    insertIntoTerminalComposerDraft(
+      targetDraftKey,
       insertion,
+      textarea?.selectionStart,
+      textarea?.selectionEnd,
     );
-    pendingCaretRef.current = next.caret;
-    updateText(next.text);
   };
 
   const uploadAndInsert = async (files: File[]) => {
@@ -128,43 +165,54 @@ export function TerminalComposer({
       (file) => file.type === "" || file.type.startsWith("image/"),
     );
     if (images.length === 0) return;
-    setUploadCount((count) => count + 1);
+    const uploadDraftKey = draftKey;
+    if (!beginTerminalComposerUpload(uploadDraftKey)) return;
     try {
       for (const file of images) {
         const path = await onUploadImage(file);
-        insertAtCaret(path);
+        insertAtCaret(uploadDraftKey, path);
       }
     } catch (error) {
       onError(error instanceof Error ? error.message : "Image upload failed");
     } finally {
-      setUploadCount((count) => count - 1);
+      finishTerminalComposerUpload(uploadDraftKey);
     }
   };
 
   const submit = async (sendEnter: boolean) => {
     const draft = text;
-    if (!draft || submitting || uploadCount > 0) return;
-    setSubmitting(true);
+    const submittedDraftKey = draftKey;
+    if (
+      !draft ||
+      uploadCount > 0 ||
+      composingRef.current ||
+      !beginTerminalComposerSubmission(submittedDraftKey)
+    ) {
+      return;
+    }
+
+    // Remove the submitted prefix before the request so an unmount/remount
+    // cannot expose it as a second send while the first request is pending.
+    // New text remains in the shared draft and is restored with the submitted
+    // text if the request fails.
+    const current = readTerminalComposerDraft(submittedDraftKey);
+    const next = current.startsWith(draft)
+      ? current.slice(draft.length)
+      : current;
+    if (next) {
+      writeTerminalComposerDraft(submittedDraftKey, next);
+    } else {
+      clearTerminalComposerDraft(submittedDraftKey);
+    }
+
     try {
       await onSubmit(draft, sendEnter);
-      // Remove only the submitted text: anything typed while the request was
-      // in flight stays in the draft so it cannot be sent twice or lost.
-      setText((current) => {
-        const next = current.startsWith(draft)
-          ? current.slice(draft.length)
-          : current;
-        textRef.current = next;
-        if (next) {
-          writeTerminalComposerDraft(draftKey, next);
-        } else {
-          clearTerminalComposerDraft(draftKey);
-        }
-        return next;
-      });
     } catch (error) {
+      const pendingText = readTerminalComposerDraft(submittedDraftKey);
+      writeTerminalComposerDraft(submittedDraftKey, `${draft}${pendingText}`);
       onError(error instanceof Error ? error.message : "Failed to send input");
     } finally {
-      setSubmitting(false);
+      finishTerminalComposerSubmission(submittedDraftKey);
       textareaRef.current?.focus({ preventScroll: true });
     }
   };
@@ -174,138 +222,211 @@ export function TerminalComposer({
     e.currentTarget.blur();
   };
 
-  const busy = submitting || uploadCount > 0;
+  const busy = submissionPending || uploadCount > 0;
+  const submitDisabled = !text || busy || composing;
+  const hasShortcuts = shortcutRows.some((row) => row.length > 0);
   const shortcutColumns = Math.max(1, ...shortcutRows.map((row) => row.length));
 
   return (
-    <div
-      className="terminal-composer"
-      role="dialog"
-      aria-label="Terminal composer"
-    >
-      {shortcutRows.some((row) => row.length > 0) ? (
-        <div
-          className="terminal-composer-shortcuts"
-          style={
-            {
-              "--mobile-shortcut-columns": shortcutColumns,
-            } as CSSProperties
+    <>
+      <div
+        className="terminal-composer"
+        role="dialog"
+        aria-label="Terminal composer"
+      >
+        {hasShortcuts && shortcutsOpen ? (
+          <div
+            className="terminal-composer-shortcuts"
+            style={
+              {
+                "--mobile-shortcut-columns": shortcutColumns,
+              } as CSSProperties
+            }
+            aria-label="Terminal shortcuts"
+          >
+            {shortcutRows.map((row, rowIndex) => (
+              <div
+                className="terminal-composer-shortcut-row"
+                key={`composer-shortcut-row-${rowIndex}`}
+              >
+                {row.map((shortcut) => {
+                  const option = mobileTerminalShortcutOption(shortcut.action);
+                  return (
+                    <button
+                      type="button"
+                      title={option?.label ?? shortcut.label}
+                      aria-label={`Send ${option?.label ?? shortcut.label}`}
+                      onPointerDown={keepTextareaFocus}
+                      onClick={() => onRunShortcut(shortcut)}
+                      key={shortcut.id}
+                    >
+                      {shortcut.label}
+                    </button>
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        ) : null}
+        <textarea
+          ref={textareaRef}
+          className="terminal-composer-input"
+          value={text}
+          rows={1}
+          placeholder="Compose input for the terminal…"
+          autoComplete="off"
+          aria-label="Terminal input draft"
+          onChange={(e) => updateText(e.currentTarget)}
+          onSelect={(e) =>
+            writeTerminalComposerSelection(
+              draftKey,
+              e.currentTarget.selectionStart,
+              e.currentTarget.selectionEnd,
+            )
           }
-          aria-label="Terminal shortcuts"
-        >
-          {shortcutRows.map((row, rowIndex) => (
-            <div
-              className="terminal-composer-shortcut-row"
-              key={`composer-shortcut-row-${rowIndex}`}
-            >
-              {row.map((shortcut) => {
-                const option = mobileTerminalShortcutOption(shortcut.action);
-                return (
-                  <button
-                    type="button"
-                    title={option?.label ?? shortcut.label}
-                    aria-label={`Send ${option?.label ?? shortcut.label}`}
-                    onPointerDown={keepTextareaFocus}
-                    onClick={() => onRunShortcut(shortcut)}
-                    key={shortcut.id}
-                  >
-                    {shortcut.label}
-                  </button>
-                );
-              })}
-            </div>
-          ))}
-        </div>
-      ) : null}
-      <textarea
-        ref={textareaRef}
-        className="terminal-composer-input"
-        value={text}
-        rows={1}
-        placeholder="Compose input for the terminal…"
-        autoComplete="off"
-        aria-label="Terminal input draft"
-        onChange={(e) => updateText(e.target.value)}
-        onPaste={(e) => {
-          const images = Array.from(e.clipboardData?.items ?? [])
-            .filter((item) => item.kind === "file")
-            .map((item) => item.getAsFile())
-            .filter((file): file is File => file !== null);
-          // No image on the clipboard: let the native text paste proceed.
-          if (images.length === 0) return;
-          e.preventDefault();
-          void uploadAndInsert(images);
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+          onCompositionStart={() => {
+            composingRef.current = true;
+            setComposing(true);
+          }}
+          onCompositionEnd={() => {
+            composingRef.current = false;
+            setComposing(false);
+          }}
+          onPaste={(e) => {
+            const images = Array.from(e.clipboardData?.items ?? [])
+              .filter(
+                (item) =>
+                  item.kind === "file" && item.type.startsWith("image/"),
+              )
+              .map((item) => item.getAsFile())
+              .filter((file): file is File => file !== null);
+            // No image on the clipboard: let the native text paste proceed.
+            if (images.length === 0) return;
             e.preventDefault();
-            void submit(true);
-          }
-        }}
-      />
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept="image/*"
-        multiple
-        hidden
-        onChange={(e) => {
-          const files = Array.from(e.target.files ?? []);
-          // Reset so picking the same file again still fires change.
-          e.target.value = "";
-          if (files.length > 0) void uploadAndInsert(files);
-        }}
-      />
-      <div className="terminal-composer-actions">
-        <button
-          type="button"
-          className="terminal-composer-close"
-          title="Close composer"
-          aria-label="Close composer"
-          onPointerDown={keepTextareaFocus}
-          onClick={onClose}
-        >
-          <X size={15} />
-        </button>
-        <button
-          type="button"
-          className="terminal-composer-attach"
-          title="Add an image"
-          aria-label="Add an image"
-          disabled={busy}
-          onPointerDown={keepTextareaFocus}
-          onClick={() => fileInputRef.current?.click()}
-        >
-          <ImagePlus size={15} />
-        </button>
-        <span className="terminal-composer-hint">
-          {uploadCount > 0 ? "Uploading image…" : submitting ? "Sending…" : ""}
-        </span>
-        <button
-          type="button"
-          className="terminal-composer-submit"
-          title="Insert into the terminal without executing"
-          aria-label="Insert draft into the terminal"
-          disabled={!text || busy}
-          onPointerDown={keepTextareaFocus}
-          onClick={() => void submit(false)}
-        >
-          <CornerDownRight size={14} />
-          Insert
-        </button>
-        <button
-          type="button"
-          className="terminal-composer-submit is-primary"
-          title="Insert into the terminal and send Enter"
-          aria-label="Send draft to the terminal"
-          disabled={!text || busy}
-          onPointerDown={keepTextareaFocus}
-          onClick={() => void submit(true)}
-        >
-          <CornerDownLeft size={14} />
-          Send
-        </button>
+            void uploadAndInsert(images);
+          }}
+          onKeyDown={(e) => {
+            if (
+              !e.nativeEvent.isComposing &&
+              !composingRef.current &&
+              e.key === "Enter" &&
+              (e.metaKey || e.ctrlKey)
+            ) {
+              e.preventDefault();
+              void submit(true);
+            }
+          }}
+        />
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          hidden
+          onChange={(e) => {
+            const files = Array.from(e.target.files ?? []);
+            // Reset so picking the same file again still fires change.
+            e.target.value = "";
+            if (files.length > 0) void uploadAndInsert(files);
+          }}
+        />
+        <div className="terminal-composer-actions">
+          <button
+            type="button"
+            className="terminal-composer-close"
+            title="Close composer"
+            aria-label="Close composer"
+            onPointerDown={keepTextareaFocus}
+            onClick={onClose}
+          >
+            <X size={15} />
+          </button>
+          {hasShortcuts ? (
+            <button
+              type="button"
+              className={`terminal-composer-shortcuts-toggle ${
+                shortcutsOpen ? "is-open" : ""
+              }`}
+              title={shortcutsOpen ? "Hide shortcuts" : "Show shortcuts"}
+              aria-label={
+                shortcutsOpen
+                  ? "Hide terminal shortcuts"
+                  : "Show terminal shortcuts"
+              }
+              aria-expanded={shortcutsOpen}
+              onPointerDown={keepTextareaFocus}
+              onClick={() => setShortcutsOpen((open) => !open)}
+            >
+              <Keyboard size={15} />
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className="terminal-composer-attach"
+            title="Add an image"
+            aria-label="Add an image"
+            disabled={busy}
+            onPointerDown={keepTextareaFocus}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <ImagePlus size={15} />
+          </button>
+          <button
+            type="button"
+            className="terminal-composer-help"
+            title="About Input Composer"
+            aria-label="About Input Composer"
+            aria-haspopup="dialog"
+            aria-expanded={helpOpen}
+            onPointerDown={keepTextareaFocus}
+            onClick={() => setHelpOpen(true)}
+          >
+            <CircleHelp size={15} />
+          </button>
+          <span className="terminal-composer-hint">
+            {uploadCount > 0
+              ? "Uploading image…"
+              : submissionPending
+                ? "Sending…"
+                : ""}
+          </span>
+          <button
+            type="button"
+            className="terminal-composer-submit"
+            title="Insert into the terminal without executing"
+            aria-label="Insert draft into the terminal"
+            disabled={submitDisabled}
+            onPointerDown={keepTextareaFocus}
+            onClick={() => void submit(false)}
+          >
+            <CornerDownRight size={14} />
+            Insert
+          </button>
+          <button
+            type="button"
+            className="terminal-composer-submit is-primary"
+            title="Insert into the terminal and send Enter"
+            aria-label="Send draft to the terminal"
+            disabled={submitDisabled}
+            onPointerDown={keepTextareaFocus}
+            onClick={() => void submit(true)}
+          >
+            <CornerDownLeft size={14} />
+            Send
+          </button>
+        </div>
       </div>
-    </div>
+      {helpOpen && typeof document !== "undefined"
+        ? createPortal(
+            <MessageDialog
+              open
+              title="About Input Composer"
+              message={TERMINAL_COMPOSER_HELP}
+              onClose={() => setHelpOpen(false)}
+            />,
+            document.body,
+          )
+        : null}
+    </>
   );
 }

--- a/web/src/components/TerminalComposer.tsx
+++ b/web/src/components/TerminalComposer.tsx
@@ -1,0 +1,311 @@
+import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { CornerDownLeft, CornerDownRight, ImagePlus, X } from "lucide-react";
+import {
+  clearTerminalComposerDraft,
+  readTerminalComposerDraft,
+  terminalComposerInsertAtCaret,
+  writeTerminalComposerDraft,
+} from "../terminalComposer";
+import {
+  mobileTerminalShortcutOption,
+  type MobileTerminalShortcut,
+} from "../mobileTerminalShortcuts";
+
+/**
+ * Bottom-docked mobile terminal composer. A plain textarea owns all editing
+ * (IME, dictation, selection, autocorrect, multiline paste) and text only
+ * reaches the PTY when the user explicitly chooses Insert or Send, which
+ * sidesteps the xterm helper-textarea races described in the IME recovery
+ * code. Drafts are write-through to the in-memory store so pane switches and
+ * virtual-keyboard resizes never lose text.
+ *
+ * The configurable mobile shortcut keys live at the top of the dock so the
+ * composer is the single mobile control surface. Opening the composer focuses
+ * the textarea (caret at the end of any restored draft) so the virtual
+ * keyboard is ready immediately; the standalone shortcut panel remains for
+ * keys-only interactions.
+ *
+ * Images arrive through clipboard paste or the file picker, upload once, and
+ * land in the draft as plain paths at the caret; they reach the terminal only
+ * through an explicit Insert or Send like any other text.
+ */
+export function TerminalComposer({
+  draftKey,
+  shortcutRows,
+  onRunShortcut,
+  onClose,
+  onSubmit,
+  onUploadImage,
+  onError,
+}: {
+  draftKey: string;
+  shortcutRows: MobileTerminalShortcut[][];
+  onRunShortcut: (shortcut: MobileTerminalShortcut) => void;
+  onClose: () => void;
+  onSubmit: (text: string, submit: boolean) => Promise<void>;
+  onUploadImage: (file: File) => Promise<string>;
+  onError: (message: string) => void;
+}) {
+  const [text, setText] = useState(() => readTerminalComposerDraft(draftKey));
+  const [submitting, setSubmitting] = useState(false);
+  const [uploadCount, setUploadCount] = useState(0);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const pendingCaretRef = useRef<number | null>(null);
+  // Latest draft text, mirrored synchronously on every write path so async
+  // upload continuations never read a stale render closure.
+  const textRef = useRef(text);
+
+  // Load the incoming pane's draft. Writes happen in the change handler, so
+  // a key change never carries the previous pane's text into the new key.
+  useEffect(() => {
+    const draft = readTerminalComposerDraft(draftKey);
+    textRef.current = draft;
+    setText(draft);
+  }, [draftKey]);
+
+  // Focus on open so the virtual keyboard appears, with the caret parked at
+  // the end of any restored draft. Mount-only: pane switches must not yank
+  // the caret out of an in-progress edit.
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    textarea.focus({ preventScroll: true });
+    const end = textarea.value.length;
+    textarea.setSelectionRange(end, end);
+  }, []);
+
+  // Autosize within the CSS max-height.
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    textarea.style.height = "0px";
+    textarea.style.height = `${textarea.scrollHeight}px`;
+  }, [text]);
+
+  // Restore the caret after a programmatic insertion (e.g. an uploaded image
+  // path), which collapses the selection to the end otherwise.
+  useEffect(() => {
+    if (pendingCaretRef.current === null) return;
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    const caret = pendingCaretRef.current;
+    pendingCaretRef.current = null;
+    textarea.focus({ preventScroll: true });
+    textarea.setSelectionRange(caret, caret);
+  }, [text]);
+
+  // No visualViewport lift here: the app shell already lifts its content
+  // above the keyboard with --keyboard-inset-content padding (App.tsx
+  // useVisualViewportCssVars), and the CSS bottom calc adds the small iOS
+  // trim back so the floating form accessory bar clears the action row. A
+  // full second lift would push the composer a keyboard height too high.
+  const updateText = (value: string) => {
+    textRef.current = value;
+    setText(value);
+    writeTerminalComposerDraft(draftKey, value);
+  };
+
+  const insertAtCaret = (insertion: string) => {
+    const currentText = textRef.current;
+    const textarea = textareaRef.current;
+    const selectionStart = textarea
+      ? textarea.selectionStart
+      : currentText.length;
+    const selectionEnd = textarea ? textarea.selectionEnd : selectionStart;
+    const next = terminalComposerInsertAtCaret(
+      currentText,
+      selectionStart,
+      selectionEnd,
+      insertion,
+    );
+    pendingCaretRef.current = next.caret;
+    updateText(next.text);
+  };
+
+  const uploadAndInsert = async (files: File[]) => {
+    const images = files.filter(
+      (file) => file.type === "" || file.type.startsWith("image/"),
+    );
+    if (images.length === 0) return;
+    setUploadCount((count) => count + 1);
+    try {
+      for (const file of images) {
+        const path = await onUploadImage(file);
+        insertAtCaret(path);
+      }
+    } catch (error) {
+      onError(error instanceof Error ? error.message : "Image upload failed");
+    } finally {
+      setUploadCount((count) => count - 1);
+    }
+  };
+
+  const submit = async (sendEnter: boolean) => {
+    const draft = text;
+    if (!draft || submitting || uploadCount > 0) return;
+    setSubmitting(true);
+    try {
+      await onSubmit(draft, sendEnter);
+      // Remove only the submitted text: anything typed while the request was
+      // in flight stays in the draft so it cannot be sent twice or lost.
+      setText((current) => {
+        const next = current.startsWith(draft)
+          ? current.slice(draft.length)
+          : current;
+        textRef.current = next;
+        if (next) {
+          writeTerminalComposerDraft(draftKey, next);
+        } else {
+          clearTerminalComposerDraft(draftKey);
+        }
+        return next;
+      });
+    } catch (error) {
+      onError(error instanceof Error ? error.message : "Failed to send input");
+    } finally {
+      setSubmitting(false);
+      textareaRef.current?.focus({ preventScroll: true });
+    }
+  };
+
+  const keepTextareaFocus = (e: React.PointerEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.currentTarget.blur();
+  };
+
+  const busy = submitting || uploadCount > 0;
+  const shortcutColumns = Math.max(1, ...shortcutRows.map((row) => row.length));
+
+  return (
+    <div
+      className="terminal-composer"
+      role="dialog"
+      aria-label="Terminal composer"
+    >
+      {shortcutRows.some((row) => row.length > 0) ? (
+        <div
+          className="terminal-composer-shortcuts"
+          style={
+            {
+              "--mobile-shortcut-columns": shortcutColumns,
+            } as CSSProperties
+          }
+          aria-label="Terminal shortcuts"
+        >
+          {shortcutRows.map((row, rowIndex) => (
+            <div
+              className="terminal-composer-shortcut-row"
+              key={`composer-shortcut-row-${rowIndex}`}
+            >
+              {row.map((shortcut) => {
+                const option = mobileTerminalShortcutOption(shortcut.action);
+                return (
+                  <button
+                    type="button"
+                    title={option?.label ?? shortcut.label}
+                    aria-label={`Send ${option?.label ?? shortcut.label}`}
+                    onPointerDown={keepTextareaFocus}
+                    onClick={() => onRunShortcut(shortcut)}
+                    key={shortcut.id}
+                  >
+                    {shortcut.label}
+                  </button>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      ) : null}
+      <textarea
+        ref={textareaRef}
+        className="terminal-composer-input"
+        value={text}
+        rows={1}
+        placeholder="Compose input for the terminal…"
+        autoComplete="off"
+        aria-label="Terminal input draft"
+        onChange={(e) => updateText(e.target.value)}
+        onPaste={(e) => {
+          const images = Array.from(e.clipboardData?.items ?? [])
+            .filter((item) => item.kind === "file")
+            .map((item) => item.getAsFile())
+            .filter((file): file is File => file !== null);
+          // No image on the clipboard: let the native text paste proceed.
+          if (images.length === 0) return;
+          e.preventDefault();
+          void uploadAndInsert(images);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+            e.preventDefault();
+            void submit(true);
+          }
+        }}
+      />
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        hidden
+        onChange={(e) => {
+          const files = Array.from(e.target.files ?? []);
+          // Reset so picking the same file again still fires change.
+          e.target.value = "";
+          if (files.length > 0) void uploadAndInsert(files);
+        }}
+      />
+      <div className="terminal-composer-actions">
+        <button
+          type="button"
+          className="terminal-composer-close"
+          title="Close composer"
+          aria-label="Close composer"
+          onPointerDown={keepTextareaFocus}
+          onClick={onClose}
+        >
+          <X size={15} />
+        </button>
+        <button
+          type="button"
+          className="terminal-composer-attach"
+          title="Add an image"
+          aria-label="Add an image"
+          disabled={busy}
+          onPointerDown={keepTextareaFocus}
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <ImagePlus size={15} />
+        </button>
+        <span className="terminal-composer-hint">
+          {uploadCount > 0 ? "Uploading image…" : submitting ? "Sending…" : ""}
+        </span>
+        <button
+          type="button"
+          className="terminal-composer-submit"
+          title="Insert into the terminal without executing"
+          aria-label="Insert draft into the terminal"
+          disabled={!text || busy}
+          onPointerDown={keepTextareaFocus}
+          onClick={() => void submit(false)}
+        >
+          <CornerDownRight size={14} />
+          Insert
+        </button>
+        <button
+          type="button"
+          className="terminal-composer-submit is-primary"
+          title="Insert into the terminal and send Enter"
+          aria-label="Send draft to the terminal"
+          disabled={!text || busy}
+          onPointerDown={keepTextareaFocus}
+          onClick={() => void submit(true)}
+        >
+          <CornerDownLeft size={14} />
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -15,12 +15,18 @@ import {
 } from "@xterm/addon-clipboard";
 import { FitAddon } from "@xterm/addon-fit";
 import { UnicodeGraphemesAddon } from "@xterm/addon-unicode-graphemes";
-import { Columns2, Keyboard, Maximize2, Rows2, X } from "lucide-react";
+import {
+  Columns2,
+  Keyboard,
+  Maximize2,
+  Rows2,
+  SquarePen,
+  X,
+} from "lucide-react";
 import "@xterm/xterm/css/xterm.css";
 import { shallowEqual, store, useStoreSelector } from "../store";
 import { paneCanClose } from "../paneJump";
 import { bridge, type ConnectionClient } from "../api";
-import { connectionHttpPath } from "../connectionHttp";
 import {
   registerTerminalConnectionDisposer,
   terminalConnectionKey,
@@ -80,6 +86,15 @@ import {
 } from "../mobileTerminalShortcuts";
 import { mobileTerminalShortcutExecution } from "../mobileTerminalShortcutAction";
 import {
+  clearTerminalComposerDrafts,
+  terminalComposerCloseWarning,
+  terminalComposerDraftKey,
+  terminalComposerDraftPaneIds,
+  terminalComposerRequest,
+} from "../terminalComposer";
+import { uploadTerminalImage } from "../terminalImageUpload";
+import { TerminalComposer } from "./TerminalComposer";
+import {
   readTerminalRecoveryReloadAt,
   shouldArmTerminalRecoveryResume,
   shouldReloadTerminalAfterResume,
@@ -116,37 +131,6 @@ function sendBytes(
     terminal_id: terminalId,
     data: bytesToB64(bytes),
   });
-}
-
-async function uploadImage(
-  client: ConnectionClient,
-  file: File,
-): Promise<string> {
-  if (!client.isCurrent()) throw new Error("connection changed during upload");
-  const ext = (file.type.split("/")[1] || "png").toLowerCase();
-  const uploadUrl = new URL(
-    connectionHttpPath(
-      client.connectionId,
-      "/upload-image",
-      client.serverRuntimeGeneration,
-    ),
-    window.location.origin,
-  );
-  if (uploadUrl.origin !== window.location.origin) {
-    throw new Error("invalid upload origin");
-  }
-  const res = await fetch(uploadUrl, {
-    method: "POST",
-    headers: {
-      "x-image-ext": ext,
-      "content-type": file.type || "image/png",
-    },
-    body: file,
-  });
-  const data = await res.json().catch(() => ({}));
-  if (!client.isCurrent()) throw new Error("connection changed during upload");
-  if (!res.ok) throw new Error(data.error || res.statusText);
-  return data.path as string;
 }
 
 const FONT_FAMILY =
@@ -499,6 +483,7 @@ export function TerminalView({
   const [pasteLoading, setPasteLoading] = useState(false);
   const [attachRetry, setAttachRetry] = useState(0);
   const [mobileKeysOpen, setMobileKeysOpen] = useState(false);
+  const [composerOpen, setComposerOpen] = useState(false);
   const [closePaneRequested, setClosePaneRequested] = useState(false);
   const [localAgentHistoryOpen, setLocalAgentHistoryOpen] = useState(false);
   const containerRef = useCallback(
@@ -1067,7 +1052,7 @@ export function TerminalView({
           : new File([blob], "clipboard-image.png", {
               type: blob.type || "image/png",
             });
-      const path = await uploadImage(connectionClient, file);
+      const path = await uploadTerminalImage(connectionClient, file);
       await pasteText(path, destinationPaneId);
     };
     let clipboardPasteInFlight = false;
@@ -1950,6 +1935,21 @@ export function TerminalView({
     };
   }, []);
 
+  const submitTerminalComposer = async (text: string, submit: boolean) => {
+    const targetPaneId = paneIdRef.current;
+    if (!targetPaneId) throw new Error("No active pane");
+    const request = terminalComposerRequest(targetPaneId, text, submit);
+    await connectionClient.call(request.method, request.params);
+  };
+  const uploadComposerImage = (file: File) =>
+    uploadTerminalImage(connectionClient, file);
+  const notifyComposerError = (message: string) => {
+    store.notify({
+      kind: "error",
+      message: "Terminal composer failed",
+      detail: message,
+    });
+  };
   const runMobileShortcut = (shortcut: MobileTerminalShortcut) => {
     const execution = mobileTerminalShortcutExecution(shortcut.action);
     if (!execution) return;
@@ -1989,10 +1989,45 @@ export function TerminalView({
     );
   }
 
+  const composerDraftKey = terminalComposerDraftKey(
+    s.activeConnectionId,
+    s.connectionGeneration,
+    pane.pane_id,
+  );
+  const composerDraftWarning = terminalComposerCloseWarning(
+    terminalComposerDraftPaneIds(s.activeConnectionId, s.connectionGeneration, [
+      pane.pane_id,
+    ]).length,
+  );
+
   return (
     <>
       <div className="terminal-shell">
-        <div ref={containerRef} className="terminal-view" />
+        <div className="terminal-main">
+          <div ref={containerRef} className="terminal-view" />
+          {showMobileKeys && visibleMobileSideShortcuts.length > 0 ? (
+            <div
+              className="terminal-mobile-side-shortcuts"
+              aria-label="Terminal side shortcuts"
+            >
+              {visibleMobileSideShortcuts.map((shortcut) => {
+                const option = mobileTerminalShortcutOption(shortcut.action);
+                return (
+                  <button
+                    type="button"
+                    title={option?.label ?? shortcut.label}
+                    aria-label={`Run ${option?.label ?? shortcut.label}`}
+                    onPointerDown={preventShortcutFocus}
+                    onClick={() => runMobileShortcut(shortcut)}
+                    key={shortcut.id}
+                  >
+                    {shortcut.label}
+                  </button>
+                );
+              })}
+            </div>
+          ) : null}
+        </div>
         {showMobileKeys &&
         visibleMobileShortcutRows.some((row) => row.length > 0) ? (
           <div
@@ -2052,27 +2087,39 @@ export function TerminalView({
             </div>
           </div>
         ) : null}
-        {showMobileKeys && visibleMobileSideShortcuts.length > 0 ? (
-          <div
-            className="terminal-mobile-side-shortcuts"
-            aria-label="Terminal side shortcuts"
+        {showMobileKeys ? (
+          <button
+            type="button"
+            className={`terminal-composer-toggle ${
+              composerOpen ? "is-open" : ""
+            }`}
+            title={
+              composerOpen
+                ? "Close terminal composer"
+                : "Open terminal composer"
+            }
+            aria-label={
+              composerOpen
+                ? "Close terminal composer"
+                : "Open terminal composer"
+            }
+            aria-expanded={composerOpen}
+            onPointerDown={preventPaneActionFocus}
+            onClick={() => setComposerOpen((value) => !value)}
           >
-            {visibleMobileSideShortcuts.map((shortcut) => {
-              const option = mobileTerminalShortcutOption(shortcut.action);
-              return (
-                <button
-                  type="button"
-                  title={option?.label ?? shortcut.label}
-                  aria-label={`Run ${option?.label ?? shortcut.label}`}
-                  onPointerDown={preventShortcutFocus}
-                  onClick={() => runMobileShortcut(shortcut)}
-                  key={shortcut.id}
-                >
-                  {shortcut.label}
-                </button>
-              );
-            })}
-          </div>
+            <SquarePen size={16} />
+          </button>
+        ) : null}
+        {composerOpen ? (
+          <TerminalComposer
+            draftKey={composerDraftKey}
+            shortcutRows={visibleMobileShortcutRows}
+            onRunShortcut={runMobileShortcut}
+            onClose={() => setComposerOpen(false)}
+            onSubmit={submitTerminalComposer}
+            onUploadImage={uploadComposerImage}
+            onError={notifyComposerError}
+          />
         ) : null}
         <div className="terminal-pane-toolbar" aria-label="Pane actions">
           <button
@@ -2141,11 +2188,18 @@ export function TerminalView({
       <ConfirmDialog
         open={closePaneRequested}
         title="Close Pane"
-        message="Close this terminal pane?"
+        message={`Close this terminal pane?${composerDraftWarning}`}
         confirmLabel="Close"
         danger
         onClose={() => setClosePaneRequested(false)}
-        onConfirm={() => store.closePane(pane.pane_id)}
+        onConfirm={() => {
+          clearTerminalComposerDrafts(
+            s.activeConnectionId,
+            s.connectionGeneration,
+            [pane.pane_id],
+          );
+          store.closePane(pane.pane_id);
+        }}
       />
       <MessageDialog
         open={!!uploadError}

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -1,90 +1,38 @@
 import {
+  ClipboardAddon,
+  type ClipboardSelectionType,
+} from "@xterm/addon-clipboard";
+import { FitAddon } from "@xterm/addon-fit";
+import { UnicodeGraphemesAddon } from "@xterm/addon-unicode-graphemes";
+import type { IBufferLine, ILink } from "@xterm/xterm";
+import { Terminal } from "@xterm/xterm";
+import { Columns2, Keyboard, Maximize2, Rows2, X } from "lucide-react";
+import {
+  type CSSProperties,
   useCallback,
   useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
   useState,
-  type CSSProperties,
 } from "react";
-import { Terminal } from "@xterm/xterm";
-import type { IBufferLine, ILink } from "@xterm/xterm";
-import {
-  ClipboardAddon,
-  type ClipboardSelectionType,
-} from "@xterm/addon-clipboard";
-import { FitAddon } from "@xterm/addon-fit";
-import { UnicodeGraphemesAddon } from "@xterm/addon-unicode-graphemes";
-import {
-  Columns2,
-  Keyboard,
-  Maximize2,
-  Rows2,
-  SquarePen,
-  X,
-} from "lucide-react";
 import "@xterm/xterm/css/xterm.css";
-import { shallowEqual, store, useStoreSelector } from "../store";
-import { paneCanClose } from "../paneJump";
 import { bridge, type ConnectionClient } from "../api";
+import { mobileTerminalShortcutExecution } from "../mobileTerminalShortcutAction";
 import {
-  registerTerminalConnectionDisposer,
-  terminalConnectionKey,
-  terminalPushMatches,
-  type TerminalConnectionIdentity,
-} from "../terminalConnection";
-import { ConfirmDialog, MessageDialog } from "./ModalDialogs";
-import { paneHasAgentHistory } from "./agentSession";
-import {
-  findTerminalHttpLinks,
-  sanitizeTerminalHttpUrl,
-} from "../terminalLinks";
-import {
-  findTerminalFileLinkCandidates,
-  type ResolvedTerminalFile,
-  type TerminalFileLinkCandidate,
-  TerminalFileResolutionCache,
-} from "../terminalFileLinks";
-import {
-  terminalPasteInputText,
-  terminalPasteRequest,
-  type TerminalPasteTextareaSnapshot,
-} from "../terminalPaste";
+  defaultMobileTerminalShortcutRows,
+  defaultMobileTerminalSideShortcuts,
+  type MobileTerminalShortcut,
+  type MobileTerminalShortcutRows,
+  type MobileTerminalSideShortcuts,
+  mobileTerminalShortcutOption,
+} from "../mobileTerminalShortcuts";
+import { paneCanClose } from "../paneJump";
+import { shallowEqual, store, useStoreSelector } from "../store";
 import {
   createTerminalClipboardProvider,
   decodeTerminalClipboard,
 } from "../terminalClipboard";
-import {
-  macCommandEditingSequence,
-  modifiedEnterSequence,
-} from "../terminalKeys";
-import {
-  isTerminalImeCommittedInputType,
-  terminalImeEventTime,
-  terminalImeFallbackText,
-  TerminalImeFallbackTracker,
-  TerminalImeKeyEventTracker,
-  TerminalImeTextareaFallbackTracker,
-} from "../terminalIme";
-import { terminalPageScroll, terminalWheelScroll } from "../terminalScroll";
-import { TerminalSelectionDragGuard } from "../terminalSelectionGuard";
-import { terminalFocusBlockedByOverlay } from "../terminalFocus";
-import {
-  TerminalAttachFrameWatchdog,
-  TerminalResizeSync,
-  rememberTerminalRelayViewport,
-  terminalAttachWatchdogMs,
-  terminalRelayViewportSize,
-} from "../terminalResize";
-import {
-  defaultMobileTerminalShortcutRows,
-  defaultMobileTerminalSideShortcuts,
-  mobileTerminalShortcutOption,
-  type MobileTerminalShortcut,
-  type MobileTerminalShortcutRows,
-  type MobileTerminalSideShortcuts,
-} from "../mobileTerminalShortcuts";
-import { mobileTerminalShortcutExecution } from "../mobileTerminalShortcutAction";
 import {
   clearTerminalComposerDrafts,
   terminalComposerCloseWarning,
@@ -92,14 +40,59 @@ import {
   terminalComposerDraftPaneIds,
   terminalComposerRequest,
 } from "../terminalComposer";
+import {
+  registerTerminalConnectionDisposer,
+  type TerminalConnectionIdentity,
+  terminalConnectionKey,
+  terminalPushMatches,
+} from "../terminalConnection";
+import {
+  findTerminalFileLinkCandidates,
+  type ResolvedTerminalFile,
+  type TerminalFileLinkCandidate,
+  TerminalFileResolutionCache,
+} from "../terminalFileLinks";
+import { terminalFocusBlockedByOverlay } from "../terminalFocus";
 import { uploadTerminalImage } from "../terminalImageUpload";
-import { TerminalComposer } from "./TerminalComposer";
+import {
+  isTerminalImeCommittedInputType,
+  TerminalImeFallbackTracker,
+  TerminalImeKeyEventTracker,
+  TerminalImeTextareaFallbackTracker,
+  terminalImeEventTime,
+  terminalImeFallbackText,
+} from "../terminalIme";
+import {
+  macCommandEditingSequence,
+  modifiedEnterSequence,
+} from "../terminalKeys";
+import {
+  findTerminalHttpLinks,
+  sanitizeTerminalHttpUrl,
+} from "../terminalLinks";
+import {
+  type TerminalPasteTextareaSnapshot,
+  terminalPasteInputText,
+  terminalPasteRequest,
+} from "../terminalPaste";
 import {
   readTerminalRecoveryReloadAt,
   shouldArmTerminalRecoveryResume,
   shouldReloadTerminalAfterResume,
   writeTerminalRecoveryReloadAt,
 } from "../terminalRecovery";
+import {
+  rememberTerminalRelayViewport,
+  TerminalAttachFrameWatchdog,
+  TerminalResizeSync,
+  terminalAttachWatchdogMs,
+  terminalRelayViewportSize,
+} from "../terminalResize";
+import { terminalPageScroll, terminalWheelScroll } from "../terminalScroll";
+import { TerminalSelectionDragGuard } from "../terminalSelectionGuard";
+import { paneHasAgentHistory } from "./agentSession";
+import { ConfirmDialog, MessageDialog } from "./ModalDialogs";
+import { TerminalComposer } from "./TerminalComposer";
 
 const SYSTEM_CLIPBOARD = "c" as ClipboardSelectionType;
 
@@ -409,6 +402,8 @@ export function TerminalView({
   showMobileKeys = true,
   mobileShortcuts = defaultMobileTerminalShortcutRows(),
   mobileSideShortcuts = defaultMobileTerminalSideShortcuts(),
+  composerOpen: controlledComposerOpen,
+  onComposerOpenChange,
   agentHistoryOpen: controlledAgentHistoryOpen,
   onAgentHistoryOpenChange,
   onOpenWorkspaceFile,
@@ -417,6 +412,8 @@ export function TerminalView({
   showMobileKeys?: boolean;
   mobileShortcuts?: MobileTerminalShortcutRows;
   mobileSideShortcuts?: MobileTerminalSideShortcuts;
+  composerOpen?: boolean;
+  onComposerOpenChange?: (open: boolean) => void;
   agentHistoryOpen?: boolean;
   onAgentHistoryOpenChange?: (open: boolean) => void;
   onOpenWorkspaceFile?: (request: TerminalWorkspaceFileRequest) => void;
@@ -483,7 +480,7 @@ export function TerminalView({
   const [pasteLoading, setPasteLoading] = useState(false);
   const [attachRetry, setAttachRetry] = useState(0);
   const [mobileKeysOpen, setMobileKeysOpen] = useState(false);
-  const [composerOpen, setComposerOpen] = useState(false);
+  const [localComposerOpen, setLocalComposerOpen] = useState(false);
   const [closePaneRequested, setClosePaneRequested] = useState(false);
   const [localAgentHistoryOpen, setLocalAgentHistoryOpen] = useState(false);
   const containerRef = useCallback(
@@ -530,6 +527,21 @@ export function TerminalView({
   const isActivePane = !!pane && (!paneId || pane.pane_id === activePaneId);
   const canShowAgentHistory = isActivePane && paneHasAgentHistory(pane);
   const canClosePane = !!pane && paneCanClose(s.panes, pane.pane_id);
+  const composerOpen = controlledComposerOpen ?? localComposerOpen;
+  const composerOpenRef = useRef(composerOpen);
+  composerOpenRef.current = composerOpen;
+  useLayoutEffect(() => {
+    if (!termInstance) return;
+    termInstance.options.disableStdin = composerOpen;
+    if (composerOpen) termInstance.blur();
+  }, [composerOpen, termInstance]);
+  const setComposerOpen = useCallback(
+    (open: boolean) => {
+      if (controlledComposerOpen === undefined) setLocalComposerOpen(open);
+      onComposerOpenChange?.(open);
+    },
+    [controlledComposerOpen, onComposerOpenChange],
+  );
   const agentHistoryOpen = controlledAgentHistoryOpen ?? localAgentHistoryOpen;
   const setAgentHistoryOpen = useCallback(
     (open: boolean) => {
@@ -565,11 +577,11 @@ export function TerminalView({
     paneLayoutRef.current = s.layout;
   }, [s.layout]);
   const focusTerminalSoon = useCallback(() => {
-    if (!isActivePaneRef.current) return;
+    if (!isActivePaneRef.current || composerOpenRef.current) return;
     if (shouldAvoidVirtualKeyboard()) return;
     requestAnimationFrame(() => {
       window.setTimeout(() => {
-        if (!connectionClient.isCurrent()) return;
+        if (!connectionClient.isCurrent() || composerOpenRef.current) return;
         const term = termRef.current;
         const active = document.activeElement;
         const activeElement = active instanceof HTMLElement ? active : null;
@@ -745,6 +757,7 @@ export function TerminalView({
     let terminalEffectDisposed = false;
     const term = new Terminal({
       cursorBlink: true,
+      disableStdin: composerOpenRef.current,
       fontFamily: FONT_FAMILY,
       ...terminalDensity(),
       theme: {
@@ -833,6 +846,7 @@ export function TerminalView({
     let pastePaneIdBeforeInput: string | null = null;
     let lastTerminalTextareaSnapshot = readTerminalTextareaSnapshot();
     term.onData((data) => {
+      if (composerOpenRef.current) return;
       const unsuppressedData = imeTextareaFallback.recordXtermData(data);
       if (!unsuppressedData) return;
       const dataAt = performance.now();
@@ -973,6 +987,7 @@ export function TerminalView({
     ro.observe(container);
 
     const sendText = (text: string) => {
+      if (composerOpenRef.current) return;
       const terminalId = desiredTerminalRef.current;
       if (!terminalId) return;
       const bytes = new TextEncoder().encode(text);
@@ -982,7 +997,7 @@ export function TerminalView({
       text: string,
       destinationPaneId: string | null = paneIdRef.current ?? null,
     ) => {
-      if (!text) return;
+      if (!text || composerOpenRef.current) return;
       if (destinationPaneId) {
         const request = terminalPasteRequest(destinationPaneId, text);
         await connectionClient.call(request.method, request.params);
@@ -1057,7 +1072,7 @@ export function TerminalView({
     };
     let clipboardPasteInFlight = false;
     const pasteFromBrowserClipboard = async () => {
-      if (clipboardPasteInFlight) return;
+      if (composerOpenRef.current || clipboardPasteInFlight) return;
       clipboardPasteInFlight = true;
       const destinationPaneId = paneIdRef.current ?? null;
       try {
@@ -1128,6 +1143,11 @@ export function TerminalView({
       isTerminalImeCommittedInputType(input.inputType);
 
     term.attachCustomKeyEventHandler((e) => {
+      if (composerOpenRef.current) {
+        e.preventDefault();
+        e.stopPropagation();
+        return false;
+      }
       if (applePlatform && e.type === "keydown") {
         imeKeyEvent.begin();
       }
@@ -2086,29 +2106,6 @@ export function TerminalView({
               </div>
             </div>
           </div>
-        ) : null}
-        {showMobileKeys ? (
-          <button
-            type="button"
-            className={`terminal-composer-toggle ${
-              composerOpen ? "is-open" : ""
-            }`}
-            title={
-              composerOpen
-                ? "Close terminal composer"
-                : "Open terminal composer"
-            }
-            aria-label={
-              composerOpen
-                ? "Close terminal composer"
-                : "Open terminal composer"
-            }
-            aria-expanded={composerOpen}
-            onPointerDown={preventPaneActionFocus}
-            onClick={() => setComposerOpen((value) => !value)}
-          >
-            <SquarePen size={16} />
-          </button>
         ) : null}
         {composerOpen ? (
           <TerminalComposer

--- a/web/src/components/WorkspaceTree.tsx
+++ b/web/src/components/WorkspaceTree.tsx
@@ -1,6 +1,11 @@
 import { shallowEqual, store, useStoreSelector } from "../store";
 import type { GitStatusSummary, Pane, Workspace } from "../types";
 import { shortId } from "../utils";
+import {
+  clearTerminalComposerDrafts,
+  terminalComposerCloseWarning,
+  terminalComposerDraftPaneIds,
+} from "../terminalComposer";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { ContextMenu, type ContextMenuState } from "./ContextMenu";
 import { CreateWorkspaceDialog } from "./CreateWorkspaceDialog";
@@ -178,6 +183,7 @@ export function WorkspaceTree({
   const s = useStoreSelector(
     (state) => ({
       activeConnectionId: state.activeConnectionId,
+      connectionGeneration: state.connectionGeneration,
       lastRefresh: state.lastRefresh,
       layout: state.layout,
       panes: state.panes,
@@ -476,14 +482,27 @@ export function WorkspaceTree({
         title="Close Agent Pane"
         message={
           pendingClosePane
-            ? `Close pane "${shortId(pendingClosePane.pane_id)}"?`
+            ? `Close pane "${shortId(pendingClosePane.pane_id)}"?${terminalComposerCloseWarning(
+                terminalComposerDraftPaneIds(
+                  s.activeConnectionId,
+                  s.connectionGeneration,
+                  [pendingClosePane.pane_id],
+                ).length,
+              )}`
             : "Close this pane?"
         }
         confirmLabel="Close"
         danger
         onClose={() => setPendingClosePane(null)}
         onConfirm={() => {
-          if (pendingClosePane) store.closePane(pendingClosePane.pane_id);
+          if (pendingClosePane) {
+            clearTerminalComposerDrafts(
+              s.activeConnectionId,
+              s.connectionGeneration,
+              [pendingClosePane.pane_id],
+            );
+            store.closePane(pendingClosePane.pane_id);
+          }
         }}
       />
       <CreateWorkspaceDialog

--- a/web/src/components/overlayScrollbar.test.ts
+++ b/web/src/components/overlayScrollbar.test.ts
@@ -14,6 +14,7 @@ describe("overlay scrollbar exclusions", () => {
       ".pane-jump-popover",
       ".agent-session-export-menu",
       ".terminal-mobile-keys-panel",
+      ".terminal-composer-shortcuts",
       "[role=dialog]",
       "[role=menu]",
       "[role=listbox]",

--- a/web/src/components/overlayScrollbar.ts
+++ b/web/src/components/overlayScrollbar.ts
@@ -7,6 +7,7 @@ export const OVERLAY_SCROLLBAR_EXCLUDED_SELECTOR = [
   ".agent-session-export-menu",
   ".agent-history-minimap",
   ".terminal-mobile-keys-panel",
+  ".terminal-composer-shortcuts",
   "[role=dialog]",
   "[role=menu]",
   "[role=listbox]",

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7549,11 +7549,11 @@ textarea:focus {
 .terminal-mobile-side-shortcuts {
   display: none;
 }
-.terminal-composer-toggle,
 .terminal-composer {
   display: none;
 }
 .mobile-controls-toggle,
+.mobile-terminal-controls,
 .mobile-workspace-shortcut {
   display: none;
 }
@@ -7859,7 +7859,55 @@ textarea:focus {
     -webkit-backdrop-filter: blur(14px);
     backdrop-filter: blur(14px);
   }
-  .mobile-nav button {
+  .mobile-terminal-controls {
+    position: fixed;
+    right: calc(10px + env(safe-area-inset-right, 0px));
+    bottom: calc(
+      106px +
+      env(safe-area-inset-bottom, 0px) +
+      var(--keyboard-inset-bottom, 0px)
+    );
+    z-index: 74;
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    padding: 4px;
+    border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--panel) 76%, transparent);
+    box-shadow: var(--shadow-lg);
+    transform: translate3d(0, 0, 0) scale(1);
+    transform-origin: right bottom;
+    opacity: 1;
+    transition:
+      opacity 160ms ease,
+      transform 180ms ease;
+    -webkit-backdrop-filter: blur(14px);
+    backdrop-filter: blur(14px);
+  }
+  .mobile-nav.mobile-terminal-tools {
+    position: static;
+    right: auto;
+    bottom: auto;
+    z-index: auto;
+    max-width: 75px;
+    padding: 0;
+    overflow: visible;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+    transform: translate3d(0, 0, 0) scale(1);
+    transform-origin: right center;
+    transition:
+      max-width 180ms ease,
+      opacity 160ms ease,
+      transform 180ms ease;
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+  .mobile-nav button,
+  .mobile-controls-toggle {
     position: relative;
     width: 32px;
     min-width: 32px;
@@ -7882,7 +7930,8 @@ textarea:focus {
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
   }
-  .mobile-nav button.active {
+  .mobile-nav button.active,
+  .mobile-controls-toggle:active {
     background: var(--accent-soft);
     color: var(--text-strong);
     box-shadow: inset 0 0 0 1px var(--accent);
@@ -7906,6 +7955,17 @@ textarea:focus {
     font-weight: 800;
     line-height: 15px;
     text-align: center;
+    pointer-events: none;
+  }
+  .mobile-composer-draft-dot {
+    position: absolute;
+    top: 1px;
+    right: 1px;
+    width: 7px;
+    height: 7px;
+    border: 1px solid var(--panel);
+    border-radius: 999px;
+    background: var(--accent);
     pointer-events: none;
   }
   .mobile-tab-sheet-backdrop {
@@ -8048,60 +8108,37 @@ textarea:focus {
     transform: translate3d(0, 50px, 0) scale(0.72);
   }
   .mobile-controls-toggle {
-    position: fixed;
-    right: calc(10px + env(safe-area-inset-right, 0px));
-    bottom: calc(
-      106px +
-      env(safe-area-inset-bottom, 0px) +
-      var(--keyboard-inset-bottom, 0px)
-    );
-    z-index: 74;
-    width: 42px;
-    height: 42px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 4px;
-    border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--panel) 76%, transparent);
     color: var(--text-strong);
-    box-shadow: var(--shadow-lg);
-    transform: translate3d(0, 0, 0) scale(1);
-    transition:
-      bottom 180ms ease,
-      opacity 160ms ease,
-      background 120ms ease,
-      border-color 120ms ease,
-      transform 180ms ease;
-    -webkit-backdrop-filter: blur(14px);
-    backdrop-filter: blur(14px);
-  }
-  .mobile-controls-toggle svg {
-    width: 32px;
-    height: 32px;
-    padding: 7px;
-    border-radius: 999px;
-    background: transparent;
-  }
-  .mobile-controls-toggle:active {
-    border-color: var(--accent);
-    background: var(--accent-soft);
-    transform: scale(0.94);
   }
   /* While the on-screen keyboard is open the floating controls cover too
      much of the terminal, so fade them out until the keyboard closes. */
-  .keyboard-open .mobile-nav,
+  .keyboard-open .mobile-nav:not(.mobile-terminal-tools),
   .keyboard-open .mobile-workspace-shortcut,
-  .keyboard-open .mobile-controls-toggle {
+  .keyboard-open .mobile-terminal-controls {
     opacity: 0;
     pointer-events: none;
     transform: translate3d(0, 12px, 0) scale(0.85);
   }
-  .mobile-controls-collapsed .mobile-nav {
+  .keyboard-open .terminal-mobile-keys,
+  .keyboard-open .terminal-mobile-side-shortcuts {
+    visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+  }
+  .mobile-controls-collapsed .mobile-nav:not(.mobile-terminal-tools) {
     opacity: 0;
     pointer-events: none;
     transform: translate3d(0, -46px, 0) scale(0.72);
+  }
+  .mobile-controls-collapsed .mobile-terminal-controls {
+    gap: 0;
+  }
+  .mobile-controls-collapsed .mobile-terminal-tools {
+    max-width: 0;
+    overflow: hidden;
+    opacity: 0;
+    pointer-events: none;
+    transform: translate3d(10px, 0, 0) scale(0.72);
   }
 
   .body {
@@ -8393,27 +8430,12 @@ textarea:focus {
     line-height: 1.1;
   }
   .terminal-mobile-keys-toggle,
-  .terminal-mobile-keys-panel,
-  .terminal-composer-toggle {
+  .terminal-mobile-keys-panel {
     border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
     background: color-mix(in srgb, var(--panel) 68%, transparent);
     box-shadow: var(--shadow-lg);
     -webkit-backdrop-filter: blur(14px);
     backdrop-filter: blur(14px);
-  }
-  .terminal-composer-toggle {
-    position: absolute;
-    /* Clear the fully opened mobile-keys panel: 10px top offset + ~64px for
-       two 28px shortcut rows + padding, plus a visible gap. */
-    top: 84px;
-    right: calc(8px + env(safe-area-inset-right, 0px));
-    z-index: 7;
-    display: inline-flex;
-  }
-  .terminal-composer-toggle:active,
-  .terminal-composer-toggle.is-open {
-    border-color: var(--accent);
-    background: var(--accent-soft);
   }
   /* With the composer open the shell stacks its children vertically, so the
      terminal shrinks to make room instead of being covered by an overlay. */
@@ -8459,6 +8481,21 @@ textarea:focus {
     outline: none;
     border-color: color-mix(in srgb, var(--accent) 70%, var(--border));
   }
+  .terminal-shell:has(.terminal-composer-input:focus) .terminal-mobile-keys,
+  .terminal-shell:has(.terminal-composer-input:focus)
+    .terminal-mobile-side-shortcuts,
+  .app:has(.terminal-composer-input:focus) > .mobile-nav,
+  .app:has(.terminal-composer-input:focus) .mobile-workspace-shortcut,
+  .app:has(.terminal-composer-input:focus) .mobile-terminal-controls {
+    visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+  }
+  .app:has(.terminal-composer-input:focus) > .mobile-nav,
+  .app:has(.terminal-composer-input:focus) .mobile-workspace-shortcut,
+  .app:has(.terminal-composer-input:focus) .mobile-terminal-controls {
+    transform: translate3d(0, 12px, 0) scale(0.85);
+  }
   .terminal-composer-actions {
     display: flex;
     align-items: center;
@@ -8496,7 +8533,9 @@ textarea:focus {
     opacity: 0.45;
   }
   .terminal-composer-close,
-  .terminal-composer-attach {
+  .terminal-composer-shortcuts-toggle,
+  .terminal-composer-attach,
+  .terminal-composer-help {
     width: 30px;
     padding: 0;
     flex: 0 0 auto;
@@ -8505,7 +8544,8 @@ textarea:focus {
     padding: 0 10px;
     flex: 0 0 auto;
   }
-  .terminal-composer-submit.is-primary {
+  .terminal-composer-submit.is-primary,
+  .terminal-composer-shortcuts-toggle.is-open {
     border-color: var(--accent);
     background: var(--accent-soft);
   }
@@ -8513,8 +8553,7 @@ textarea:focus {
     border-color: var(--accent);
     background: var(--accent-soft);
   }
-  .terminal-mobile-keys-toggle,
-  .terminal-composer-toggle {
+  .terminal-mobile-keys-toggle {
     width: 36px;
     height: 36px;
     display: inline-flex;
@@ -8699,6 +8738,39 @@ textarea:focus {
   .terminal-mobile-side-shortcuts button:active {
     border-color: var(--accent);
     background: var(--accent-soft);
+  }
+  @media (hover: none) and (pointer: coarse) and (forced-colors: none) {
+    .mobile-terminal-controls
+      button:hover:not(:disabled):not(.active):not(:active) {
+      border-color: transparent;
+      background: transparent;
+      box-shadow: none;
+    }
+    .mobile-workspace-shortcut:hover:not(:disabled):not(.is-active):not(
+        :active
+      ) {
+      border-color: color-mix(in srgb, var(--border) 72%, transparent);
+      background: color-mix(in srgb, var(--panel) 76%, transparent);
+      box-shadow: var(--shadow-lg);
+      color: var(--muted);
+    }
+    .terminal-mobile-keys:not(.is-open)
+      .terminal-mobile-keys-toggle:hover:not(:disabled):not(:active) {
+      border-color: color-mix(in srgb, var(--border) 72%, transparent);
+      background: color-mix(in srgb, var(--panel) 68%, transparent);
+      box-shadow: var(--shadow-lg);
+    }
+    .terminal-composer-shortcuts button:hover:not(:disabled):not(:active),
+    .terminal-mobile-keys-panel button:hover:not(:disabled):not(:active) {
+      border-color: color-mix(in srgb, var(--border) 72%, var(--text) 28%);
+      background: color-mix(in srgb, var(--panel-2) 76%, transparent);
+      box-shadow: none;
+    }
+    .terminal-mobile-side-shortcuts button:hover:not(:disabled):not(:active) {
+      border-color: color-mix(in srgb, var(--border) 72%, var(--text) 28%);
+      background: color-mix(in srgb, var(--panel) 70%, transparent);
+      box-shadow: var(--shadow-lg);
+    }
   }
   .terminal-view {
     border-right: none;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6750,6 +6750,16 @@ textarea:focus {
   min-height: 0;
   display: flex;
 }
+/* Flex child that owns the terminal region. The mobile composer docks below
+   it as a sibling, so overlays that must center over the terminal (side
+   shortcuts) anchor here instead of the whole shell. */
+.terminal-main {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+}
 .terminal-view {
   flex: 1 1 auto;
   width: 100%;
@@ -7537,6 +7547,10 @@ textarea:focus {
 }
 .terminal-mobile-keys,
 .terminal-mobile-side-shortcuts {
+  display: none;
+}
+.terminal-composer-toggle,
+.terminal-composer {
   display: none;
 }
 .mobile-controls-toggle,
@@ -8379,14 +8393,128 @@ textarea:focus {
     line-height: 1.1;
   }
   .terminal-mobile-keys-toggle,
-  .terminal-mobile-keys-panel {
+  .terminal-mobile-keys-panel,
+  .terminal-composer-toggle {
     border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
     background: color-mix(in srgb, var(--panel) 68%, transparent);
     box-shadow: var(--shadow-lg);
     -webkit-backdrop-filter: blur(14px);
     backdrop-filter: blur(14px);
   }
-  .terminal-mobile-keys-toggle {
+  .terminal-composer-toggle {
+    position: absolute;
+    /* Clear the fully opened mobile-keys panel: 10px top offset + ~64px for
+       two 28px shortcut rows + padding, plus a visible gap. */
+    top: 84px;
+    right: calc(8px + env(safe-area-inset-right, 0px));
+    z-index: 7;
+    display: inline-flex;
+  }
+  .terminal-composer-toggle:active,
+  .terminal-composer-toggle.is-open {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+  }
+  /* With the composer open the shell stacks its children vertically, so the
+     terminal shrinks to make room instead of being covered by an overlay. */
+  .terminal-shell:has(.terminal-composer) {
+    flex-direction: column;
+  }
+  .terminal-composer {
+    /* In-flow at the bottom of the column shell. The margin lifts the action
+       row past the iOS form accessory bar: the app-level
+       --keyboard-inset-content lift under-reports the keyboard occlusion by
+       that trim by design, and the difference is 0 on Android and whenever
+       the keyboard is closed. */
+    margin-bottom: calc(
+      var(--keyboard-inset-bottom, 0px) -
+      var(--keyboard-inset-content, 0px)
+    );
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px calc(8px + env(safe-area-inset-right, 0px))
+      calc(8px + env(safe-area-inset-bottom, 0px))
+      calc(8px + env(safe-area-inset-left, 0px));
+    border-top: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+    background: color-mix(in srgb, var(--panel) 86%, transparent);
+    -webkit-backdrop-filter: blur(14px);
+    backdrop-filter: blur(14px);
+  }
+  .terminal-composer-input {
+    width: 100%;
+    min-height: 38px;
+    max-height: 32dvh;
+    resize: none;
+    padding: 8px 10px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--panel-2);
+    color: var(--text-strong);
+    font-size: 16px;
+    line-height: 1.4;
+    overscroll-behavior: contain;
+  }
+  .terminal-composer-input:focus {
+    outline: none;
+    border-color: color-mix(in srgb, var(--accent) 70%, var(--border));
+  }
+  .terminal-composer-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .terminal-composer-hint {
+    flex: 1 1 auto;
+    min-width: 0;
+    color: var(--muted);
+    font-size: 11px;
+    text-align: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .terminal-composer-actions button {
+    height: 30px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    border: 1px solid color-mix(in srgb, var(--border) 72%, var(--text) 28%);
+    border-radius: 7px;
+    background: color-mix(in srgb, var(--panel-2) 76%, transparent);
+    color: var(--text-strong);
+    font-size: 12px;
+    font-weight: 600;
+    touch-action: manipulation;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .terminal-composer-actions button:disabled {
+    opacity: 0.45;
+  }
+  .terminal-composer-close,
+  .terminal-composer-attach {
+    width: 30px;
+    padding: 0;
+    flex: 0 0 auto;
+  }
+  .terminal-composer-submit {
+    padding: 0 10px;
+    flex: 0 0 auto;
+  }
+  .terminal-composer-submit.is-primary {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+  }
+  .terminal-composer-actions button:active:not(:disabled) {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+  }
+  .terminal-mobile-keys-toggle,
+  .terminal-composer-toggle {
     width: 36px;
     height: 36px;
     display: inline-flex;
@@ -8401,6 +8529,56 @@ textarea:focus {
     -webkit-user-select: none;
     -webkit-touch-callout: none;
     -webkit-tap-highlight-color: transparent;
+  }
+  .terminal-composer-shortcuts {
+    width: max-content;
+    max-width: 100%;
+    display: grid;
+    grid-template-columns: repeat(var(--mobile-shortcut-columns), 48px);
+    gap: 2px;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .terminal-composer-shortcuts::-webkit-scrollbar {
+    display: none;
+  }
+  .terminal-composer-shortcut-row {
+    grid-column: 1 / -1;
+    display: flex;
+    gap: 2px;
+  }
+  .terminal-composer-shortcuts button {
+    width: 48px;
+    min-width: 0;
+    height: 28px;
+    flex: 0 0 48px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 4px;
+    border: 1px solid color-mix(in srgb, var(--border) 72%, var(--text) 28%);
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--panel-2) 76%, transparent);
+    color: var(--text-strong);
+    overflow: hidden;
+    font:
+      700 11px / 1 ui-monospace,
+      SFMono-Regular,
+      Menlo,
+      Consolas,
+      monospace;
+    letter-spacing: 0;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    touch-action: manipulation;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .terminal-composer-shortcuts button:active {
+    border-color: var(--accent);
+    background: var(--accent-soft);
   }
   .terminal-mobile-keys-toggle:active,
   .terminal-mobile-keys.is-open .terminal-mobile-keys-toggle {
@@ -8559,6 +8737,11 @@ textarea:focus {
   }
   .terminal-view .xterm {
     padding: 5px 0 calc(6px + env(safe-area-inset-bottom, 0px)) 6px;
+  }
+  /* The composer already carries the bottom safe-area padding, so the
+     terminal above it drops the extra inset that otherwise reads as a gap. */
+  .terminal-shell:has(.terminal-composer) .terminal-view .xterm {
+    padding-bottom: 6px;
   }
   .terminal-empty {
     border-radius: 0;

--- a/web/src/terminalComposer.test.ts
+++ b/web/src/terminalComposer.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test";
+import {
+  clearTerminalComposerDraft,
+  clearTerminalComposerDrafts,
+  readTerminalComposerDraft,
+  terminalComposerCloseWarning,
+  terminalComposerDraftCount,
+  terminalComposerDraftKey,
+  terminalComposerDraftPaneIds,
+  terminalComposerInsertAtCaret,
+  terminalComposerRequest,
+  writeTerminalComposerDraft,
+} from "./terminalComposer";
+
+describe("terminal composer drafts", () => {
+  test("scopes drafts by connection, generation, and pane", () => {
+    const first = terminalComposerDraftKey("conn-a", 1, "pane-1");
+    const switchedPane = terminalComposerDraftKey("conn-a", 1, "pane-2");
+    const reconnected = terminalComposerDraftKey("conn-a", 2, "pane-1");
+    const otherConnection = terminalComposerDraftKey("conn-b", 1, "pane-1");
+    const keys = [first, switchedPane, reconnected, otherConnection];
+    expect(new Set(keys).size).toBe(keys.length);
+
+    writeTerminalComposerDraft(first, "draft one");
+    writeTerminalComposerDraft(switchedPane, "draft two");
+    expect(readTerminalComposerDraft(first)).toBe("draft one");
+    expect(readTerminalComposerDraft(switchedPane)).toBe("draft two");
+    expect(readTerminalComposerDraft(reconnected)).toBe("");
+    expect(readTerminalComposerDraft(otherConnection)).toBe("");
+
+    clearTerminalComposerDraft(first);
+    clearTerminalComposerDraft(switchedPane);
+  });
+
+  test("digit-ending connection ids cannot collide across generations", () => {
+    const first = terminalComposerDraftKey("srv1", 2, "pane-1");
+    const second = terminalComposerDraftKey("srv", 12, "pane-1");
+    expect(first).not.toBe(second);
+
+    writeTerminalComposerDraft(first, "draft one");
+    writeTerminalComposerDraft(second, "draft two");
+    expect(readTerminalComposerDraft(first)).toBe("draft one");
+    expect(readTerminalComposerDraft(second)).toBe("draft two");
+
+    clearTerminalComposerDraft(first);
+    clearTerminalComposerDraft(second);
+  });
+
+  test("drops empty drafts instead of retaining them", () => {
+    const key = terminalComposerDraftKey("conn-c", 1, "pane-9");
+    const before = terminalComposerDraftCount();
+    writeTerminalComposerDraft(key, "hello");
+    expect(terminalComposerDraftCount()).toBe(before + 1);
+    writeTerminalComposerDraft(key, "");
+    expect(terminalComposerDraftCount()).toBe(before);
+    expect(readTerminalComposerDraft(key)).toBe("");
+  });
+
+  test("finds and clears drafts only for the given panes", () => {
+    writeTerminalComposerDraft(terminalComposerDraftKey("c", 1, "p1"), "a");
+    writeTerminalComposerDraft(terminalComposerDraftKey("c", 1, "p2"), "");
+    writeTerminalComposerDraft(terminalComposerDraftKey("c", 1, "p3"), "b");
+    writeTerminalComposerDraft(terminalComposerDraftKey("c", 2, "p1"), "gen");
+
+    expect(terminalComposerDraftPaneIds("c", 1, ["p1", "p2", "p3"])).toEqual([
+      "p1",
+      "p3",
+    ]);
+
+    clearTerminalComposerDrafts("c", 1, ["p1", "p3"]);
+    expect(terminalComposerDraftPaneIds("c", 1, ["p1", "p2", "p3"])).toEqual(
+      [],
+    );
+    // Other generations stay untouched.
+    expect(
+      readTerminalComposerDraft(terminalComposerDraftKey("c", 2, "p1")),
+    ).toBe("gen");
+    clearTerminalComposerDrafts("c", 2, ["p1"]);
+  });
+
+  test("close warning matches the draft count", () => {
+    expect(terminalComposerCloseWarning(0)).toBe("");
+    expect(terminalComposerCloseWarning(1)).toBe(
+      " The unsent composer draft will be discarded.",
+    );
+    expect(terminalComposerCloseWarning(3)).toBe(
+      " 3 unsent composer drafts will be discarded.",
+    );
+  });
+});
+
+describe("terminal composer request", () => {
+  test("inserts text without any keys when not submitting", () => {
+    const request = terminalComposerRequest("p3", "echo 你好", false);
+    expect(request.method).toBe("pane.send_input");
+    expect(request.params).toEqual({
+      pane_id: "p3",
+      text: "echo 你好",
+      keys: [],
+    });
+  });
+
+  test("sends exactly one enter key when submitting", () => {
+    const request = terminalComposerRequest("p3", "ls", true);
+    expect(request.params.keys).toEqual(["enter"]);
+  });
+
+  test("normalizes newlines like terminal paste", () => {
+    const request = terminalComposerRequest("p3", "one\r\ntwo\nthree", true);
+    expect(request.params.text).toBe("one\rtwo\rthree");
+  });
+});
+
+describe("terminal composer caret insertion", () => {
+  const insert = (
+    text: string,
+    selectionStart: number,
+    selectionEnd: number,
+    insertion: string,
+  ) =>
+    terminalComposerInsertAtCaret(
+      text,
+      selectionStart,
+      selectionEnd,
+      insertion,
+    );
+
+  test("inserts into empty text with a trailing space", () => {
+    expect(insert("", 0, 0, "/tmp/a.png")).toEqual({
+      text: "/tmp/a.png ",
+      caret: 11,
+    });
+  });
+
+  test("pads around non-whitespace neighbors", () => {
+    expect(insert("cat", 3, 3, "/tmp/a.png")).toEqual({
+      text: "cat /tmp/a.png ",
+      caret: 15,
+    });
+    expect(insert("|base64", 0, 0, "/tmp/a.png")).toEqual({
+      text: "/tmp/a.png |base64",
+      caret: 11,
+    });
+    expect(insert("echo hi", 4, 4, "/tmp/a.png")).toEqual({
+      text: "echo /tmp/a.png hi",
+      caret: 15,
+    });
+  });
+
+  test("continued typing after an end insertion stays a separate word", () => {
+    const inserted = insert("cat", 3, 3, "/tmp/a.png");
+    expect(`${inserted.text}hello`).toBe("cat /tmp/a.png hello");
+  });
+
+  test("does not double up existing whitespace", () => {
+    expect(insert("cat ", 4, 4, "/tmp/a.png")).toEqual({
+      text: "cat /tmp/a.png ",
+      caret: 15,
+    });
+    expect(insert(" /tmp", 0, 0, "x.png")).toEqual({
+      text: "x.png /tmp",
+      caret: 5,
+    });
+  });
+
+  test("replaces the current selection", () => {
+    expect(insert("cat old.png now", 4, 11, "/tmp/new.png")).toEqual({
+      text: "cat /tmp/new.png now",
+      caret: 16,
+    });
+  });
+});

--- a/web/src/terminalComposer.test.ts
+++ b/web/src/terminalComposer.test.ts
@@ -1,15 +1,28 @@
 import { describe, expect, test } from "bun:test";
 import {
+  activateTerminalComposerDraftScope,
+  beginTerminalComposerSubmission,
+  beginTerminalComposerUpload,
   clearTerminalComposerDraft,
   clearTerminalComposerDrafts,
+  finishTerminalComposerSubmission,
+  finishTerminalComposerUpload,
+  insertIntoTerminalComposerDraft,
   readTerminalComposerDraft,
+  readTerminalComposerSelection,
+  subscribeTerminalComposerDraft,
+  subscribeTerminalComposerSubmission,
+  subscribeTerminalComposerUpload,
   terminalComposerCloseWarning,
   terminalComposerDraftCount,
   terminalComposerDraftKey,
   terminalComposerDraftPaneIds,
   terminalComposerInsertAtCaret,
   terminalComposerRequest,
+  terminalComposerSubmissionPending,
+  terminalComposerUploadCount,
   writeTerminalComposerDraft,
+  writeTerminalComposerSelection,
 } from "./terminalComposer";
 
 describe("terminal composer drafts", () => {
@@ -76,6 +89,135 @@ describe("terminal composer drafts", () => {
       readTerminalComposerDraft(terminalComposerDraftKey("c", 2, "p1")),
     ).toBe("gen");
     clearTerminalComposerDrafts("c", 2, ["p1"]);
+  });
+
+  test("notifies active composers when async work updates a draft", () => {
+    const key = terminalComposerDraftKey("notify", 1, "p1");
+    const observed: string[] = [];
+    const unsubscribe = subscribeTerminalComposerDraft(key, (text) =>
+      observed.push(text),
+    );
+
+    writeTerminalComposerDraft(key, "sent command");
+    clearTerminalComposerDraft(key);
+    unsubscribe();
+    writeTerminalComposerDraft(key, "after unsubscribe");
+
+    expect(observed).toEqual(["sent command", ""]);
+    clearTerminalComposerDraft(key);
+  });
+
+  test("serializes submissions per draft key across mounts", () => {
+    const first = terminalComposerDraftKey("submit", 1, "p1");
+    const otherPane = terminalComposerDraftKey("submit", 1, "p2");
+    const observed: boolean[] = [];
+    const unsubscribe = subscribeTerminalComposerSubmission(first, (pending) =>
+      observed.push(pending),
+    );
+
+    expect(beginTerminalComposerSubmission(first)).toBe(true);
+    expect(terminalComposerSubmissionPending(first)).toBe(true);
+    expect(beginTerminalComposerSubmission(first)).toBe(false);
+    expect(beginTerminalComposerSubmission(otherPane)).toBe(true);
+
+    finishTerminalComposerSubmission(first);
+    expect(terminalComposerSubmissionPending(first)).toBe(false);
+    expect(observed).toEqual([true, false]);
+
+    unsubscribe();
+    finishTerminalComposerSubmission(otherPane);
+  });
+
+  test("tracks uploads across composer remounts", () => {
+    const key = terminalComposerDraftKey("upload-pending", 1, "p1");
+    const observed: number[] = [];
+    const unsubscribe = subscribeTerminalComposerUpload(key, (count) =>
+      observed.push(count),
+    );
+
+    expect(beginTerminalComposerUpload(key)).toBe(true);
+    expect(terminalComposerUploadCount(key)).toBe(1);
+    expect(beginTerminalComposerUpload(key)).toBe(true);
+    finishTerminalComposerUpload(key);
+    expect(terminalComposerUploadCount(key)).toBe(1);
+    finishTerminalComposerUpload(key);
+
+    expect(terminalComposerUploadCount(key)).toBe(0);
+    expect(observed).toEqual([1, 2, 1, 0]);
+    unsubscribe();
+  });
+
+  test("inserts async results into the latest shared draft", () => {
+    const key = terminalComposerDraftKey("upload", 1, "p1");
+    writeTerminalComposerDraft(key, "newer edits");
+
+    expect(insertIntoTerminalComposerDraft(key, "/tmp/image.png")).toEqual({
+      text: "newer edits /tmp/image.png ",
+      caret: 27,
+    });
+    expect(readTerminalComposerDraft(key)).toBe("newer edits /tmp/image.png ");
+
+    clearTerminalComposerDraft(key);
+  });
+
+  test("uses the latest shared caret when an upload completes after remount", () => {
+    const key = terminalComposerDraftKey("caret", 1, "p1");
+    writeTerminalComposerDraft(key, "echo after");
+    // A newly mounted textarea publishes its current selection under the same
+    // draft key before an upload started by the prior mount completes.
+    writeTerminalComposerSelection(key, 5, 5);
+
+    expect(insertIntoTerminalComposerDraft(key, "/tmp/image.png")).toEqual({
+      text: "echo /tmp/image.png after",
+      caret: 20,
+    });
+    expect(readTerminalComposerSelection(key)).toEqual({ start: 20, end: 20 });
+
+    clearTerminalComposerDraft(key);
+    expect(readTerminalComposerSelection(key)).toBeNull();
+  });
+
+  test("retires drafts, submissions, uploads, and stale writes on scope changes", () => {
+    const first = terminalComposerDraftKey("conn-a", 1, "p1");
+    const second = terminalComposerDraftKey("conn-b", 2, "p1");
+    activateTerminalComposerDraftScope("conn-a", 1);
+    writeTerminalComposerDraft(first, "secret command");
+    expect(beginTerminalComposerSubmission(first)).toBe(true);
+    expect(beginTerminalComposerUpload(first)).toBe(true);
+
+    activateTerminalComposerDraftScope("conn-b", 2);
+
+    expect(readTerminalComposerDraft(first)).toBe("");
+    expect(terminalComposerSubmissionPending(first)).toBe(false);
+    expect(terminalComposerUploadCount(first)).toBe(0);
+    writeTerminalComposerDraft(first, "restored by stale failure");
+    expect(insertIntoTerminalComposerDraft(first, "/tmp/stale.png")).toEqual({
+      text: "",
+      caret: 0,
+    });
+    expect(readTerminalComposerDraft(first)).toBe("");
+
+    writeTerminalComposerDraft(second, "current draft");
+    expect(readTerminalComposerDraft(second)).toBe("current draft");
+    clearTerminalComposerDraft(second);
+  });
+
+  test("pane closure retires async work for that draft key", () => {
+    const key = terminalComposerDraftKey("conn-b", 2, "closing-pane");
+    writeTerminalComposerDraft(key, "draft");
+    expect(beginTerminalComposerSubmission(key)).toBe(true);
+    expect(beginTerminalComposerUpload(key)).toBe(true);
+
+    clearTerminalComposerDrafts("conn-b", 2, ["closing-pane"]);
+
+    expect(terminalComposerSubmissionPending(key)).toBe(false);
+    expect(terminalComposerUploadCount(key)).toBe(0);
+    expect(beginTerminalComposerSubmission(key)).toBe(false);
+    expect(beginTerminalComposerUpload(key)).toBe(false);
+    expect(insertIntoTerminalComposerDraft(key, "/tmp/stale.png")).toEqual({
+      text: "",
+      caret: 0,
+    });
   });
 
   test("close warning matches the draft count", () => {

--- a/web/src/terminalComposer.ts
+++ b/web/src/terminalComposer.ts
@@ -9,6 +9,51 @@ import { prepareTerminalPasteText } from "./terminalPaste";
  * switch never mixes drafts or sends text to the wrong pane.
  */
 const drafts = new Map<string, string>();
+const selections = new Map<string, { start: number; end: number }>();
+const retiredDraftKeys = new Set<string>();
+let activeDraftScopePrefix: string | null = null;
+type TerminalComposerDraftListener = (text: string) => void;
+type TerminalComposerSubmissionListener = (pending: boolean) => void;
+type TerminalComposerUploadListener = (count: number) => void;
+const draftListeners = new Map<string, Set<TerminalComposerDraftListener>>();
+const pendingSubmissions = new Set<string>();
+const submissionListeners = new Map<
+  string,
+  Set<TerminalComposerSubmissionListener>
+>();
+const pendingUploads = new Map<string, number>();
+const uploadListeners = new Map<string, Set<TerminalComposerUploadListener>>();
+
+function notifyTerminalComposerDraft(key: string, text: string): void {
+  for (const listener of draftListeners.get(key) ?? []) listener(text);
+}
+
+function notifyTerminalComposerSubmission(key: string, pending: boolean): void {
+  for (const listener of submissionListeners.get(key) ?? []) listener(pending);
+}
+
+function notifyTerminalComposerUpload(key: string, count: number): void {
+  for (const listener of uploadListeners.get(key) ?? []) listener(count);
+}
+
+function clearTerminalComposerUploads(key: string): void {
+  if (!pendingUploads.delete(key)) return;
+  notifyTerminalComposerUpload(key, 0);
+}
+
+function terminalComposerDraftScopePrefix(
+  connectionId: string,
+  connectionGeneration: number,
+): string {
+  return `${JSON.stringify([connectionId, connectionGeneration]).slice(0, -1)},`;
+}
+
+function terminalComposerDraftKeyIsActive(key: string): boolean {
+  return (
+    !retiredDraftKeys.has(key) &&
+    (activeDraftScopePrefix === null || key.startsWith(activeDraftScopePrefix))
+  );
+}
 
 export function terminalComposerDraftKey(
   connectionId: string,
@@ -24,16 +69,178 @@ export function readTerminalComposerDraft(key: string): string {
   return drafts.get(key) ?? "";
 }
 
-export function writeTerminalComposerDraft(key: string, text: string): void {
-  if (text) {
-    drafts.set(key, text);
-  } else {
-    drafts.delete(key);
+export function readTerminalComposerSelection(
+  key: string,
+): { start: number; end: number } | null {
+  return selections.get(key) ?? null;
+}
+
+/** Records the live textarea selection so async uploads use the latest mount. */
+export function writeTerminalComposerSelection(
+  key: string,
+  selectionStart: number,
+  selectionEnd: number,
+): void {
+  if (!terminalComposerDraftKeyIsActive(key)) return;
+  const length = readTerminalComposerDraft(key).length;
+  if (length === 0) {
+    selections.delete(key);
+    return;
   }
+  const start = Math.max(0, Math.min(selectionStart, length));
+  const end = Math.max(start, Math.min(selectionEnd, length));
+  selections.set(key, { start, end });
+}
+
+export function writeTerminalComposerDraft(key: string, text: string): void {
+  if (!text) {
+    clearTerminalComposerDraft(key);
+    return;
+  }
+  if (!terminalComposerDraftKeyIsActive(key)) return;
+  if (drafts.get(key) === text) return;
+  drafts.set(key, text);
+  notifyTerminalComposerDraft(key, text);
 }
 
 export function clearTerminalComposerDraft(key: string): void {
-  drafts.delete(key);
+  selections.delete(key);
+  if (!drafts.delete(key)) return;
+  notifyTerminalComposerDraft(key, "");
+}
+
+/** Keeps mounted composers synchronized with async updates to their draft. */
+export function subscribeTerminalComposerDraft(
+  key: string,
+  listener: TerminalComposerDraftListener,
+): () => void {
+  const listeners = draftListeners.get(key) ?? new Set();
+  listeners.add(listener);
+  draftListeners.set(key, listeners);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) draftListeners.delete(key);
+  };
+}
+
+export function terminalComposerSubmissionPending(key: string): boolean {
+  return pendingSubmissions.has(key);
+}
+
+/** Starts at most one submission for a pane draft, even across remounts. */
+export function beginTerminalComposerSubmission(key: string): boolean {
+  if (!terminalComposerDraftKeyIsActive(key)) return false;
+  if (pendingSubmissions.has(key)) return false;
+  pendingSubmissions.add(key);
+  notifyTerminalComposerSubmission(key, true);
+  return true;
+}
+
+export function finishTerminalComposerSubmission(key: string): void {
+  if (!pendingSubmissions.delete(key)) return;
+  notifyTerminalComposerSubmission(key, false);
+}
+
+export function subscribeTerminalComposerSubmission(
+  key: string,
+  listener: TerminalComposerSubmissionListener,
+): () => void {
+  const listeners = submissionListeners.get(key) ?? new Set();
+  listeners.add(listener);
+  submissionListeners.set(key, listeners);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) submissionListeners.delete(key);
+  };
+}
+
+export function terminalComposerUploadCount(key: string): number {
+  return pendingUploads.get(key) ?? 0;
+}
+
+/** Tracks uploads across composer remounts for the same pane draft. */
+export function beginTerminalComposerUpload(key: string): boolean {
+  if (!terminalComposerDraftKeyIsActive(key)) return false;
+  const count = terminalComposerUploadCount(key) + 1;
+  pendingUploads.set(key, count);
+  notifyTerminalComposerUpload(key, count);
+  return true;
+}
+
+export function finishTerminalComposerUpload(key: string): void {
+  const count = terminalComposerUploadCount(key);
+  if (count <= 0) return;
+  if (count === 1) {
+    clearTerminalComposerUploads(key);
+    return;
+  }
+  pendingUploads.set(key, count - 1);
+  notifyTerminalComposerUpload(key, count - 1);
+}
+
+export function subscribeTerminalComposerUpload(
+  key: string,
+  listener: TerminalComposerUploadListener,
+): () => void {
+  const listeners = uploadListeners.get(key) ?? new Set();
+  listeners.add(listener);
+  uploadListeners.set(key, listeners);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) uploadListeners.delete(key);
+  };
+}
+
+/**
+ * Activates the app's single browser routing scope. Drafts and submissions
+ * outside it are unreachable, and retired async work cannot write them back.
+ */
+export function activateTerminalComposerDraftScope(
+  connectionId: string,
+  connectionGeneration: number,
+): void {
+  activeDraftScopePrefix = terminalComposerDraftScopePrefix(
+    connectionId,
+    connectionGeneration,
+  );
+  for (const key of drafts.keys()) {
+    if (!terminalComposerDraftKeyIsActive(key)) clearTerminalComposerDraft(key);
+  }
+  for (const key of selections.keys()) {
+    if (!terminalComposerDraftKeyIsActive(key)) selections.delete(key);
+  }
+  for (const key of pendingSubmissions) {
+    if (!terminalComposerDraftKeyIsActive(key)) {
+      finishTerminalComposerSubmission(key);
+    }
+  }
+  for (const key of pendingUploads.keys()) {
+    if (!terminalComposerDraftKeyIsActive(key)) {
+      clearTerminalComposerUploads(key);
+    }
+  }
+}
+
+/** Inserts into the latest shared draft so async completions cannot overwrite it. */
+export function insertIntoTerminalComposerDraft(
+  key: string,
+  insertion: string,
+  selectionStart?: number,
+  selectionEnd?: number,
+): { text: string; caret: number } {
+  const current = readTerminalComposerDraft(key);
+  if (!terminalComposerDraftKeyIsActive(key)) {
+    return { text: current, caret: current.length };
+  }
+  const storedSelection = readTerminalComposerSelection(key);
+  const start = selectionStart ?? storedSelection?.start ?? current.length;
+  const end = selectionEnd ?? storedSelection?.end ?? start;
+  const next = terminalComposerInsertAtCaret(current, start, end, insertion);
+  // Publish the selection before the draft notification so a remounted
+  // subscriber restores this caret when it renders the inserted path.
+  selections.set(key, { start: next.caret, end: next.caret });
+  writeTerminalComposerDraft(key, next.text);
+  return next;
 }
 
 /** Test hook: number of retained drafts. */
@@ -58,16 +265,22 @@ export function terminalComposerDraftPaneIds(
   );
 }
 
-/** Discards drafts for panes the user explicitly confirmed closing. */
+/** Discards drafts and retires async work for panes confirmed closing. */
 export function clearTerminalComposerDrafts(
   connectionId: string,
   connectionGeneration: number,
   paneIds: readonly string[],
 ): void {
   for (const paneId of paneIds) {
-    clearTerminalComposerDraft(
-      terminalComposerDraftKey(connectionId, connectionGeneration, paneId),
+    const key = terminalComposerDraftKey(
+      connectionId,
+      connectionGeneration,
+      paneId,
     );
+    retiredDraftKeys.add(key);
+    clearTerminalComposerDraft(key);
+    finishTerminalComposerSubmission(key);
+    clearTerminalComposerUploads(key);
   }
 }
 

--- a/web/src/terminalComposer.ts
+++ b/web/src/terminalComposer.ts
@@ -1,0 +1,130 @@
+import { prepareTerminalPasteText } from "./terminalPaste";
+
+/**
+ * Draft storage for the mobile terminal composer.
+ *
+ * Drafts live only in memory: terminal input can contain secrets, so they
+ * must never reach localStorage. Keys are scoped by connection identity
+ * (including the reconnect generation) and pane ID, so a reconnect or a pane
+ * switch never mixes drafts or sends text to the wrong pane.
+ */
+const drafts = new Map<string, string>();
+
+export function terminalComposerDraftKey(
+  connectionId: string,
+  connectionGeneration: number,
+  paneId: string,
+): string {
+  // Structured key: plain concatenation would let a digit-ending connection
+  // ID collide across generations ("srv1"+2 vs "srv"+12).
+  return JSON.stringify([connectionId, connectionGeneration, paneId]);
+}
+
+export function readTerminalComposerDraft(key: string): string {
+  return drafts.get(key) ?? "";
+}
+
+export function writeTerminalComposerDraft(key: string, text: string): void {
+  if (text) {
+    drafts.set(key, text);
+  } else {
+    drafts.delete(key);
+  }
+}
+
+export function clearTerminalComposerDraft(key: string): void {
+  drafts.delete(key);
+}
+
+/** Test hook: number of retained drafts. */
+export function terminalComposerDraftCount(): number {
+  return drafts.size;
+}
+
+/**
+ * Returns the subset of paneIds that currently hold a non-empty draft. Close
+ * flows use this to warn before the draft becomes unreachable.
+ */
+export function terminalComposerDraftPaneIds(
+  connectionId: string,
+  connectionGeneration: number,
+  paneIds: readonly string[],
+): string[] {
+  return paneIds.filter(
+    (paneId) =>
+      readTerminalComposerDraft(
+        terminalComposerDraftKey(connectionId, connectionGeneration, paneId),
+      ) !== "",
+  );
+}
+
+/** Discards drafts for panes the user explicitly confirmed closing. */
+export function clearTerminalComposerDrafts(
+  connectionId: string,
+  connectionGeneration: number,
+  paneIds: readonly string[],
+): void {
+  for (const paneId of paneIds) {
+    clearTerminalComposerDraft(
+      terminalComposerDraftKey(connectionId, connectionGeneration, paneId),
+    );
+  }
+}
+
+/**
+ * Sentence appended to a close-confirmation message when the close would
+ * discard composer drafts. Returns "" when there is nothing to warn about.
+ */
+export function terminalComposerCloseWarning(draftCount: number): string {
+  if (draftCount <= 0) return "";
+  return draftCount === 1
+    ? " The unsent composer draft will be discarded."
+    : ` ${draftCount} unsent composer drafts will be discarded.`;
+}
+
+/**
+ * Builds the mode-aware pane input request for a composer submission. The
+ * server wraps the text in bracketed-paste markers only when the PTY has
+ * bracketed paste enabled, and encodes the Enter key for the active terminal
+ * mode. `submit: false` inserts the draft without executing it.
+ */
+export function terminalComposerRequest(
+  paneId: string,
+  text: string,
+  submit: boolean,
+) {
+  return {
+    method: "pane.send_input" as const,
+    params: {
+      pane_id: paneId,
+      text: prepareTerminalPasteText(text),
+      keys: submit ? ["enter"] : ([] as string[]),
+    },
+  };
+}
+
+/**
+ * Inserts an uploaded image path at the composer caret, replacing the current
+ * selection. A single space is added before the path when it would otherwise
+ * touch non-whitespace text, and always after it unless whitespace follows,
+ * so the path stays a separate shell word and continued typing cannot merge
+ * into it. Returns the next draft text and the caret position after it.
+ */
+export function terminalComposerInsertAtCaret(
+  text: string,
+  selectionStart: number,
+  selectionEnd: number,
+  insertion: string,
+): { text: string; caret: number } {
+  const before = text.slice(0, selectionStart);
+  const after = text.slice(selectionEnd);
+  const needsLeadingSpace = before !== "" && !/\s$/.test(before);
+  const needsTrailingSpace = !/^\s/.test(after);
+  const inserted = `${needsLeadingSpace ? " " : ""}${insertion}${
+    needsTrailingSpace ? " " : ""
+  }`;
+  return {
+    text: `${before}${inserted}${after}`,
+    caret: before.length + inserted.length,
+  };
+}

--- a/web/src/terminalImageUpload.test.ts
+++ b/web/src/terminalImageUpload.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { ConnectionClient } from "./api";
+import { uploadTerminalImage } from "./terminalImageUpload";
+
+const originalFetch = globalThis.fetch;
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+const client = {
+  connectionId: "conn-a",
+  generation: 1,
+  serverRuntimeGeneration: 3,
+  call: async () => undefined,
+  isCurrent: () => true,
+  acceptsServerGeneration: () => true,
+} satisfies ConnectionClient;
+const image = new File(["image"], "image.png", { type: "image/png" });
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { location: { origin: "https://studio.example" } },
+  });
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalWindow) {
+    Object.defineProperty(globalThis, "window", originalWindow);
+  } else {
+    delete (globalThis as { window?: unknown }).window;
+  }
+});
+
+describe("terminal image upload responses", () => {
+  test("returns a validated path", async () => {
+    globalThis.fetch = (async () =>
+      Response.json({ path: "/tmp/image.png" })) as unknown as typeof fetch;
+
+    await expect(uploadTerminalImage(client, image)).resolves.toBe(
+      "/tmp/image.png",
+    );
+  });
+
+  test("rejects malformed JSON instead of silently continuing", async () => {
+    globalThis.fetch = (async () =>
+      new Response("{", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch;
+
+    await expect(uploadTerminalImage(client, image)).rejects.toThrow();
+  });
+
+  test("surfaces non-JSON HTTP error bodies", async () => {
+    globalThis.fetch = (async () =>
+      new Response("proxy authentication required", {
+        status: 407,
+        statusText: "Proxy Authentication Required",
+      })) as unknown as typeof fetch;
+
+    await expect(uploadTerminalImage(client, image)).rejects.toThrow(
+      "proxy authentication required",
+    );
+  });
+
+  test("uses structured errors from failed JSON responses", async () => {
+    globalThis.fetch = (async () =>
+      Response.json(
+        { error: "image is too large" },
+        { status: 413, statusText: "Payload Too Large" },
+      )) as unknown as typeof fetch;
+
+    await expect(uploadTerminalImage(client, image)).rejects.toThrow(
+      "image is too large",
+    );
+  });
+
+  test("rejects successful responses without a path", async () => {
+    globalThis.fetch = (async () =>
+      Response.json({})) as unknown as typeof fetch;
+
+    await expect(uploadTerminalImage(client, image)).rejects.toThrow(
+      "image upload response did not include a path",
+    );
+  });
+});

--- a/web/src/terminalImageUpload.ts
+++ b/web/src/terminalImageUpload.ts
@@ -1,0 +1,38 @@
+import type { ConnectionClient } from "./api";
+import { connectionHttpPath } from "./connectionHttp";
+
+/**
+ * Uploads an image through the connection's HTTP endpoint and returns the
+ * server-side path. Callers decide when (or whether) that path reaches a
+ * terminal; uploading here never writes to a PTY by itself.
+ */
+export async function uploadTerminalImage(
+  client: ConnectionClient,
+  file: File,
+): Promise<string> {
+  if (!client.isCurrent()) throw new Error("connection changed during upload");
+  const ext = (file.type.split("/")[1] || "png").toLowerCase();
+  const uploadUrl = new URL(
+    connectionHttpPath(
+      client.connectionId,
+      "/upload-image",
+      client.serverRuntimeGeneration,
+    ),
+    window.location.origin,
+  );
+  if (uploadUrl.origin !== window.location.origin) {
+    throw new Error("invalid upload origin");
+  }
+  const res = await fetch(uploadUrl, {
+    method: "POST",
+    headers: {
+      "x-image-ext": ext,
+      "content-type": file.type || "image/png",
+    },
+    body: file,
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!client.isCurrent()) throw new Error("connection changed during upload");
+  if (!res.ok) throw new Error(data.error || res.statusText);
+  return data.path as string;
+}

--- a/web/src/terminalImageUpload.ts
+++ b/web/src/terminalImageUpload.ts
@@ -31,8 +31,37 @@ export async function uploadTerminalImage(
     },
     body: file,
   });
-  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const body = (await res.text()).trim();
+    if (!client.isCurrent()) {
+      throw new Error("connection changed during upload");
+    }
+    let detail = body;
+    if (body) {
+      try {
+        const payload: unknown = JSON.parse(body);
+        if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+          const error = (payload as { error?: unknown }).error;
+          if (typeof error === "string" && error) detail = error;
+        }
+      } catch {
+        // Auth proxies and generic HTTP servers commonly return plain text or
+        // HTML errors. The response is already a failure, so preserve its body.
+      }
+    }
+    throw new Error(
+      detail || res.statusText || `Image upload failed (${res.status})`,
+    );
+  }
+
+  const data: unknown = await res.json();
   if (!client.isCurrent()) throw new Error("connection changed during upload");
-  if (!res.ok) throw new Error(data.error || res.statusText);
-  return data.path as string;
+  if (data === null || typeof data !== "object" || Array.isArray(data)) {
+    throw new Error("image upload response was not an object");
+  }
+  const payload = data as { path?: unknown };
+  if (typeof payload.path !== "string" || payload.path.length === 0) {
+    throw new Error("image upload response did not include a path");
+  }
+  return payload.path;
 }


### PR DESCRIPTION
## Summary

Refs #70 (slices 1-3).

- **Mobile terminal composer**: a pen toggle opens a bottom-docked panel with a plain textarea where IME, dictation, selection editing, autocorrect, and multiline paste work natively. **Insert** places the draft in the terminal without executing; **Send** adds exactly one Enter. Submissions route through the mode-aware `pane.send_input` API so bracketed paste follows the authoritative PTY mode, avoiding the dropped/duplicated/replayed input of the xterm helper-textarea path on mobile.
- **Draft lifecycle**: drafts stay in memory per connection generation and pane, never persisted. Closing a pane, tab, or workspace with an unsent draft warns first and discards on confirm (all close paths covered: pane toolbar, workspace tree, tab strip/sheet, command palette, context menu).
- **Images**: pasted clipboard images and the image picker upload once through the existing `/upload-image` endpoint and insert the returned path at the caret, padded to stay a separate shell word. Paths reach the terminal only via Insert/Send.
- **Shortcuts**: the configurable mobile shortcut keys also render inside the composer; the standalone shortcut panel and side shortcuts are unchanged.
- **Layout**: the composer docks in-flow so the terminal shrinks instead of being covered, with iOS form-accessory-bar clearance and safe-area handling. Desktop behavior is unchanged.

## Verification

- `bun run precommit` — format, lint, typecheck, 779 tests (12 new unit tests for draft scoping, request construction, caret insertion, close-guard helpers)
- `bun run build:web`
- Manual on physical iPhone (PWA): Chinese → English → Chinese composition, dictation, image paste and picker, accessory-bar clearance, pane switching with drafts, close-pane draft warning

## Not in scope

Issue #70 slice 4 (direct-mode cleanup / possible xterm fork pin) is left for follow-up; the app-level IME recovery for direct terminal input is untouched.