### PR TITLE
Polish mobile terminal shortcut layout

### DIFF
--- a/web/src/components/MobileTerminalShortcutsDialog.tsx
+++ b/web/src/components/MobileTerminalShortcutsDialog.tsx
@@ -77,23 +77,34 @@ function newShortcut(): MobileTerminalShortcut {
 function ShortcutKeySelect({
   value,
   ariaLabel,
+  openRequest,
   onChange,
 }: {
   value: MobileTerminalShortcutAction;
   ariaLabel: string;
+  openRequest: number;
   onChange: (action: MobileTerminalShortcutAction) => void;
 }) {
   const currentItemRef = useRef<HTMLDivElement>(null);
+  const valueRef = useRef(value);
+  valueRef.current = value;
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
-  const [activeValue, setActiveValue] = useState<string>(value);
+  const [activeValue, setActiveValue] = useState(() => String(value));
   const currentOption = mobileTerminalShortcutOption(value);
 
   const setSelectorOpen = (next: boolean) => {
     setOpen(next);
     setSearch("");
-    if (next) setActiveValue(value);
+    if (next) setActiveValue(valueRef.current);
   };
+
+  useEffect(() => {
+    if (openRequest === 0) return;
+    setOpen(true);
+    setSearch("");
+    setActiveValue(valueRef.current);
+  }, [openRequest]);
 
   return (
     <Popover open={open} onOpenChange={setSelectorOpen}>
@@ -190,7 +201,6 @@ export function MobileTerminalShortcutsDialog({
   onClose: () => void;
 }) {
   const dialogRef = useRef<HTMLDivElement>(null);
-  const labelInputRef = useRef<HTMLInputElement>(null);
   const rowsRef = useRef(rows);
   const sideShortcutsRef = useRef(sideShortcuts);
   const onCloseRef = useRef(onClose);
@@ -204,12 +214,14 @@ export function MobileTerminalShortcutsDialog({
     cloneSideShortcuts(sideShortcuts),
   );
   const [selectedSlot, setSelectedSlot] = useState<SelectedSlot | null>(null);
+  const [keySelectorOpenRequest, setKeySelectorOpenRequest] = useState(0);
 
   useEffect(() => {
     if (!open) return;
     setDraft(cloneRows(rowsRef.current));
     setSideDraft(cloneSideShortcuts(sideShortcutsRef.current));
     setSelectedSlot(null);
+    setKeySelectorOpenRequest(0);
     const cancelFocus = focusDialogElement(dialogRef.current);
     const onKey = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
@@ -241,7 +253,7 @@ export function MobileTerminalShortcutsDialog({
       return next;
     });
     setSelectedSlot({ area: "panel", rowIndex, slotIndex });
-    requestAnimationFrame(() => labelInputRef.current?.focus());
+    setKeySelectorOpenRequest((request) => request + 1);
   };
 
   const selectSideSlot = (slotIndex: number) => {
@@ -252,7 +264,7 @@ export function MobileTerminalShortcutsDialog({
       return next;
     });
     setSelectedSlot({ area: "side", slotIndex });
-    requestAnimationFrame(() => labelInputRef.current?.focus());
+    setKeySelectorOpenRequest((request) => request + 1);
   };
 
   const updateSelectedShortcut = (
@@ -474,7 +486,6 @@ export function MobileTerminalShortcutsDialog({
                 <label>
                   <span>Label</span>
                   <input
-                    ref={labelInputRef}
                     value={selectedShortcut.label}
                     maxLength={10}
                     aria-label={
@@ -494,6 +505,7 @@ export function MobileTerminalShortcutsDialog({
                   <span>Key</span>
                   <ShortcutKeySelect
                     value={selectedShortcut.action}
+                    openRequest={keySelectorOpenRequest}
                     ariaLabel={
                       selectedSlot.area === "side"
                         ? `Side slot ${selectedSlot.slotIndex + 1} key`
@@ -526,7 +538,7 @@ export function MobileTerminalShortcutsDialog({
         <div className="modal-actions mobile-shortcuts-actions">
           <button
             type="button"
-            className="ghost"
+            className="ghost mobile-shortcuts-restore"
             onClick={() => {
               setDraft(defaultMobileTerminalShortcutRows());
               setSideDraft(defaultMobileTerminalSideShortcuts());

--- a/web/src/components/TerminalComposer.tsx
+++ b/web/src/components/TerminalComposer.tsx
@@ -6,13 +6,7 @@ import {
   Keyboard,
   X,
 } from "lucide-react";
-import {
-  type CSSProperties,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
+import { type CSSProperties, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import {
   type MobileTerminalShortcut,
@@ -69,7 +63,7 @@ export function TerminalComposer({
   onError,
 }: {
   draftKey: string;
-  shortcutRows: MobileTerminalShortcut[][];
+  shortcutRows: (MobileTerminalShortcut | null)[][];
   onRunShortcut: (shortcut: MobileTerminalShortcut) => void;
   onClose: () => void;
   onSubmit: (text: string, submit: boolean) => Promise<void>;
@@ -90,57 +84,12 @@ export function TerminalComposer({
       localStorage.getItem(TERMINAL_COMPOSER_SHORTCUTS_OPEN_STORAGE_KEY) !==
       "false",
   );
-  const composerRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const composingRef = useRef(false);
   const focusSelectionAfterInsertRef = useRef(false);
   const activeDraftKeyRef = useRef(draftKey);
   activeDraftKeyRef.current = draftKey;
-
-  useLayoutEffect(() => {
-    const composer = composerRef.current;
-    if (!composer) return;
-    const viewport = window.visualViewport;
-    const floatingControls = Array.from(
-      document.querySelectorAll<HTMLElement>(
-        ".mobile-nav:not(.mobile-terminal-tools), .mobile-workspace-shortcut, .mobile-terminal-controls",
-      ),
-    );
-    const updateControlOverlap = () => {
-      const interactiveRegions = Array.from(
-        composer.querySelectorAll<HTMLElement>(
-          ".terminal-composer-shortcuts, .terminal-composer-input, .terminal-composer-actions",
-        ),
-      );
-      for (const control of floatingControls) {
-        const controlRect = control.getBoundingClientRect();
-        const overlaps = interactiveRegions.some((region) => {
-          const regionRect = region.getBoundingClientRect();
-          return (
-            controlRect.left < regionRect.right + 8 &&
-            controlRect.right > regionRect.left - 8 &&
-            controlRect.top < regionRect.bottom + 8 &&
-            controlRect.bottom > regionRect.top - 8
-          );
-        });
-        control.classList.toggle("is-composer-overlapped", overlaps);
-      }
-    };
-    updateControlOverlap();
-    const observer = new ResizeObserver(updateControlOverlap);
-    observer.observe(composer);
-    window.addEventListener("resize", updateControlOverlap);
-    viewport?.addEventListener("resize", updateControlOverlap);
-    return () => {
-      observer.disconnect();
-      window.removeEventListener("resize", updateControlOverlap);
-      viewport?.removeEventListener("resize", updateControlOverlap);
-      for (const control of floatingControls) {
-        control.classList.remove("is-composer-overlapped");
-      }
-    };
-  }, []);
 
   // Load the incoming pane's draft and subscribe to updates from async work
   // that may outlive an earlier composer mount for this pane.
@@ -269,13 +218,14 @@ export function TerminalComposer({
 
   const busy = submissionPending || uploadCount > 0;
   const submitDisabled = !text || busy || composing;
-  const hasShortcuts = shortcutRows.some((row) => row.length > 0);
+  const hasShortcuts = shortcutRows.some((row) =>
+    row.some((shortcut) => shortcut !== null),
+  );
   const shortcutColumns = Math.max(1, ...shortcutRows.map((row) => row.length));
 
   return (
     <>
       <div
-        ref={composerRef}
         className="terminal-composer"
         role="dialog"
         aria-label="Terminal composer"
@@ -295,7 +245,16 @@ export function TerminalComposer({
                 className="terminal-composer-shortcut-row"
                 key={`composer-shortcut-row-${rowIndex}`}
               >
-                {row.map((shortcut) => {
+                {row.map((shortcut, slotIndex) => {
+                  if (!shortcut) {
+                    return (
+                      <span
+                        className="terminal-composer-shortcut-spacer"
+                        aria-hidden="true"
+                        key={`composer-shortcut-${rowIndex}-${slotIndex}`}
+                      />
+                    );
+                  }
                   const option = mobileTerminalShortcutOption(shortcut.action);
                   return (
                     <button

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -487,7 +487,6 @@ export function TerminalView({
     (el: HTMLDivElement | null) => setContainer(el),
     [],
   );
-  const pasteFromClipboardRef = useRef<(() => void) | null>(null);
   const termRef = useRef<Terminal | null>(null);
   // Mirrors termRef as state so the attach effect re-runs when the xterm
   // instance is recreated: the init effect's cleanup resets the attach refs,
@@ -1129,11 +1128,6 @@ export function TerminalView({
         clipboardPasteInFlight = false;
       }
     };
-    pasteFromClipboardRef.current = () => {
-      void pasteFromBrowserClipboard().catch((error) => {
-        setUploadError(`Paste failed: ${(error as Error).message}`);
-      });
-    };
     const applePlatform = isApplePlatform();
     const appleTouchPlatform = applePlatform && navigator.maxTouchPoints > 0;
     const shouldHandleCtrlVPaste = !applePlatform;
@@ -1708,7 +1702,6 @@ export function TerminalView({
       document.removeEventListener("pointerdown", onDocumentPointerDown, {
         capture: true,
       });
-      pasteFromClipboardRef.current = null;
       imeFallback.dispose();
       linkProvider.dispose();
       const terminalId = attachedRef.current ?? desiredTerminalRef.current;
@@ -1975,22 +1968,19 @@ export function TerminalView({
     if (!execution) return;
     if (execution.type === "scroll") {
       scrollPage(execution.direction, execution.amount);
-    } else if (execution.type === "paste") {
-      if (shouldAvoidVirtualKeyboard()) blurTerminalInput();
-      pasteFromClipboardRef.current?.();
     } else {
       sendControl(execution.bytes);
     }
   };
-  const visibleMobileShortcutRows = mobileShortcuts.map((row) =>
-    row.filter((shortcut) => shortcut !== null),
+  const hasMobileShortcuts = mobileShortcuts.some((row) =>
+    row.some((shortcut) => shortcut !== null),
   );
-  const visibleMobileSideShortcuts = mobileSideShortcuts.filter(
+  const hasMobileSideShortcuts = mobileSideShortcuts.some(
     (shortcut) => shortcut !== null,
   );
-  const visibleMobileShortcutColumns = Math.max(
+  const mobileShortcutColumns = Math.max(
     1,
-    ...visibleMobileShortcutRows.map((row) => row.length),
+    ...mobileShortcuts.map((row) => row.length),
   );
 
   if (!pane) {
@@ -2025,12 +2015,21 @@ export function TerminalView({
       <div className="terminal-shell">
         <div className="terminal-main">
           <div ref={containerRef} className="terminal-view" />
-          {showMobileKeys && visibleMobileSideShortcuts.length > 0 ? (
+          {showMobileKeys && hasMobileSideShortcuts ? (
             <div
               className="terminal-mobile-side-shortcuts"
               aria-label="Terminal side shortcuts"
             >
-              {visibleMobileSideShortcuts.map((shortcut) => {
+              {mobileSideShortcuts.map((shortcut, slotIndex) => {
+                if (!shortcut) {
+                  return (
+                    <span
+                      className="terminal-mobile-side-shortcut-spacer"
+                      aria-hidden="true"
+                      key={`mobile-side-shortcut-${slotIndex}`}
+                    />
+                  );
+                }
                 const option = mobileTerminalShortcutOption(shortcut.action);
                 return (
                   <button
@@ -2048,8 +2047,7 @@ export function TerminalView({
             </div>
           ) : null}
         </div>
-        {showMobileKeys &&
-        visibleMobileShortcutRows.some((row) => row.length > 0) ? (
+        {showMobileKeys && hasMobileShortcuts ? (
           <div
             className={`terminal-mobile-keys ${
               mobileKeysOpen ? "is-open" : ""
@@ -2075,16 +2073,25 @@ export function TerminalView({
                 className="terminal-mobile-keys-grid"
                 style={
                   {
-                    "--mobile-shortcut-columns": visibleMobileShortcutColumns,
+                    "--mobile-shortcut-columns": mobileShortcutColumns,
                   } as CSSProperties
                 }
               >
-                {visibleMobileShortcutRows.map((row, rowIndex) => (
+                {mobileShortcuts.map((row, rowIndex) => (
                   <div
                     className="terminal-mobile-keys-row"
                     key={`mobile-shortcut-row-${rowIndex}`}
                   >
-                    {row.map((shortcut) => {
+                    {row.map((shortcut, slotIndex) => {
+                      if (!shortcut) {
+                        return (
+                          <span
+                            className="terminal-mobile-key-spacer"
+                            aria-hidden="true"
+                            key={`mobile-shortcut-${rowIndex}-${slotIndex}`}
+                          />
+                        );
+                      }
                       const option = mobileTerminalShortcutOption(
                         shortcut.action,
                       );
@@ -2110,7 +2117,7 @@ export function TerminalView({
         {composerOpen ? (
           <TerminalComposer
             draftKey={composerDraftKey}
-            shortcutRows={visibleMobileShortcutRows}
+            shortcutRows={mobileShortcuts}
             onRunShortcut={runMobileShortcut}
             onClose={() => setComposerOpen(false)}
             onSubmit={submitTerminalComposer}

--- a/web/src/mobileTerminalShortcutAction.test.ts
+++ b/web/src/mobileTerminalShortcutAction.test.ts
@@ -13,12 +13,6 @@ describe("mobile terminal shortcut execution", () => {
     });
   });
 
-  test("routes the paste action to the browser clipboard", () => {
-    expect(mobileTerminalShortcutExecution("paste")).toEqual({
-      type: "paste",
-    });
-  });
-
   test("routes page actions to full or half scrollback", () => {
     expect(mobileTerminalShortcutExecution("page-up")).toEqual({
       type: "scroll",

--- a/web/src/mobileTerminalShortcutAction.ts
+++ b/web/src/mobileTerminalShortcutAction.ts
@@ -1,6 +1,5 @@
 import {
   mobileTerminalShortcutBytes,
-  mobileTerminalShortcutClipboard,
   mobileTerminalShortcutScroll,
   type MobileTerminalShortcutAction,
 } from "./mobileTerminalShortcuts";
@@ -14,17 +13,11 @@ export type MobileTerminalShortcutExecution =
       type: "scroll";
       direction: "up" | "down";
       amount: "full" | "half";
-    }
-  | {
-      type: "paste";
     };
 
 export function mobileTerminalShortcutExecution(
   action: MobileTerminalShortcutAction,
 ): MobileTerminalShortcutExecution | null {
-  if (mobileTerminalShortcutClipboard(action) === "paste") {
-    return { type: "paste" };
-  }
   const scroll = mobileTerminalShortcutScroll(action);
   if (scroll) return { type: "scroll", ...scroll };
   const bytes = mobileTerminalShortcutBytes(action);

--- a/web/src/mobileTerminalShortcuts.test.ts
+++ b/web/src/mobileTerminalShortcuts.test.ts
@@ -22,9 +22,33 @@ describe("mobile terminal shortcuts", () => {
     expect(
       rows.map((row) => row.map((shortcut) => shortcut?.action ?? null)),
     ).toEqual([
-      ["ctrl-c", "ctrl-d", "ctrl-r", "escape", "page-up", null, null, null],
-      ["tab", "enter", "alt-up", "page-down", "paste", null, null, null],
+      [
+        "ctrl-c",
+        "ctrl-d",
+        "ctrl-r",
+        "alt-up",
+        null,
+        "arrow-up",
+        null,
+        "page-up",
+      ],
+      [
+        "escape",
+        "tab",
+        "enter",
+        null,
+        "arrow-left",
+        "arrow-down",
+        "arrow-right",
+        "page-down",
+      ],
     ]);
+    expect([
+      rows[0][5]?.label,
+      rows[1][4]?.label,
+      rows[1][5]?.label,
+      rows[1][6]?.label,
+    ]).toEqual(["▲", "◀", "▼", "▶"]);
     expect(
       rows.every((row) => row.length <= MAX_MOBILE_TERMINAL_SHORTCUTS_PER_ROW),
     ).toBe(true);
@@ -56,7 +80,7 @@ describe("mobile terminal shortcuts", () => {
     expect(rows[0][1]?.id).toBe("same-2");
     expect(Array.from(rows[0][1]?.label ?? "")).toHaveLength(10);
     expect(rows[1]).toEqual([
-      { id: "up", label: "Up", action: "arrow-up" },
+      { id: "up", label: "▲", action: "arrow-up" },
       null,
       null,
       null,
@@ -65,6 +89,21 @@ describe("mobile terminal shortcuts", () => {
       null,
       null,
     ]);
+  });
+
+  test("drops removed paste actions from stored shortcuts", () => {
+    const rows = normalizeMobileTerminalShortcutRows([
+      [{ id: "old-paste", label: "Paste", action: "paste" }],
+      [],
+    ]);
+    const sideShortcuts = parseMobileTerminalSideShortcuts(
+      JSON.stringify([
+        { id: "old-side-paste", label: "Paste", action: "paste" },
+      ]),
+    );
+
+    expect(rows[0][0]).toBeNull();
+    expect(sideShortcuts[0]).toBeNull();
   });
 
   test("migrates legacy compact rows past invalid entries", () => {
@@ -160,7 +199,7 @@ describe("mobile terminal shortcuts", () => {
     const encoded = serializeMobileTerminalShortcutRows(first);
     const parsed = parseMobileTerminalShortcutRows(encoded);
     expect(parsed[0][0]?.label).toBe("Changed");
-    expect(mobileTerminalShortcutCount(parsed)).toBe(10);
+    expect(mobileTerminalShortcutCount(parsed)).toBe(13);
   });
 
   test("encodes control, navigation, and modified keys", () => {

--- a/web/src/mobileTerminalShortcuts.ts
+++ b/web/src/mobileTerminalShortcuts.ts
@@ -19,7 +19,6 @@ type MobileTerminalShortcutOptionDefinition = {
     direction: "up" | "down";
     amount: "full" | "half";
   };
-  clipboard?: "paste";
 };
 
 export const MOBILE_TERMINAL_SHORTCUT_OPTIONS = [
@@ -150,13 +149,6 @@ export const MOBILE_TERMINAL_SHORTCUT_OPTIONS = [
     bytes: [0x7f],
   },
   {
-    id: "paste",
-    label: "Paste (text or image)",
-    defaultButtonLabel: "Paste",
-    group: "Basic",
-    clipboard: "paste",
-  },
-  {
     id: "delete",
     label: "Delete",
     defaultButtonLabel: "Del",
@@ -166,28 +158,28 @@ export const MOBILE_TERMINAL_SHORTCUT_OPTIONS = [
   {
     id: "arrow-up",
     label: "Arrow Up",
-    defaultButtonLabel: "Up",
+    defaultButtonLabel: "▲",
     group: "Navigation",
     bytes: [0x1b, 0x5b, 0x41],
   },
   {
     id: "arrow-down",
     label: "Arrow Down",
-    defaultButtonLabel: "Down",
+    defaultButtonLabel: "▼",
     group: "Navigation",
     bytes: [0x1b, 0x5b, 0x42],
   },
   {
     id: "arrow-right",
     label: "Arrow Right",
-    defaultButtonLabel: "Right",
+    defaultButtonLabel: "▶",
     group: "Navigation",
     bytes: [0x1b, 0x5b, 0x43],
   },
   {
     id: "arrow-left",
     label: "Arrow Left",
-    defaultButtonLabel: "Left",
+    defaultButtonLabel: "◀",
     group: "Navigation",
     bytes: [0x1b, 0x5b, 0x44],
   },
@@ -305,21 +297,21 @@ const defaultRows: MobileTerminalShortcutRows = [
     { id: "default-ctrl-c", label: "C-c", action: "ctrl-c" },
     { id: "default-ctrl-d", label: "C-d", action: "ctrl-d" },
     { id: "default-ctrl-r", label: "C-R", action: "ctrl-r" },
-    { id: "default-escape", label: "Esc", action: "escape" },
+    { id: "default-alt-up", label: "A-Up", action: "alt-up" },
+    null,
+    { id: "default-arrow-up", label: "▲", action: "arrow-up" },
+    null,
     { id: "default-page-up", label: "PgUp", action: "page-up" },
-    null,
-    null,
-    null,
   ],
   [
+    { id: "default-escape", label: "Esc", action: "escape" },
     { id: "default-tab", label: "Tab", action: "tab" },
     { id: "default-enter", label: "Enter", action: "enter" },
-    { id: "default-alt-up", label: "A-Up", action: "alt-up" },
+    null,
+    { id: "default-arrow-left", label: "◀", action: "arrow-left" },
+    { id: "default-arrow-down", label: "▼", action: "arrow-down" },
+    { id: "default-arrow-right", label: "▶", action: "arrow-right" },
     { id: "default-page-down", label: "PgDn", action: "page-down" },
-    { id: "default-paste", label: "Paste", action: "paste" },
-    null,
-    null,
-    null,
   ],
 ];
 
@@ -339,12 +331,6 @@ export function mobileTerminalShortcutOption(
   action: MobileTerminalShortcutAction,
 ) {
   return optionById.get(action) ?? null;
-}
-
-export function mobileTerminalShortcutClipboard(
-  action: MobileTerminalShortcutAction,
-): "paste" | null {
-  return optionById.get(action)?.clipboard ?? null;
 }
 
 export function mobileTerminalShortcutBytes(
@@ -420,14 +406,10 @@ export function normalizeMobileTerminalShortcutRows(
       const candidate = sourceRow[sourceIndex];
       if (!candidate || typeof candidate !== "object") continue;
       const raw = candidate as Record<string, unknown>;
-      if (
-        typeof raw.action !== "string" ||
-        !optionById.has(raw.action as MobileTerminalShortcutAction)
-      ) {
-        continue;
-      }
+      if (typeof raw.action !== "string") continue;
       const action = raw.action as MobileTerminalShortcutAction;
-      const option = optionById.get(action)!;
+      const option = optionById.get(action);
+      if (!option) continue;
       const label =
         typeof raw.label === "string" && clipLabel(raw.label)
           ? clipLabel(raw.label)
@@ -459,14 +441,10 @@ export function normalizeMobileTerminalSideShortcuts(
     const candidate = value[slotIndex];
     if (!candidate || typeof candidate !== "object") continue;
     const raw = candidate as Record<string, unknown>;
-    if (
-      typeof raw.action !== "string" ||
-      !optionById.has(raw.action as MobileTerminalShortcutAction)
-    ) {
-      continue;
-    }
+    if (typeof raw.action !== "string") continue;
     const action = raw.action as MobileTerminalShortcutAction;
-    const option = optionById.get(action)!;
+    const option = optionById.get(action);
+    if (!option) continue;
     shortcuts[slotIndex] = {
       id: normalizedId(raw.id, 2, slotIndex, usedIds),
       label:

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3269,6 +3269,16 @@ textarea:focus {
   gap: 8px;
   margin: 0;
 }
+.mobile-shortcuts-restore {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+.mobile-shortcuts-restore > svg {
+  display: block;
+  flex: 0 0 auto;
+}
 .file-explorer-modal {
   width: min(900px, 100%);
 }
@@ -7839,7 +7849,7 @@ textarea:focus {
   /* Keep the floating control stack at one stable screen position across
      Composer, tab, and workspace transitions. */
   .app {
-    --mobile-floating-controls-lift: 60px;
+    --mobile-floating-controls-lift: 112px;
   }
   .mobile-nav {
     position: fixed;
@@ -8117,27 +8127,25 @@ textarea:focus {
   .mobile-controls-toggle {
     color: var(--text-strong);
   }
-  /* Keep each capsule fixed and visible unless that specific capsule overlaps
-     a real Composer control. Composer background alone does not hide it. */
-  .mobile-nav.is-composer-overlapped,
-  .mobile-workspace-shortcut.is-composer-overlapped,
-  .mobile-terminal-controls.is-composer-overlapped {
-    visibility: hidden;
-    opacity: 0;
-    pointer-events: none;
-    transform: translate3d(0, 12px, 0) scale(0.85);
-  }
   /* While the on-screen keyboard is open the floating controls cover too
-     much of the terminal, so fade them out until the keyboard closes. */
+     much of the terminal, so fade them out until the keyboard closes. Some
+     mobile browsers do not expose Composer keyboard geometry, so its focused
+     textarea is the direct fallback signal. */
   .keyboard-open .mobile-nav:not(.mobile-terminal-tools),
   .keyboard-open .mobile-workspace-shortcut,
-  .keyboard-open .mobile-terminal-controls {
+  .keyboard-open .mobile-terminal-controls,
+  .app:has(.terminal-composer-input:focus)
+    .mobile-nav:not(.mobile-terminal-tools),
+  .app:has(.terminal-composer-input:focus) .mobile-workspace-shortcut,
+  .app:has(.terminal-composer-input:focus) .mobile-terminal-controls {
     opacity: 0;
     pointer-events: none;
     transform: translate3d(0, 12px, 0) scale(0.85);
   }
   .keyboard-open .terminal-mobile-keys,
-  .keyboard-open .terminal-mobile-side-shortcuts {
+  .keyboard-open .terminal-mobile-side-shortcuts,
+  .app:has(.terminal-composer-input:focus) .terminal-mobile-keys,
+  .app:has(.terminal-composer-input:focus) .terminal-mobile-side-shortcuts {
     visibility: hidden;
     opacity: 0;
     pointer-events: none;
@@ -8492,21 +8500,6 @@ textarea:focus {
     outline: none;
     border-color: color-mix(in srgb, var(--accent) 70%, var(--border));
   }
-  .terminal-shell:has(.terminal-composer-input:focus) .terminal-mobile-keys,
-  .terminal-shell:has(.terminal-composer-input:focus)
-    .terminal-mobile-side-shortcuts,
-  .app:has(.terminal-composer-input:focus) > .mobile-nav,
-  .app:has(.terminal-composer-input:focus) .mobile-workspace-shortcut,
-  .app:has(.terminal-composer-input:focus) .mobile-terminal-controls {
-    visibility: hidden;
-    opacity: 0;
-    pointer-events: none;
-  }
-  .app:has(.terminal-composer-input:focus) > .mobile-nav,
-  .app:has(.terminal-composer-input:focus) .mobile-workspace-shortcut,
-  .app:has(.terminal-composer-input:focus) .mobile-terminal-controls {
-    transform: translate3d(0, 12px, 0) scale(0.85);
-  }
   .terminal-composer-actions {
     display: flex;
     align-items: center;
@@ -8581,26 +8574,28 @@ textarea:focus {
     -webkit-tap-highlight-color: transparent;
   }
   .terminal-composer-shortcuts {
-    width: max-content;
-    max-width: 100%;
+    width: 100%;
+    min-width: 0;
     display: grid;
     grid-template-columns: repeat(var(--mobile-shortcut-columns), 48px);
     gap: 2px;
     overflow-x: auto;
     scrollbar-width: none;
   }
-  /* When the Composer is not actively receiving input, leave a right-side
-     lane for the fixed bottom navigation capsule. */
-  .app:not(:has(.terminal-composer-input:focus)) .terminal-composer-shortcuts {
-    max-width: calc(100% - 164px);
-  }
   .terminal-composer-shortcuts::-webkit-scrollbar {
     display: none;
   }
   .terminal-composer-shortcut-row {
     grid-column: 1 / -1;
-    display: flex;
+    display: grid;
+    grid-template-columns: repeat(var(--mobile-shortcut-columns), 48px);
     gap: 2px;
+  }
+  .terminal-composer-shortcut-spacer,
+  .terminal-mobile-key-spacer {
+    width: 48px;
+    height: 28px;
+    pointer-events: none;
   }
   .terminal-composer-shortcuts button {
     width: 48px;
@@ -8644,8 +8639,9 @@ textarea:focus {
     max-width: calc(100vw - 62px - env(safe-area-inset-right, 0px));
     padding: 3px;
     overflow-x: auto;
+    /* Anchor overflow at the right edge so the directional and page keys stay
+       visible on narrow screens. The nested grid resets item order to LTR. */
     direction: rtl;
-    text-align: right;
     border-radius: 12px;
     opacity: 0;
     pointer-events: none;
@@ -8669,8 +8665,8 @@ textarea:focus {
   .terminal-mobile-keys-row {
     width: 100%;
     grid-column: 1 / -1;
-    display: flex;
-    justify-content: flex-end;
+    display: grid;
+    grid-template-columns: repeat(var(--mobile-shortcut-columns), 48px);
     gap: 2px;
   }
   .terminal-mobile-keys.is-open .terminal-mobile-keys-panel {
@@ -8726,6 +8722,11 @@ textarea:focus {
     gap: 3px;
     transform: translateY(-50%);
     pointer-events: auto;
+  }
+  .terminal-mobile-side-shortcut-spacer {
+    width: 42px;
+    height: 32px;
+    pointer-events: none;
   }
   .terminal-mobile-side-shortcuts button {
     width: 42px;


### PR DESCRIPTION
## Summary

- Preserve configured empty shortcut slots across the Composer, terminal shortcut panel, and four-button side stack.
- Replace the Paste shortcut with directional defaults, symbol labels, and direct key-selector opening.
- Keep floating mobile controls at a stable position above the two Composer shortcut rows, right-anchor narrow shortcut grids, and hide floating controls while the Composer keyboard is active.
- Align the Restore defaults icon and label.

## Verification

- `bun run precommit` — 792 passed, 1 skipped, 0 failed
- `bun run build:web`
- Manual mobile Composer and soft-keyboard smoke check

## Screenshots

Not included: the final behavior depends on native soft-keyboard focus and was validated interactively on-device.
