### PR TITLE
Polish mobile terminal composer behavior

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -302,12 +302,13 @@ const viewportDebugEnabled =
   typeof window !== "undefined" &&
   new URLSearchParams(window.location.search).has("debugViewport");
 
-// iOS counts the floating keyboard accessory bar (form assistant) as covered
-// area, over-reporting the keyboard inset. Lift content past that overshoot
-// by default on iOS; Android reports exact insets, so trim stays 0 there.
-// ?kbdTrim=<px> overrides the default for experiments.
-const defaultKeyboardInsetTrim =
-  typeof navigator !== "undefined" && isIosDevice(navigator) ? 30 : 0;
+// Mobile browsers can over-report keyboard occlusion by including an input
+// accessory or browser-control strip. Keep enough visual viewport lift to
+// expose the composer, but trim the platform-specific overshoot.
+const usesIosKeyboardViewportLift =
+  typeof navigator !== "undefined" && isIosDevice(navigator);
+// ?kbdTrim=<px> overrides the default for device-specific experiments.
+const defaultKeyboardInsetTrim = usesIosKeyboardViewportLift ? 30 : 0;
 const keyboardInsetTrim =
   typeof window !== "undefined"
     ? Math.max(
@@ -400,11 +401,20 @@ function useVisualViewportCssVars() {
         "--keyboard-inset-bottom",
         `${Math.round(keyboardInset)}px`,
       );
-      // Content lift used for the app padding. kbdTrim lets us test how far
-      // the terminal surface can extend toward the keyboard accessory bar.
+      // Both platforms need the visual viewport lift here; without it some
+      // Android browsers place the composer behind the software keyboard.
+      const contentInset = Math.max(0, keyboardInset - keyboardInsetTrim);
       root.style.setProperty(
         "--keyboard-inset-content",
-        `${Math.round(Math.max(0, keyboardInset - keyboardInsetTrim))}px`,
+        `${Math.round(contentInset)}px`,
+      );
+      root.style.setProperty(
+        "--keyboard-inset-composer-gap",
+        `${Math.round(
+          usesIosKeyboardViewportLift
+            ? Math.max(0, keyboardInset - contentInset)
+            : 0,
+        )}px`,
       );
       return keyboardOpen;
     };
@@ -466,6 +476,7 @@ function useVisualViewportCssVars() {
       root.style.removeProperty("--app-viewport-offset-top");
       root.style.removeProperty("--keyboard-inset-bottom");
       root.style.removeProperty("--keyboard-inset-content");
+      root.style.removeProperty("--keyboard-inset-composer-gap");
     };
   }, []);
 }
@@ -1038,7 +1049,11 @@ export default function App() {
   const [sidebarHidden, setSidebarHidden] = useState(false);
   const [mobileControlsCollapsed, setMobileControlsCollapsed] = useState(false);
   const [mobileTabSheetOpen, setMobileTabSheetOpen] = useState(false);
-  const [openTerminalComposerDraftKey, setOpenTerminalComposerDraftKey] =
+  const terminalComposerScopeKey = JSON.stringify([
+    s.activeConnectionId,
+    s.connectionGeneration,
+  ]);
+  const [openTerminalComposerScopeKey, setOpenTerminalComposerScopeKey] =
     useState<string | null>(null);
   const [terminalComposerHasDraft, setTerminalComposerHasDraft] =
     useState(false);
@@ -1075,8 +1090,11 @@ export default function App() {
     // Drop mobile-only controls when their context disappears so they cannot
     // stay active invisibly or resurface when the mobile layout returns.
     if (!mobile || !focusedWorkspace) setMobileTabSheetOpen(false);
-    if (!mobile) setOpenTerminalComposerDraftKey(null);
+    if (!mobile) setOpenTerminalComposerScopeKey(null);
   }, [mobile, focusedWorkspace]);
+  useEffect(() => {
+    setOpenTerminalComposerScopeKey(null);
+  }, [terminalComposerScopeKey]);
   const activePaneId = activePaneIdForSnapshot(s);
   const activePane = activePaneId
     ? s.panes.find((pane) => pane.pane_id === activePaneId)
@@ -1091,15 +1109,14 @@ export default function App() {
       : null;
   const terminalComposerOpen =
     mobile &&
-    activeTerminalComposerDraftKey !== null &&
-    openTerminalComposerDraftKey === activeTerminalComposerDraftKey;
+    !mobileTabSheetOpen &&
+    openTerminalComposerScopeKey === terminalComposerScopeKey &&
+    activeTerminalComposerDraftKey !== null;
   const setTerminalComposerOpen = useCallback(
     (open: boolean) => {
-      setOpenTerminalComposerDraftKey(
-        open ? activeTerminalComposerDraftKey : null,
-      );
+      setOpenTerminalComposerScopeKey(open ? terminalComposerScopeKey : null);
     },
-    [activeTerminalComposerDraftKey],
+    [terminalComposerScopeKey],
   );
   useEffect(() => {
     if (!activeTerminalComposerDraftKey) {
@@ -2532,11 +2549,7 @@ export default function App() {
             tabIndex={mobileControlsCollapsed ? -1 : 0}
             disabled={!focusedWorkspace}
             onPointerDown={blurActiveInput}
-            onClick={() => {
-              const open = !mobileTabSheetOpen;
-              setMobileTabSheetOpen(open);
-              if (open) setTerminalComposerOpen(false);
-            }}
+            onClick={() => setMobileTabSheetOpen((open) => !open)}
           >
             <SquareStack size={16} />
             {focusedWorkspaceTabCount > 0 ? (

--- a/web/src/components/MobileTabSheet.tsx
+++ b/web/src/components/MobileTabSheet.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useRef } from "react";
-import { createPortal } from "react-dom";
 import { Plus, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { shallowEqual, store, useStoreSelector } from "../store";
 import { AgentStatusIcon } from "./AgentStatusIcon";
-import { CloseButton } from "./CloseButton";
 import { summarizeTabAgents } from "./agentSession";
+import { CloseButton } from "./CloseButton";
 import { focusDialogElement } from "./dialogFocus";
 import { requestCloseTab, tabName } from "./TabBar";
 
@@ -32,8 +32,27 @@ export function MobileTabSheet({
   );
   const sheetRef = useRef<HTMLDivElement>(null);
   const onCloseRef = useRef(onClose);
+  const transitionPendingRef = useRef(false);
+  const [transitionPending, setTransitionPending] = useState(false);
 
-  onCloseRef.current = onClose;
+  const closeIfIdle = () => {
+    if (!transitionPendingRef.current) onClose();
+  };
+  onCloseRef.current = closeIfIdle;
+
+  const runTabTransition = async (operation: () => Promise<unknown>) => {
+    if (transitionPendingRef.current) return;
+    transitionPendingRef.current = true;
+    setTransitionPending(true);
+    try {
+      await operation();
+      onClose();
+      onShowSession();
+    } finally {
+      transitionPendingRef.current = false;
+      setTransitionPending(false);
+    }
+  };
 
   const focusedWs = s.workspaces.find((w) => w.focused);
   const tabs = focusedWs
@@ -70,7 +89,7 @@ export function MobileTabSheet({
   return createPortal(
     <div
       className="modal-backdrop mobile-tab-sheet-backdrop"
-      onMouseDown={onClose}
+      onMouseDown={closeIfIdle}
     >
       <div
         ref={sheetRef}
@@ -78,12 +97,17 @@ export function MobileTabSheet({
         role="dialog"
         aria-modal="true"
         aria-label="Tabs"
+        aria-busy={transitionPending}
         tabIndex={-1}
         onMouseDown={(event) => event.stopPropagation()}
       >
         <div className="mobile-tab-sheet-head">
           <h3>Tabs</h3>
-          <CloseButton label="Close tab switcher" onClick={onClose} />
+          <CloseButton
+            label="Close tab switcher"
+            disabled={transitionPending}
+            onClick={closeIfIdle}
+          />
         </div>
         <div className="mobile-tab-sheet-list" role="list">
           {tabs.map((t) => {
@@ -98,11 +122,10 @@ export function MobileTabSheet({
                 <button
                   type="button"
                   className="mobile-tab-sheet-focus"
-                  onClick={() => {
-                    store.focusTab(t.tab_id);
-                    onClose();
-                    onShowSession();
-                  }}
+                  disabled={transitionPending}
+                  onClick={() =>
+                    void runTabTransition(() => store.focusTab(t.tab_id))
+                  }
                 >
                   {agentSummary ? (
                     <span
@@ -127,6 +150,7 @@ export function MobileTabSheet({
                   className="mobile-tab-sheet-close"
                   aria-label={`Close ${name}`}
                   title={`Close ${name}`}
+                  disabled={transitionPending}
                   onClick={() => requestCloseTab(t.tab_id)}
                 >
                   <X size={14} />
@@ -138,11 +162,10 @@ export function MobileTabSheet({
         <button
           type="button"
           className="mobile-tab-sheet-new"
-          onClick={() => {
-            store.createTab(focusedWs.workspace_id);
-            onClose();
-            onShowSession();
-          }}
+          disabled={transitionPending}
+          onClick={() =>
+            void runTabTransition(() => store.createTab(focusedWs.workspace_id))
+          }
         >
           <Plus size={15} />
           <span>New Tab</span>

--- a/web/src/components/TerminalComposer.tsx
+++ b/web/src/components/TerminalComposer.tsx
@@ -102,22 +102,27 @@ export function TerminalComposer({
     const composer = composerRef.current;
     if (!composer) return;
     const root = document.documentElement;
-    let measuredValue = "";
-    const updateHeight = () => {
-      measuredValue = `${Math.ceil(composer.getBoundingClientRect().height)}px`;
-      root.style.setProperty("--terminal-composer-height", measuredValue);
+    const viewport = window.visualViewport;
+    const updateControlOverlap = () => {
+      const lowestControl = document.querySelector<HTMLElement>(
+        ".mobile-nav:not(.mobile-terminal-tools)",
+      );
+      const overlaps =
+        lowestControl !== null &&
+        composer.getBoundingClientRect().top <
+          lowestControl.getBoundingClientRect().bottom + 8;
+      root.classList.toggle("terminal-composer-overlaps-controls", overlaps);
     };
-    updateHeight();
-    const observer = new ResizeObserver(updateHeight);
+    updateControlOverlap();
+    const observer = new ResizeObserver(updateControlOverlap);
     observer.observe(composer);
+    window.addEventListener("resize", updateControlOverlap);
+    viewport?.addEventListener("resize", updateControlOverlap);
     return () => {
       observer.disconnect();
-      if (
-        root.style.getPropertyValue("--terminal-composer-height") ===
-        measuredValue
-      ) {
-        root.style.removeProperty("--terminal-composer-height");
-      }
+      window.removeEventListener("resize", updateControlOverlap);
+      viewport?.removeEventListener("resize", updateControlOverlap);
+      root.classList.remove("terminal-composer-overlaps-controls");
     };
   }, []);
 

--- a/web/src/components/TerminalComposer.tsx
+++ b/web/src/components/TerminalComposer.tsx
@@ -101,17 +101,31 @@ export function TerminalComposer({
   useLayoutEffect(() => {
     const composer = composerRef.current;
     if (!composer) return;
-    const root = document.documentElement;
     const viewport = window.visualViewport;
+    const floatingControls = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        ".mobile-nav:not(.mobile-terminal-tools), .mobile-workspace-shortcut, .mobile-terminal-controls",
+      ),
+    );
     const updateControlOverlap = () => {
-      const lowestControl = document.querySelector<HTMLElement>(
-        ".mobile-nav:not(.mobile-terminal-tools)",
+      const interactiveRegions = Array.from(
+        composer.querySelectorAll<HTMLElement>(
+          ".terminal-composer-shortcuts, .terminal-composer-input, .terminal-composer-actions",
+        ),
       );
-      const overlaps =
-        lowestControl !== null &&
-        composer.getBoundingClientRect().top <
-          lowestControl.getBoundingClientRect().bottom + 8;
-      root.classList.toggle("terminal-composer-overlaps-controls", overlaps);
+      for (const control of floatingControls) {
+        const controlRect = control.getBoundingClientRect();
+        const overlaps = interactiveRegions.some((region) => {
+          const regionRect = region.getBoundingClientRect();
+          return (
+            controlRect.left < regionRect.right + 8 &&
+            controlRect.right > regionRect.left - 8 &&
+            controlRect.top < regionRect.bottom + 8 &&
+            controlRect.bottom > regionRect.top - 8
+          );
+        });
+        control.classList.toggle("is-composer-overlapped", overlaps);
+      }
     };
     updateControlOverlap();
     const observer = new ResizeObserver(updateControlOverlap);
@@ -122,7 +136,9 @@ export function TerminalComposer({
       observer.disconnect();
       window.removeEventListener("resize", updateControlOverlap);
       viewport?.removeEventListener("resize", updateControlOverlap);
-      root.classList.remove("terminal-composer-overlaps-controls");
+      for (const control of floatingControls) {
+        control.classList.remove("is-composer-overlapped");
+      }
     };
   }, []);
 

--- a/web/src/components/TerminalComposer.tsx
+++ b/web/src/components/TerminalComposer.tsx
@@ -6,7 +6,13 @@ import {
   Keyboard,
   X,
 } from "lucide-react";
-import { type CSSProperties, useEffect, useRef, useState } from "react";
+import {
+  type CSSProperties,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 import {
   type MobileTerminalShortcut,
@@ -33,6 +39,8 @@ import { MessageDialog } from "./ModalDialogs";
 
 const TERMINAL_COMPOSER_HELP =
   "Input Composer uses your phone’s native editor for reliable IME, dictation, multiline text, and cursor editing before anything is sent to the terminal. Adding an image opens the system file picker, which takes focus from the composer and may dismiss the keyboard. After you choose an image, its uploaded path is inserted into the draft; tap the text area to reopen the keyboard if needed.";
+const TERMINAL_COMPOSER_SHORTCUTS_OPEN_STORAGE_KEY =
+  "terminalComposerShortcutsOpen";
 
 /**
  * Bottom-docked mobile terminal composer. A plain textarea owns all editing
@@ -43,10 +51,9 @@ const TERMINAL_COMPOSER_HELP =
  * virtual-keyboard resizes never lose text.
  *
  * The configurable mobile shortcut keys live at the top of the dock so the
- * composer is the single mobile control surface. Opening the composer focuses
- * the textarea (caret at the end of any restored draft) so the virtual
- * keyboard is ready immediately; the standalone shortcut panel remains for
- * keys-only interactions.
+ * composer is the single mobile control surface. The textarea only receives
+ * focus when the user taps it, so opening the composer does not unexpectedly
+ * summon the virtual keyboard or hide other mobile controls.
  *
  * Images arrive through clipboard paste or the file picker, upload once, and
  * land in the draft as plain paths at the caret; they reach the terminal only
@@ -78,12 +85,41 @@ export function TerminalComposer({
   );
   const [composing, setComposing] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
-  const [shortcutsOpen, setShortcutsOpen] = useState(true);
+  const [shortcutsOpen, setShortcutsOpen] = useState(
+    () =>
+      localStorage.getItem(TERMINAL_COMPOSER_SHORTCUTS_OPEN_STORAGE_KEY) !==
+      "false",
+  );
+  const composerRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const composingRef = useRef(false);
+  const focusSelectionAfterInsertRef = useRef(false);
   const activeDraftKeyRef = useRef(draftKey);
   activeDraftKeyRef.current = draftKey;
+
+  useLayoutEffect(() => {
+    const composer = composerRef.current;
+    if (!composer) return;
+    const root = document.documentElement;
+    let measuredValue = "";
+    const updateHeight = () => {
+      measuredValue = `${Math.ceil(composer.getBoundingClientRect().height)}px`;
+      root.style.setProperty("--terminal-composer-height", measuredValue);
+    };
+    updateHeight();
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(composer);
+    return () => {
+      observer.disconnect();
+      if (
+        root.style.getPropertyValue("--terminal-composer-height") ===
+        measuredValue
+      ) {
+        root.style.removeProperty("--terminal-composer-height");
+      }
+    };
+  }, []);
 
   // Load the incoming pane's draft and subscribe to updates from async work
   // that may outlive an earlier composer mount for this pane.
@@ -103,18 +139,6 @@ export function TerminalComposer({
     return subscribeTerminalComposerUpload(draftKey, setUploadCount);
   }, [draftKey]);
 
-  // Focus on open so the virtual keyboard appears, with the caret parked at
-  // the end of any restored draft. Mount-only: pane switches must not yank
-  // the caret out of an in-progress edit.
-  useEffect(() => {
-    const textarea = textareaRef.current;
-    if (!textarea) return;
-    textarea.focus({ preventScroll: true });
-    const end = textarea.value.length;
-    textarea.setSelectionRange(end, end);
-    writeTerminalComposerSelection(draftKey, end, end);
-  }, []);
-
   // Autosize within the CSS max-height.
   useEffect(() => {
     const textarea = textareaRef.current;
@@ -129,16 +153,15 @@ export function TerminalComposer({
   useEffect(() => {
     const textarea = textareaRef.current;
     const selection = readTerminalComposerSelection(draftKey);
+    const shouldFocus = focusSelectionAfterInsertRef.current;
+    focusSelectionAfterInsertRef.current = false;
     if (!textarea || !selection) return;
-    if (!helpOpen) textarea.focus({ preventScroll: true });
+    if (shouldFocus && !helpOpen) textarea.focus({ preventScroll: true });
     textarea.setSelectionRange(selection.start, selection.end);
   }, [draftKey, helpOpen, text]);
 
-  // No visualViewport lift here: the app shell already lifts its content
-  // above the keyboard with --keyboard-inset-content padding (App.tsx
-  // useVisualViewportCssVars), and the CSS bottom calc adds the small iOS
-  // trim back so the floating form accessory bar clears the action row. A
-  // full second lift would push the composer a keyboard height too high.
+  // No visualViewport lift here: App.tsx owns keyboard geometry and exposes
+  // the measured inset through shared CSS variables.
   const updateText = (textarea: HTMLTextAreaElement) => {
     setText(textarea.value);
     writeTerminalComposerDraft(draftKey, textarea.value);
@@ -152,6 +175,7 @@ export function TerminalComposer({
   const insertAtCaret = (targetDraftKey: string, insertion: string) => {
     const textarea =
       activeDraftKeyRef.current === targetDraftKey ? textareaRef.current : null;
+    focusSelectionAfterInsertRef.current = textarea !== null;
     insertIntoTerminalComposerDraft(
       targetDraftKey,
       insertion,
@@ -230,6 +254,7 @@ export function TerminalComposer({
   return (
     <>
       <div
+        ref={composerRef}
         className="terminal-composer"
         role="dialog"
         aria-label="Terminal composer"
@@ -355,7 +380,14 @@ export function TerminalComposer({
               }
               aria-expanded={shortcutsOpen}
               onPointerDown={keepTextareaFocus}
-              onClick={() => setShortcutsOpen((open) => !open)}
+              onClick={() => {
+                const open = !shortcutsOpen;
+                localStorage.setItem(
+                  TERMINAL_COMPOSER_SHORTCUTS_OPEN_STORAGE_KEY,
+                  String(open),
+                );
+                setShortcutsOpen(open);
+              }}
             >
               <Keyboard size={15} />
             </button>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8714,8 +8714,10 @@ textarea:focus {
     background: var(--accent-soft);
   }
   .terminal-mobile-side-shortcuts {
-    position: absolute;
-    top: 50%;
+    /* Anchor to the mobile viewport rather than the shrinking terminal, so
+       Composer and shortcut-row changes cannot move this control stack. */
+    position: fixed;
+    top: 45%;
     right: calc(8px + env(safe-area-inset-right, 0px));
     z-index: 5;
     display: grid;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7834,11 +7834,24 @@ textarea:focus {
     max-height: 126px;
   }
 
+  .app:has(.terminal-composer) {
+    --mobile-floating-controls-lift: max(
+      48px,
+      calc(var(--terminal-composer-height, 80px) - 32px)
+    );
+  }
+  .app:has(.terminal-composer-shortcuts) {
+    --mobile-floating-controls-lift: max(
+      110px,
+      calc(var(--terminal-composer-height, 142px) - 32px)
+    );
+  }
   .mobile-nav {
     position: fixed;
     right: calc(10px + env(safe-area-inset-right, 0px));
     bottom: calc(
       58px +
+      var(--mobile-floating-controls-lift, 0px) +
       env(safe-area-inset-bottom, 0px) +
       var(--keyboard-inset-bottom, 0px)
     );
@@ -7854,6 +7867,7 @@ textarea:focus {
     transform-origin: right bottom;
     opacity: 1;
     transition:
+      bottom 180ms ease,
       opacity 160ms ease,
       transform 180ms ease;
     -webkit-backdrop-filter: blur(14px);
@@ -7864,6 +7878,7 @@ textarea:focus {
     right: calc(10px + env(safe-area-inset-right, 0px));
     bottom: calc(
       106px +
+      var(--mobile-floating-controls-lift, 0px) +
       env(safe-area-inset-bottom, 0px) +
       var(--keyboard-inset-bottom, 0px)
     );
@@ -7880,6 +7895,7 @@ textarea:focus {
     transform-origin: right bottom;
     opacity: 1;
     transition:
+      bottom 180ms ease,
       opacity 160ms ease,
       transform 180ms ease;
     -webkit-backdrop-filter: blur(14px);
@@ -8064,6 +8080,7 @@ textarea:focus {
     right: calc(10px + env(safe-area-inset-right, 0px));
     bottom: calc(
       156px +
+      var(--mobile-floating-controls-lift, 0px) +
       env(safe-area-inset-bottom, 0px) +
       var(--keyboard-inset-bottom, 0px)
     );
@@ -8083,6 +8100,7 @@ textarea:focus {
     transform-origin: right bottom;
     opacity: 1;
     transition:
+      bottom 180ms ease,
       opacity 160ms ease,
       background 120ms ease,
       border-color 120ms ease,
@@ -8443,20 +8461,14 @@ textarea:focus {
     flex-direction: column;
   }
   .terminal-composer {
-    /* In-flow at the bottom of the column shell. The margin lifts the action
-       row past the iOS form accessory bar: the app-level
-       --keyboard-inset-content lift under-reports the keyboard occlusion by
-       that trim by design, and the difference is 0 on Android and whenever
-       the keyboard is closed. */
-    margin-bottom: calc(
-      var(--keyboard-inset-bottom, 0px) -
-      var(--keyboard-inset-content, 0px)
-    );
+    /* In-flow at the bottom of the column shell. The app shell owns the main
+       keyboard lift; only iOS gets a small additional form-accessory-bar gap. */
+    margin-bottom: var(--keyboard-inset-composer-gap, 0px);
     display: flex;
     flex-direction: column;
     gap: 6px;
     padding: 8px calc(8px + env(safe-area-inset-right, 0px))
-      calc(8px + env(safe-area-inset-bottom, 0px))
+      calc(12px + env(safe-area-inset-bottom, 0px))
       calc(8px + env(safe-area-inset-left, 0px));
     border-top: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
     background: color-mix(in srgb, var(--panel) 86%, transparent);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7834,17 +7834,10 @@ textarea:focus {
     max-height: 126px;
   }
 
-  .app:has(.terminal-composer) {
-    --mobile-floating-controls-lift: max(
-      48px,
-      calc(var(--terminal-composer-height, 80px) - 32px)
-    );
-  }
-  .app:has(.terminal-composer-shortcuts) {
-    --mobile-floating-controls-lift: max(
-      110px,
-      calc(var(--terminal-composer-height, 142px) - 32px)
-    );
+  /* Keep the floating control stack at one stable screen position across
+     Composer, tab, and workspace transitions. */
+  .app {
+    --mobile-floating-controls-lift: 48px;
   }
   .mobile-nav {
     position: fixed;
@@ -7852,8 +7845,7 @@ textarea:focus {
     bottom: calc(
       58px +
       var(--mobile-floating-controls-lift, 0px) +
-      env(safe-area-inset-bottom, 0px) +
-      var(--keyboard-inset-bottom, 0px)
+      env(safe-area-inset-bottom, 0px)
     );
     z-index: 72;
     display: inline-flex;
@@ -7867,7 +7859,6 @@ textarea:focus {
     transform-origin: right bottom;
     opacity: 1;
     transition:
-      bottom 180ms ease,
       opacity 160ms ease,
       transform 180ms ease;
     -webkit-backdrop-filter: blur(14px);
@@ -7879,8 +7870,7 @@ textarea:focus {
     bottom: calc(
       106px +
       var(--mobile-floating-controls-lift, 0px) +
-      env(safe-area-inset-bottom, 0px) +
-      var(--keyboard-inset-bottom, 0px)
+      env(safe-area-inset-bottom, 0px)
     );
     z-index: 74;
     display: inline-flex;
@@ -7895,7 +7885,6 @@ textarea:focus {
     transform-origin: right bottom;
     opacity: 1;
     transition:
-      bottom 180ms ease,
       opacity 160ms ease,
       transform 180ms ease;
     -webkit-backdrop-filter: blur(14px);
@@ -8081,8 +8070,7 @@ textarea:focus {
     bottom: calc(
       156px +
       var(--mobile-floating-controls-lift, 0px) +
-      env(safe-area-inset-bottom, 0px) +
-      var(--keyboard-inset-bottom, 0px)
+      env(safe-area-inset-bottom, 0px)
     );
     z-index: 73;
     width: 42px;
@@ -8100,7 +8088,6 @@ textarea:focus {
     transform-origin: right bottom;
     opacity: 1;
     transition:
-      bottom 180ms ease,
       opacity 160ms ease,
       background 120ms ease,
       border-color 120ms ease,
@@ -8127,6 +8114,16 @@ textarea:focus {
   }
   .mobile-controls-toggle {
     color: var(--text-strong);
+  }
+  /* A tall Composer hides the fixed controls instead of moving them into a
+     different screen position or allowing them to intercept Composer taps. */
+  .terminal-composer-overlaps-controls .mobile-nav:not(.mobile-terminal-tools),
+  .terminal-composer-overlaps-controls .mobile-workspace-shortcut,
+  .terminal-composer-overlaps-controls .mobile-terminal-controls {
+    visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+    transform: translate3d(0, 12px, 0) scale(0.85);
   }
   /* While the on-screen keyboard is open the floating controls cover too
      much of the terminal, so fade them out until the keyboard closes. */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7837,7 +7837,7 @@ textarea:focus {
   /* Keep the floating control stack at one stable screen position across
      Composer, tab, and workspace transitions. */
   .app {
-    --mobile-floating-controls-lift: 48px;
+    --mobile-floating-controls-lift: 60px;
   }
   .mobile-nav {
     position: fixed;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8115,11 +8115,11 @@ textarea:focus {
   .mobile-controls-toggle {
     color: var(--text-strong);
   }
-  /* A tall Composer hides the fixed controls instead of moving them into a
-     different screen position or allowing them to intercept Composer taps. */
-  .terminal-composer-overlaps-controls .mobile-nav:not(.mobile-terminal-tools),
-  .terminal-composer-overlaps-controls .mobile-workspace-shortcut,
-  .terminal-composer-overlaps-controls .mobile-terminal-controls {
+  /* Keep each capsule fixed and visible unless that specific capsule overlaps
+     a real Composer control. Composer background alone does not hide it. */
+  .mobile-nav.is-composer-overlapped,
+  .mobile-workspace-shortcut.is-composer-overlapped,
+  .mobile-terminal-controls.is-composer-overlapped {
     visibility: hidden;
     opacity: 0;
     pointer-events: none;
@@ -8586,6 +8586,11 @@ textarea:focus {
     gap: 2px;
     overflow-x: auto;
     scrollbar-width: none;
+  }
+  /* When the Composer is not actively receiving input, leave a right-side
+     lane for the fixed bottom navigation capsule. */
+  .app:not(:has(.terminal-composer-input:focus)) .terminal-composer-shortcuts {
+    max-width: calc(100% - 164px);
   }
   .terminal-composer-shortcuts::-webkit-scrollbar {
     display: none;


### PR DESCRIPTION
## Summary

- keep Composer and shortcut preferences across mobile navigation without automatically focusing the textarea
- wait for mobile tab transitions before reopening Composer so input cannot reach the previous terminal
- scope Composer-open state to the active connection generation
- preserve safe Android/iOS keyboard insets and position floating controls from the measured Composer height

## Verification

- `bun run typecheck`
- `bun run lint`
- `bun test web/src/terminalComposer.test.ts web/src/terminalImageUpload.test.ts web/src/terminalIme.test.ts` (48 passed)
- `bun run build:web`
- `git diff --check`

Refs #70 and follows #72.
