### PR TITLE
Fix select-all and copy in file and session previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fix text selection in file and session previews: Cmd/Ctrl+A now selects only
+  the preview content instead of the whole page (line numbers included), and
+  copying a selection always yields the exact document text, including lines
+  outside the rendered viewport. A Copy button in the file preview header
+  copies the entire file content.
+
 ## 0.4.11 - 2026-08-31
 
 ### Added

--- a/web/src/components/CodePreview.tsx
+++ b/web/src/components/CodePreview.tsx
@@ -1,4 +1,10 @@
 import { useEffect, useRef } from "react";
+import {
+  handlePreviewEditorCopy,
+  isEditablePreviewTarget,
+  isPreviewKeyboardTarget,
+  selectAllInPreviewEditor,
+} from "./previewSelection";
 
 type CodePreviewDeps = Awaited<ReturnType<typeof importCodePreviewDeps>>;
 
@@ -87,6 +93,7 @@ export function CodePreview({
               : []),
             deps.EditorState.readOnly.of(true),
             deps.EditorView.editable.of(false),
+            deps.EditorView.contentAttributes.of({ tabindex: "0" }),
             deps.json(),
             deps.syntaxHighlighting(deps.highlightStyle),
             deps.EditorView.theme({
@@ -223,23 +230,44 @@ export function CodePreview({
   }, [searchable, text]);
 
   useEffect(() => {
-    if (!searchable) return;
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key.toLowerCase() !== "f" || (!e.metaKey && !e.ctrlKey)) return;
+      if ((!e.metaKey && !e.ctrlKey) || e.altKey || e.shiftKey) return;
+      const key = e.key.toLowerCase();
+      if (key !== "f" && key !== "a") return;
       const parent = containerRef.current;
+      if (!parent) return;
       const target = e.target as Node | null;
-      if (!parent || !target || !parent.contains(target)) return;
+      if (isEditablePreviewTarget(e.target)) return;
       const editor = editorRef.current;
       if (!editor) return;
+      if (key === "f") {
+        if (!searchable || !target || !parent.contains(target)) return;
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        void loadCodePreviewDeps().then((deps) => {
+          deps.openSearchPanel(editor);
+        });
+        return;
+      }
+      if (parent.offsetParent === null) return;
+      if (!isPreviewKeyboardTarget(parent, target)) return;
       e.preventDefault();
-      e.stopPropagation();
-      void loadCodePreviewDeps().then((deps) => {
-        deps.openSearchPanel(editor);
-      });
+      e.stopImmediatePropagation();
+      selectAllInPreviewEditor(editor);
     };
     window.addEventListener("keydown", onKeyDown, true);
     return () => window.removeEventListener("keydown", onKeyDown, true);
   }, [searchable]);
+
+  useEffect(() => {
+    const parent = containerRef.current;
+    if (!parent) return;
+    const onCopy = (event: ClipboardEvent) => {
+      handlePreviewEditorCopy(editorRef.current, event);
+    };
+    parent.addEventListener("copy", onCopy);
+    return () => parent.removeEventListener("copy", onCopy);
+  }, []);
 
   return <div ref={containerRef} className="code-preview" tabIndex={0} />;
 }

--- a/web/src/components/FilePreviewContent.tsx
+++ b/web/src/components/FilePreviewContent.tsx
@@ -15,7 +15,15 @@ import {
 } from "../workspaceFileUrl";
 import { MarkdownPreview } from "./markdown";
 import { MermaidDiagram } from "./MermaidDiagram";
+import {
+  handlePreviewEditorCopy,
+  isEditablePreviewTarget,
+  isPreviewKeyboardTarget,
+  selectAllInPreviewEditor,
+  selectAllInPreviewElement,
+} from "./previewSelection";
 import { highlightCodeTokens } from "./syntaxHighlighting";
+import { store } from "../store";
 
 export type ActiveFilePreviewSelection = {
   entry: FileExplorerEntry | null;
@@ -109,13 +117,6 @@ function useDocumentTheme() {
   return theme;
 }
 
-function isEditablePreviewTarget(target: EventTarget | null) {
-  if (!(target instanceof HTMLElement)) return false;
-  if (target.closest(".cm-editor")) return false;
-  if (target.isContentEditable) return true;
-  return ["INPUT", "TEXTAREA", "SELECT"].includes(target.tagName);
-}
-
 export function FilePreviewContent({
   entry,
   preview,
@@ -135,6 +136,7 @@ export function FilePreviewContent({
 }) {
   const connectionClient = useConnectionClient();
   const previewSectionRef = useRef<HTMLElement | null>(null);
+  const previewContentRef = useRef<HTMLDivElement | null>(null);
   const editorViewRef = useRef<CodeMirrorEditorView | null>(null);
   const onOpenChangesRef = useRef(onOpenChanges);
   onOpenChangesRef.current = onOpenChanges;
@@ -198,21 +200,63 @@ export function FilePreviewContent({
   }, [changesAvailable, changesKey, detailTab]);
 
   useEffect(() => {
-    if (showingChanges || !hasPreviewText || renderRichPreview) return;
+    if (showingChanges || !hasPreviewText) return;
     const onKey = (e: KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
-      if (e.key.toLowerCase() !== "f") return;
+      const key = e.key.toLowerCase();
+      if (key !== "f" && key !== "a") return;
       const section = previewSectionRef.current;
       if (!section || section.offsetParent === null) return;
       if (isEditablePreviewTarget(e.target)) return;
+      if (key === "f") {
+        if (renderRichPreview) return;
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        openPreviewSearch(editorViewRef.current);
+        return;
+      }
+      if (!isPreviewKeyboardTarget(section, e.target)) return;
       e.preventDefault();
-      e.stopPropagation();
-      openPreviewSearch(editorViewRef.current);
+      e.stopImmediatePropagation();
+      if (renderRichPreview) {
+        selectAllInPreviewElement(previewContentRef.current);
+      } else {
+        selectAllInPreviewEditor(editorViewRef.current);
+      }
     };
     window.addEventListener("keydown", onKey, { capture: true });
     return () =>
       window.removeEventListener("keydown", onKey, { capture: true });
   }, [hasPreviewText, renderRichPreview, showingChanges]);
+
+  useEffect(() => {
+    const section = previewSectionRef.current;
+    if (!section) return;
+    const onCopy = (event: ClipboardEvent) => {
+      handlePreviewEditorCopy(editorViewRef.current, event);
+    };
+    section.addEventListener("copy", onCopy);
+    return () => section.removeEventListener("copy", onCopy);
+  }, []);
+
+  const copyPreviewText = async () => {
+    if (previewText === null) return;
+    try {
+      await navigator.clipboard.writeText(previewText);
+      store.notify({
+        kind: "success",
+        message: "File content copied",
+        detail: previewPath,
+        autoDismissMs: 3000,
+      });
+    } catch (copyError) {
+      store.notify({
+        kind: "error",
+        message: "Failed to copy file content",
+        detail: (copyError as Error).message,
+      });
+    }
+  };
 
   return (
     <section
@@ -235,6 +279,16 @@ export function FilePreviewContent({
             {entry?.name ?? "Preview"}
           </div>
           <div className="file-preview-head-actions">
+            {!showingChanges && hasPreviewText && !preview?.truncated ? (
+              <button
+                type="button"
+                className="file-preview-copy"
+                title="Copy entire file content"
+                onClick={() => void copyPreviewText()}
+              >
+                Copy
+              </button>
+            ) : null}
             {!showingChanges && hasRichPreview ? (
               <button
                 type="button"
@@ -276,6 +330,7 @@ export function FilePreviewContent({
         </div>
       ) : (
         <div
+          ref={previewContentRef}
           className="file-preview-file-content"
           role="region"
           aria-label={`Preview of ${entry?.name ?? "selected file"}`}
@@ -397,6 +452,7 @@ function CodeMirrorPreview({
             deps.keymap.of(deps.searchKeymap),
             deps.EditorState.readOnly.of(true),
             deps.EditorView.editable.of(false),
+            deps.EditorView.contentAttributes.of({ tabindex: "0" }),
             syntaxCompartment.of([]),
             deps.EditorView.theme(
               {

--- a/web/src/components/previewSelection.test.ts
+++ b/web/src/components/previewSelection.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { previewEditorCopyText } from "./previewSelection";
+
+describe("previewEditorCopyText", () => {
+  test("returns the selected document slice for selections inside the editor", () => {
+    const doc = "line one\nline two\nline three";
+    expect(previewEditorCopyText(doc, 0, 17, true)).toBe("line one\nline two");
+    expect(previewEditorCopyText(doc, 0, doc.length, true)).toBe(doc);
+  });
+
+  test("keeps native copy for empty selections or selections outside the editor", () => {
+    expect(previewEditorCopyText("abc", 1, 1, true)).toBeNull();
+    expect(previewEditorCopyText("abc", 0, 3, false)).toBeNull();
+  });
+});

--- a/web/src/components/previewSelection.ts
+++ b/web/src/components/previewSelection.ts
@@ -1,0 +1,98 @@
+import type { EditorView } from "@codemirror/view";
+
+/**
+ * True when a keyboard or clipboard event targets a native editable element
+ * outside the CodeMirror surface, where select-all and copy keep their
+ * default behavior.
+ */
+export function isEditablePreviewTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.closest(".cm-editor")) return false;
+  if (target.isContentEditable) return true;
+  return ["INPUT", "TEXTAREA", "SELECT"].includes(target.tagName);
+}
+
+/**
+ * True when a keyboard event comes from inside the preview or from a neutral
+ * target (nothing else focused), so the preview may claim select-all.
+ */
+export function isPreviewKeyboardTarget(
+  previewRoot: HTMLElement,
+  target: EventTarget | null,
+): boolean {
+  if (target instanceof Node && previewRoot.contains(target)) return true;
+  return (
+    target === previewRoot.ownerDocument.body ||
+    target === previewRoot.ownerDocument.documentElement
+  );
+}
+
+/**
+ * Select the whole document in a read-only CodeMirror preview and focus the
+ * content element so the selection is mirrored to the DOM and can be copied.
+ */
+export function selectAllInPreviewEditor(view: EditorView | null): void {
+  if (!view) return;
+  view.contentDOM.focus();
+  view.dispatch({
+    selection: { anchor: 0, head: view.state.doc.length },
+    userEvent: "select",
+  });
+}
+
+/** Select all rendered content of a plain-HTML preview (markdown mode). */
+export function selectAllInPreviewElement(element: HTMLElement | null): void {
+  if (!element) return;
+  const selection = element.ownerDocument.getSelection();
+  if (!selection) return;
+  selection.removeAllRanges();
+  const range = element.ownerDocument.createRange();
+  range.selectNodeContents(element);
+  selection.addRange(range);
+}
+
+/**
+ * Decide the clipboard payload for a copy event inside a CodeMirror preview.
+ * Returns the exact document slice (including lines outside the rendered
+ * viewport) or null to keep the native copy behavior.
+ */
+export function previewEditorCopyText(
+  docText: string,
+  from: number,
+  to: number,
+  selectionInsideEditor: boolean,
+): string | null {
+  if (!selectionInsideEditor || from === to) return null;
+  return docText.slice(from, to);
+}
+
+/**
+ * Replace the clipboard payload of a copy event with the exact CodeMirror
+ * document text when the native selection lives inside the editor content.
+ * CodeMirror renders only the visible lines, so a native copy would silently
+ * drop everything outside the viewport.
+ */
+export function handlePreviewEditorCopy(
+  view: EditorView | null,
+  event: ClipboardEvent,
+): boolean {
+  if (!view || isEditablePreviewTarget(event.target)) return false;
+  const domSelection = view.contentDOM.ownerDocument.getSelection();
+  const anchorNode = domSelection?.anchorNode ?? null;
+  const text = previewEditorCopyText(
+    view.state.doc.toString(),
+    view.state.selection.main.from,
+    view.state.selection.main.to,
+    anchorNode !== null && view.contentDOM.contains(anchorNode),
+  );
+  if (text === null) return false;
+  // Genuine copy events always carry clipboardData; a null value means the
+  // event was synthesized, and failing loudly beats silently copying nothing.
+  const clipboardData = event.clipboardData;
+  if (!clipboardData) {
+    throw new Error("Cannot handle a copy event without clipboardData");
+  }
+  clipboardData.setData("text/plain", text);
+  event.preventDefault();
+  return true;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4657,6 +4657,7 @@ textarea:focus {
   gap: 6px;
 }
 .file-preview-mode-toggle,
+.file-preview-copy,
 .file-preview-changes-toggle {
   height: 24px;
   padding: 0 8px;
@@ -4666,6 +4667,7 @@ textarea:focus {
   font-size: 11px;
   font-weight: 700;
 }
+.file-preview-copy:hover,
 .file-preview-changes-toggle:hover,
 .file-preview-changes-toggle[aria-pressed="true"] {
   background: var(--accent-soft);


### PR DESCRIPTION
Closes #75

## Summary

- Scope Cmd/Ctrl+A to the focused preview: it now selects only the file content instead of the whole page (line numbers included). Works in the Changes/Files preview, markdown/rich mode, and the agent session preview dialog.
- Make the read-only CodeMirror content focusable so its selection is mirrored to the DOM, and serve the exact document text from a copy handler so copying a selection no longer drops lines outside the rendered viewport.
- Add a Copy button to the file preview header for the full file content (hidden for previews truncated at 512 KB).

## Verification

- `bun run precommit` (format, lint, typecheck, 792 unit tests)
- `bun run build:web`
