### PR TITLE
Add inline review annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- Add inline review annotations for diff lines, source lines, and rendered
+  Markdown selections. A shared review panel edits and orders comments,
+  preserves drafts per checkout, copies compiled feedback, or pre-fills an
+  agent pane without submitting it. Content anchors follow moved lines when
+  possible and remain available with a stale marker when source text changes.
 - Add Git file actions to the Changes panel: right-click, long-press, or the
   keyboard context-menu key on a working-tree file opens a menu with Open
   file, Copy relative/absolute path, and status-matched Git actions (stage,

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -188,6 +188,22 @@ Lifecycle to manage saved per-checkout settings.
 
 File operations and previews work for both local and SSH-backed workspaces.
 
+## Review Annotations
+
+- Click or drag across diff line numbers, or click a source-file annotation
+  gutter, to attach a short comment with the file, side, line range, content
+  snapshot, and hunk context. Dragged diff ranges remain strongly highlighted
+  while the comment editor is open.
+- Select text in rendered Markdown to annotate the exact passage with its
+  nearest heading path.
+- Edit, delete, and reorder comments in one checkout-scoped review panel.
+- Copy the compiled feedback or pre-fill it in a selected Agent pane. Terminal
+  delivery never submits the message; review it in the Agent input and press
+  Enter manually.
+- Drafts persist in the current browser until delivered or cleared. Refreshed
+  files and diffs re-anchor matching content automatically and mark unresolved
+  anchors as stale without dropping their captured quote.
+
 ## Diff Viewer
 
 - Browse changed files as a directory tree with staged, unstaged, untracked,

--- a/web/src/annotations.test.ts
+++ b/web/src/annotations.test.ts
@@ -1,0 +1,346 @@
+import { describe, expect, test } from "bun:test";
+import {
+  annotationDraftStorageKey,
+  compileReviewFeedback,
+  createReviewAnnotation,
+  findDiffReviewLine,
+  findDiffReviewSelection,
+  moveReviewAnnotation,
+  parseDiffReviewLines,
+  readReviewAnnotations,
+  reanchorDiffReviewAnnotations,
+  reanchorFileReviewAnnotations,
+  reviewAgentPanes,
+  writeReviewAnnotations,
+  type DiffReviewAnnotation,
+  type ReviewAnnotation,
+} from "./annotations";
+
+function memoryStorage(initial: Record<string, string> = {}) {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+    removeItem: (key: string) => values.delete(key),
+    values,
+  };
+}
+
+const diffPatch = [
+  "diff --git a/src/app.ts b/src/app.ts",
+  "--- a/src/app.ts",
+  "+++ b/src/app.ts",
+  "@@ -10,3 +10,4 @@ function run() {",
+  " keep();",
+  "-oldCall();",
+  "+newCall();",
+  "+finish();",
+  " done();",
+].join("\n");
+
+function diffAnnotation(
+  patch: Partial<DiffReviewAnnotation> = {},
+): DiffReviewAnnotation {
+  return {
+    id: "a1",
+    source: "diff",
+    path: "src/app.ts",
+    kind: "unstaged",
+    side: "new",
+    line: 12,
+    quote: "finish();",
+    hunk: "@@ -10,3 +10,4 @@ function run() {",
+    comment: "Handle this failure.",
+    createdAt: 1,
+    ...patch,
+  };
+}
+
+describe("review annotation drafts", () => {
+  test("uses durable connection and checkout identity for persistence", () => {
+    const key = annotationDraftStorageKey({
+      kind: "worktree",
+      connectionId: "remote/a",
+      workspaceId: "workspace-1",
+      repoKey: "repo",
+      checkoutKey: "checkout",
+      checkoutPath: "/worktree",
+    });
+    expect(key).toContain("remote%2Fa");
+    expect(decodeURIComponent(key)).toContain(
+      "workspaceAnnotations:v1:checkout:checkout",
+    );
+  });
+
+  test("round-trips valid drafts and drops malformed records", () => {
+    const storage = memoryStorage();
+    const annotations = [diffAnnotation()];
+    writeReviewAnnotations(storage, "draft", annotations);
+    storage.setItem(
+      "mixed",
+      JSON.stringify([annotations[0], { source: "diff", path: "missing" }]),
+    );
+    expect(readReviewAnnotations(storage, "draft")).toEqual(annotations);
+    expect(readReviewAnnotations(storage, "mixed")).toEqual(annotations);
+    expect(writeReviewAnnotations(storage, "draft", [])).toBe(true);
+    expect(storage.getItem("draft")).toBeNull();
+    expect(
+      writeReviewAnnotations(
+        {
+          setItem: () => {
+            throw new Error("storage blocked");
+          },
+          removeItem: () => {
+            throw new Error("storage blocked");
+          },
+        },
+        "draft",
+        annotations,
+      ),
+    ).toBe(false);
+  });
+
+  test("creates and reorders annotations without mutating the input", () => {
+    const first = createReviewAnnotation(
+      {
+        source: "file",
+        anchor: "line",
+        path: "a.ts",
+        line: 1,
+        quote: "a",
+        comment: "First",
+      },
+      () => "first",
+      10,
+    );
+    const second = { ...first, id: "second", comment: "Second" };
+    const source = [first, second];
+    expect(
+      moveReviewAnnotation(source, "second", -1).map((item) => item.id),
+    ).toEqual(["second", "first"]);
+    expect(source.map((item) => item.id)).toEqual(["first", "second"]);
+  });
+});
+
+describe("annotation anchors", () => {
+  test("parses old, new, and context sides from a patch", () => {
+    const lines = parseDiffReviewLines(diffPatch);
+    expect(lines).toContainEqual({
+      side: "old",
+      line: 11,
+      quote: "oldCall();",
+      hunk: "@@ -10,3 +10,4 @@ function run() {",
+    });
+    expect(findDiffReviewLine(diffPatch, "new", 12)?.quote).toBe("finish();");
+    expect(findDiffReviewLine(diffPatch, "old", 12)?.quote).toBe("done();");
+  });
+
+  test("captures dragged line ranges on one side or across diff sides", () => {
+    expect(
+      findDiffReviewSelection(diffPatch, {
+        start: 11,
+        side: "additions",
+        end: 12,
+      }),
+    ).toEqual({
+      side: "new",
+      line: 11,
+      endLine: 12,
+      quote: "newCall();\nfinish();",
+      hunk: "@@ -10,3 +10,4 @@ function run() {",
+    });
+    expect(
+      findDiffReviewSelection(diffPatch, {
+        start: 11,
+        side: "deletions",
+        end: 12,
+        endSide: "additions",
+      }),
+    ).toEqual({
+      side: "old",
+      line: 11,
+      endSide: "new",
+      endLine: 12,
+      quote: "oldCall();\nnewCall();\nfinish();",
+      hunk: "@@ -10,3 +10,4 @@ function run() {",
+    });
+
+    const pairedPatch = [
+      "@@ -1,2 +1,2 @@",
+      "-oldOne();",
+      "-oldTwo();",
+      "+newOne();",
+      "+newTwo();",
+    ].join("\n");
+    expect(
+      findDiffReviewSelection(
+        pairedPatch,
+        {
+          start: 1,
+          side: "deletions",
+          end: 1,
+          endSide: "additions",
+        },
+        "split",
+      ),
+    ).toMatchObject({
+      quote: "oldOne();\nnewOne();",
+      line: 1,
+      endLine: 1,
+    });
+  });
+
+  test("reanchors moved diff content and marks missing content stale", () => {
+    const movedPatch = diffPatch.replace(
+      "+finish();",
+      "+padding();\n+finish();",
+    );
+    const moved = reanchorDiffReviewAnnotations(
+      [diffAnnotation()],
+      "src/app.ts",
+      "unstaged",
+      movedPatch,
+    )[0];
+    expect(moved).toMatchObject({ line: 13, stale: false });
+
+    const stale = reanchorDiffReviewAnnotations(
+      [diffAnnotation()],
+      "src/app.ts",
+      "unstaged",
+      diffPatch.replace("+finish();\n", ""),
+    )[0];
+    expect(stale.stale).toBe(true);
+
+    const otherScope = reanchorDiffReviewAnnotations(
+      [diffAnnotation()],
+      "src/app.ts",
+      "staged",
+      "@@ -1 +1 @@\n-old\n+new\n",
+    )[0];
+    expect(otherScope).toMatchObject({ line: 12 });
+    expect(otherScope.stale).toBeUndefined();
+
+    const range = {
+      ...diffAnnotation(),
+      line: 11,
+      endLine: 12,
+      quote: "newCall();\nfinish();",
+    };
+    const movedRange = reanchorDiffReviewAnnotations(
+      [range],
+      "src/app.ts",
+      "unstaged",
+      diffPatch.replace("+newCall();", "+padding();\n+newCall();"),
+    )[0];
+    expect(movedRange).toMatchObject({
+      line: 12,
+      endLine: 13,
+      stale: false,
+    });
+  });
+
+  test("reanchors file lines and preserves stale Markdown quotes", () => {
+    const line: ReviewAnnotation = {
+      id: "line",
+      source: "file",
+      anchor: "line",
+      path: "docs/plan.md",
+      line: 2,
+      quote: "target",
+      comment: "Explain this.",
+      createdAt: 1,
+    };
+    const quote: ReviewAnnotation = {
+      id: "quote",
+      source: "file",
+      anchor: "quote",
+      path: "docs/plan.md",
+      quote: "gradual rollout",
+      section: ["Launch", "Rollout"],
+      comment: "Which cohort?",
+      createdAt: 2,
+    };
+    const anchored = reanchorFileReviewAnnotations(
+      [line, quote],
+      "docs/plan.md",
+      "intro\npadding\ntarget\nA gradual   rollout begins.",
+    );
+    expect(anchored[0]).toMatchObject({ line: 3, stale: false });
+    expect(anchored[1].stale).toBeFalsy();
+
+    const crlfAnchored = reanchorFileReviewAnnotations(
+      [{ ...line, line: 2 }],
+      "docs/plan.md",
+      "intro\r\ntarget\r\nend",
+    );
+    expect(crlfAnchored[0]).toMatchObject({ line: 2 });
+    expect(crlfAnchored[0].stale).toBeUndefined();
+
+    const stale = reanchorFileReviewAnnotations(
+      anchored,
+      "docs/plan.md",
+      "intro only",
+    );
+    expect(stale.every((annotation) => annotation.stale)).toBe(true);
+  });
+});
+
+describe("compiled feedback and delivery targets", () => {
+  test("compiles diff, file-line, and Markdown annotations", () => {
+    const message = compileReviewFeedback([
+      diffAnnotation(),
+      {
+        id: "m1",
+        source: "file",
+        anchor: "quote",
+        path: "docs/plan.md",
+        quote: "We will migrate gradually.",
+        section: ["Launch", "Rollout"],
+        comment: "Which users are first?",
+        createdAt: 2,
+        stale: true,
+      },
+    ]);
+    expect(message).toContain("Review feedback:");
+    expect(message).toContain("`src/app.ts` (new line 12)");
+    expect(message).toContain("> finish();");
+    expect(message).toContain(
+      '`docs/plan.md` § "Launch › Rollout" (anchor may be stale)',
+    );
+    expect(message).toContain("Which users are first?");
+
+    const rangeMessage = compileReviewFeedback([
+      { ...diffAnnotation(), line: 11, endLine: 12 },
+    ]);
+    expect(rangeMessage).toContain("`src/app.ts` (new lines 11–12)");
+  });
+
+  test("prefers the originating agent pane and keeps a clipboard fallback", () => {
+    const panes = [
+      {
+        pane_id: "focused",
+        terminal_id: "t1",
+        workspace_id: "w1",
+        tab_id: "tab",
+        focused: true,
+        agent: "pi",
+        agent_status: "idle",
+        revision: 1,
+      },
+      {
+        pane_id: "origin",
+        terminal_id: "t2",
+        workspace_id: "w1",
+        tab_id: "tab",
+        focused: false,
+        agent: "codex",
+        agent_status: "unknown",
+        revision: 1,
+      },
+    ];
+    expect(
+      reviewAgentPanes(panes, "w1", "origin").map((pane) => pane.pane_id),
+    ).toEqual(["origin", "focused"]);
+    expect(reviewAgentPanes(panes, "missing")).toEqual([]);
+  });
+});

--- a/web/src/annotations.ts
+++ b/web/src/annotations.ts
@@ -1,0 +1,722 @@
+import { connectionStorageKey } from "./connectionStorage";
+import type { GitDiffKind, Pane } from "./types";
+import { resourceOwnerKey, type ResourceScope } from "./workspaceResource";
+
+export type ReviewAnnotationSide = "old" | "new";
+
+type ReviewAnnotationBase = {
+  id: string;
+  path: string;
+  quote: string;
+  comment: string;
+  createdAt: number;
+  stale?: boolean;
+};
+
+export type DiffReviewAnnotation = ReviewAnnotationBase & {
+  source: "diff";
+  kind: GitDiffKind;
+  side: ReviewAnnotationSide;
+  line: number;
+  endSide?: ReviewAnnotationSide;
+  endLine?: number;
+  hunk: string;
+};
+
+export type FileLineReviewAnnotation = ReviewAnnotationBase & {
+  source: "file";
+  anchor: "line";
+  line: number;
+};
+
+export type MarkdownReviewAnnotation = ReviewAnnotationBase & {
+  source: "file";
+  anchor: "quote";
+  section: string[];
+};
+
+export type ReviewAnnotation =
+  | DiffReviewAnnotation
+  | FileLineReviewAnnotation
+  | MarkdownReviewAnnotation;
+
+export type NewReviewAnnotation =
+  | Omit<DiffReviewAnnotation, "id" | "createdAt" | "stale">
+  | Omit<FileLineReviewAnnotation, "id" | "createdAt" | "stale">
+  | Omit<MarkdownReviewAnnotation, "id" | "createdAt" | "stale">;
+
+export type ParsedDiffLine = {
+  side: ReviewAnnotationSide;
+  line: number;
+  quote: string;
+  hunk: string;
+};
+
+export type DiffReviewSelectionRange = {
+  start: number;
+  side?: "deletions" | "additions";
+  end: number;
+  endSide?: "deletions" | "additions";
+};
+
+export type DiffReviewSelection = {
+  side: ReviewAnnotationSide;
+  line: number;
+  endSide?: ReviewAnnotationSide;
+  endLine?: number;
+  quote: string;
+  hunk: string;
+};
+
+type ParsedDiffRow = {
+  old?: ParsedDiffLine;
+  new?: ParsedDiffLine;
+};
+
+const ANNOTATION_STORAGE_PREFIX = "workspaceAnnotations:v1:";
+const MAX_STORED_ANNOTATIONS = 200;
+const MAX_PATH_LENGTH = 4_096;
+const MAX_QUOTE_LENGTH = 20_000;
+const MAX_COMMENT_LENGTH = 10_000;
+const MAX_HUNK_LENGTH = 1_000;
+const MAX_SECTION_DEPTH = 12;
+
+export function annotationDraftStorageKey(scope: ResourceScope) {
+  return connectionStorageKey(
+    scope.connectionId,
+    `${ANNOTATION_STORAGE_PREFIX}${resourceOwnerKey(scope)}`,
+  );
+}
+
+function boundedString(value: unknown, max: number): string | null {
+  return typeof value === "string" && value.length <= max ? value : null;
+}
+
+function finitePositiveLine(value: unknown): number | null {
+  return typeof value === "number" &&
+    Number.isInteger(value) &&
+    value > 0 &&
+    value <= Number.MAX_SAFE_INTEGER
+    ? value
+    : null;
+}
+
+export function parseReviewAnnotation(value: unknown): ReviewAnnotation | null {
+  if (!value || typeof value !== "object") return null;
+  const candidate = value as Record<string, unknown>;
+  const id = boundedString(candidate.id, 200);
+  const path = boundedString(candidate.path, MAX_PATH_LENGTH);
+  const quote = boundedString(candidate.quote, MAX_QUOTE_LENGTH);
+  const comment = boundedString(candidate.comment, MAX_COMMENT_LENGTH);
+  const createdAt =
+    typeof candidate.createdAt === "number" &&
+    Number.isFinite(candidate.createdAt) &&
+    candidate.createdAt >= 0
+      ? candidate.createdAt
+      : null;
+  if (
+    !id ||
+    !path ||
+    quote === null ||
+    comment === null ||
+    createdAt === null
+  ) {
+    return null;
+  }
+  const base = {
+    id,
+    path,
+    quote,
+    comment,
+    createdAt,
+    ...(candidate.stale === true ? { stale: true } : {}),
+  };
+
+  if (candidate.source === "diff") {
+    const line = finitePositiveLine(candidate.line);
+    const hunk = boundedString(candidate.hunk, MAX_HUNK_LENGTH);
+    const endLine =
+      candidate.endLine === undefined
+        ? undefined
+        : finitePositiveLine(candidate.endLine);
+    const endSide =
+      candidate.endSide === undefined ? undefined : candidate.endSide;
+    const validKind = [
+      "staged",
+      "unstaged",
+      "untracked",
+      "conflicted",
+      "branch",
+      "last-step",
+    ].includes(String(candidate.kind));
+    if (
+      line === null ||
+      hunk === null ||
+      !validKind ||
+      (candidate.side !== "old" && candidate.side !== "new") ||
+      endLine === null ||
+      (endSide !== undefined && endSide !== "old" && endSide !== "new") ||
+      (endSide !== undefined && endLine === undefined)
+    ) {
+      return null;
+    }
+    return {
+      ...base,
+      source: "diff",
+      kind: candidate.kind as GitDiffKind,
+      side: candidate.side,
+      line,
+      ...(endLine === undefined ? {} : { endLine }),
+      ...(endSide === undefined ? {} : { endSide }),
+      hunk,
+    };
+  }
+
+  if (candidate.source !== "file") return null;
+  if (candidate.anchor === "line") {
+    const line = finitePositiveLine(candidate.line);
+    return line === null
+      ? null
+      : { ...base, source: "file", anchor: "line", line };
+  }
+  if (candidate.anchor !== "quote" || !Array.isArray(candidate.section)) {
+    return null;
+  }
+  const section = candidate.section
+    .slice(0, MAX_SECTION_DEPTH)
+    .map((part) => boundedString(part, 500))
+    .filter((part): part is string => part !== null && part.length > 0);
+  return { ...base, source: "file", anchor: "quote", section };
+}
+
+export function readReviewAnnotations(
+  storage: Pick<Storage, "getItem">,
+  key: string,
+): ReviewAnnotation[] {
+  try {
+    const raw = storage.getItem(key);
+    if (!raw) return [];
+    const value = JSON.parse(raw);
+    if (!Array.isArray(value)) return [];
+    return value
+      .slice(0, MAX_STORED_ANNOTATIONS)
+      .map(parseReviewAnnotation)
+      .filter((item): item is ReviewAnnotation => item !== null);
+  } catch {
+    return [];
+  }
+}
+
+export function writeReviewAnnotations(
+  storage: Pick<Storage, "setItem" | "removeItem">,
+  key: string,
+  annotations: readonly ReviewAnnotation[],
+) {
+  try {
+    if (annotations.length === 0) storage.removeItem(key);
+    else storage.setItem(key, JSON.stringify(annotations));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function fallbackAnnotationId() {
+  return `annotation-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2)}`;
+}
+
+export function createReviewAnnotation(
+  input: NewReviewAnnotation,
+  createId: () => string = () =>
+    globalThis.crypto?.randomUUID?.() ?? fallbackAnnotationId(),
+  createdAt = Date.now(),
+): ReviewAnnotation {
+  return { ...input, id: createId(), createdAt } as ReviewAnnotation;
+}
+
+export function moveReviewAnnotation(
+  annotations: readonly ReviewAnnotation[],
+  id: string,
+  delta: -1 | 1,
+): ReviewAnnotation[] {
+  const index = annotations.findIndex((annotation) => annotation.id === id);
+  const target = index + delta;
+  if (index < 0 || target < 0 || target >= annotations.length) {
+    return [...annotations];
+  }
+  const next = [...annotations];
+  [next[index], next[target]] = [next[target], next[index]];
+  return next;
+}
+
+function parseDiffReviewRows(patch: string): ParsedDiffRow[] {
+  const result: ParsedDiffRow[] = [];
+  let oldLine = 0;
+  let newLine = 0;
+  let hunk = "";
+
+  for (const rawLine of patch.split("\n")) {
+    const header = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@.*$/.exec(rawLine);
+    if (header) {
+      oldLine = Number(header[1]);
+      newLine = Number(header[2]);
+      hunk = rawLine;
+      continue;
+    }
+    if (!hunk || rawLine.startsWith("\\")) continue;
+    if (rawLine.startsWith("+")) {
+      result.push({
+        new: {
+          side: "new",
+          line: newLine,
+          quote: rawLine.slice(1),
+          hunk,
+        },
+      });
+      newLine += 1;
+      continue;
+    }
+    if (rawLine.startsWith("-")) {
+      result.push({
+        old: {
+          side: "old",
+          line: oldLine,
+          quote: rawLine.slice(1),
+          hunk,
+        },
+      });
+      oldLine += 1;
+      continue;
+    }
+    if (rawLine.startsWith(" ")) {
+      const quote = rawLine.slice(1);
+      result.push({
+        old: { side: "old", line: oldLine, quote, hunk },
+        new: { side: "new", line: newLine, quote, hunk },
+      });
+      oldLine += 1;
+      newLine += 1;
+    }
+  }
+  return result;
+}
+
+function parseSplitDiffReviewRows(patch: string): ParsedDiffRow[] {
+  const result: ParsedDiffRow[] = [];
+  let deletions: ParsedDiffLine[] = [];
+  let additions: ParsedDiffLine[] = [];
+  let changeHunk = "";
+  const flushChanges = () => {
+    const length = Math.max(deletions.length, additions.length);
+    for (let index = 0; index < length; index += 1) {
+      result.push({ old: deletions[index], new: additions[index] });
+    }
+    deletions = [];
+    additions = [];
+    changeHunk = "";
+  };
+
+  for (const row of parseDiffReviewRows(patch)) {
+    if (row.old && row.new) {
+      flushChanges();
+      result.push(row);
+      continue;
+    }
+    const line = row.old ?? row.new;
+    if (!line) continue;
+    if (changeHunk && changeHunk !== line.hunk) flushChanges();
+    changeHunk = line.hunk;
+    if (row.old) deletions.push(row.old);
+    else if (row.new) additions.push(row.new);
+  }
+  flushChanges();
+  return result;
+}
+
+export function parseDiffReviewLines(patch: string): ParsedDiffLine[] {
+  return parseDiffReviewRows(patch).flatMap((row) =>
+    row.old && row.new ? [row.old, row.new] : [row.old ?? row.new!],
+  );
+}
+
+export function findDiffReviewLine(
+  patch: string,
+  side: ReviewAnnotationSide,
+  line: number,
+): ParsedDiffLine | null {
+  return (
+    parseDiffReviewLines(patch).find(
+      (candidate) => candidate.side === side && candidate.line === line,
+    ) ?? null
+  );
+}
+
+function reviewSide(side: "deletions" | "additions" | undefined) {
+  return side === "deletions" ? "old" : side === "additions" ? "new" : null;
+}
+
+function rowLine(row: ParsedDiffRow, side: ReviewAnnotationSide) {
+  return side === "old" ? row.old : row.new;
+}
+
+function diffRowQuotes(row: ParsedDiffRow, diffStyle: "split" | "unified") {
+  if (row.old && row.new && row.old.quote === row.new.quote) {
+    return [row.old.quote];
+  }
+  if (diffStyle === "split") {
+    return [row.old?.quote, row.new?.quote].filter(
+      (quote): quote is string => quote !== undefined,
+    );
+  }
+  return [row.old?.quote ?? row.new?.quote ?? ""];
+}
+
+export function findDiffReviewSelection(
+  patch: string,
+  range: DiffReviewSelectionRange,
+  diffStyle: "split" | "unified" = "unified",
+): DiffReviewSelection | null {
+  const startSide = reviewSide(range.side);
+  const endSide = reviewSide(range.endSide ?? range.side);
+  if (!startSide || !endSide) return null;
+
+  const rows =
+    diffStyle === "split"
+      ? parseSplitDiffReviewRows(patch)
+      : parseDiffReviewRows(patch);
+  const startIndex = rows.findIndex(
+    (row) => rowLine(row, startSide)?.line === range.start,
+  );
+  const endIndex = rows.findIndex(
+    (row) => rowLine(row, endSide)?.line === range.end,
+  );
+  if (startIndex < 0 || endIndex < 0) return null;
+
+  if (startSide === endSide) {
+    const firstLine = Math.min(range.start, range.end);
+    const lastLine = Math.max(range.start, range.end);
+    const selected = parseDiffReviewLines(patch).filter(
+      (line) =>
+        line.side === startSide &&
+        line.line >= firstLine &&
+        line.line <= lastLine,
+    );
+    if (!selected.length) return null;
+    const quote = selected.map((line) => line.quote).join("\n");
+    if (quote.length > MAX_QUOTE_LENGTH) return null;
+    return {
+      side: startSide,
+      line: firstLine,
+      ...(lastLine === firstLine ? {} : { endLine: lastLine }),
+      quote,
+      hunk: selected[0].hunk,
+    };
+  }
+
+  const firstIndex = Math.min(startIndex, endIndex);
+  const lastIndex = Math.max(startIndex, endIndex);
+  const firstIsStart = firstIndex === startIndex;
+  const firstSide = firstIsStart ? startSide : endSide;
+  const lastSide = firstIsStart ? endSide : startSide;
+  const first = rowLine(rows[firstIndex], firstSide);
+  const last = rowLine(rows[lastIndex], lastSide);
+  if (!first || !last) return null;
+  const selected = rows
+    .slice(firstIndex, lastIndex + 1)
+    .flatMap((row) => diffRowQuotes(row, diffStyle));
+  const quote = selected.join("\n");
+  if (quote.length > MAX_QUOTE_LENGTH) return null;
+  return {
+    side: firstSide,
+    line: first.line,
+    endSide: lastSide,
+    endLine: last.line,
+    quote,
+    hunk: first.hunk,
+  };
+}
+
+export function diffReviewLineLabel(
+  annotation: Pick<
+    DiffReviewAnnotation,
+    "side" | "line" | "endSide" | "endLine"
+  >,
+) {
+  if (annotation.endLine === undefined) {
+    return `${annotation.side} line ${annotation.line}`;
+  }
+  const endSide = annotation.endSide ?? annotation.side;
+  return endSide === annotation.side
+    ? `${annotation.side} lines ${annotation.line}–${annotation.endLine}`
+    : `${annotation.side} line ${annotation.line} → ${endSide} line ${annotation.endLine}`;
+}
+
+function chooseNearestLine<T extends { line: number }>(
+  candidates: T[],
+  previousLine: number,
+): T | null {
+  if (candidates.length === 0) return null;
+  const sorted = [...candidates].sort(
+    (left, right) =>
+      Math.abs(left.line - previousLine) - Math.abs(right.line - previousLine),
+  );
+  if (
+    sorted.length > 1 &&
+    Math.abs(sorted[0].line - previousLine) ===
+      Math.abs(sorted[1].line - previousLine)
+  ) {
+    return null;
+  }
+  return sorted[0];
+}
+
+function matchingWindowStarts(values: string[], wanted: string[]) {
+  if (!wanted.length || wanted.length > values.length) return [];
+  const result: number[] = [];
+  for (let start = 0; start <= values.length - wanted.length; start += 1) {
+    if (wanted.every((value, offset) => values[start + offset] === value)) {
+      result.push(start);
+    }
+  }
+  return result;
+}
+
+function pierreSide(side: ReviewAnnotationSide) {
+  return side === "old" ? ("deletions" as const) : ("additions" as const);
+}
+
+function reanchorDiffRange(
+  annotation: DiffReviewAnnotation,
+  patch: string,
+): DiffReviewAnnotation | null {
+  const annotationEndLine = annotation.endLine;
+  if (annotationEndLine === undefined) return null;
+  const endSide = annotation.endSide ?? annotation.side;
+  const styles = ["unified", "split"] as const;
+  const exact = styles
+    .map((diffStyle) =>
+      findDiffReviewSelection(
+        patch,
+        {
+          start: annotation.line,
+          side: pierreSide(annotation.side),
+          end: annotationEndLine,
+          endSide: pierreSide(endSide),
+        },
+        diffStyle,
+      ),
+    )
+    .find((selection) => selection?.quote === annotation.quote);
+  if (exact) {
+    if (!annotation.stale && exact.hunk === annotation.hunk) return annotation;
+    return { ...annotation, hunk: exact.hunk, stale: false };
+  }
+
+  const wanted = annotation.quote.split("\n");
+  if (annotation.side === endSide) {
+    const lines = parseDiffReviewLines(patch).filter(
+      (line) => line.side === annotation.side,
+    );
+    const starts = matchingWindowStarts(
+      lines.map((line) => line.quote),
+      wanted,
+    );
+    const candidates = starts.map((start) => ({
+      line: lines[start].line,
+      endLine: lines[start + wanted.length - 1].line,
+      hunk: lines[start].hunk,
+    }));
+    const match = chooseNearestLine(candidates, annotation.line);
+    return match
+      ? {
+          ...annotation,
+          line: match.line,
+          endLine: match.endLine,
+          hunk: match.hunk,
+          stale: false,
+        }
+      : null;
+  }
+
+  const candidates = styles.flatMap((diffStyle) => {
+    const rows =
+      diffStyle === "split"
+        ? parseSplitDiffReviewRows(patch)
+        : parseDiffReviewRows(patch);
+    const entries = rows.flatMap((row, rowIndex) => {
+      const quotes = diffRowQuotes(row, diffStyle);
+      return quotes.map((quote, quoteIndex) => ({
+        quote,
+        quoteIndex,
+        quoteCount: quotes.length,
+        rowIndex,
+      }));
+    });
+    const starts = matchingWindowStarts(
+      entries.map((entry) => entry.quote),
+      wanted,
+    );
+    return starts.flatMap((start) => {
+      const firstEntry = entries[start];
+      const lastEntry = entries[start + wanted.length - 1];
+      if (
+        firstEntry.quoteIndex !== 0 ||
+        lastEntry.quoteIndex !== lastEntry.quoteCount - 1
+      ) {
+        return [];
+      }
+      const first = rowLine(rows[firstEntry.rowIndex], annotation.side);
+      const last = rowLine(rows[lastEntry.rowIndex], endSide);
+      return first && last
+        ? [{ line: first.line, endLine: last.line, hunk: first.hunk }]
+        : [];
+    });
+  });
+  const match = chooseNearestLine(candidates, annotation.line);
+  return match
+    ? {
+        ...annotation,
+        line: match.line,
+        endLine: match.endLine,
+        hunk: match.hunk,
+        stale: false,
+      }
+    : null;
+}
+
+export function reanchorDiffReviewAnnotations(
+  annotations: readonly ReviewAnnotation[],
+  path: string,
+  kind: GitDiffKind,
+  patch: string,
+): ReviewAnnotation[] {
+  const lines = parseDiffReviewLines(patch);
+  return annotations.map((annotation) => {
+    if (
+      annotation.source !== "diff" ||
+      annotation.path !== path ||
+      annotation.kind !== kind
+    ) {
+      return annotation;
+    }
+    if (annotation.endLine !== undefined) {
+      const anchored = reanchorDiffRange(annotation, patch);
+      if (anchored) return anchored;
+      return annotation.stale ? annotation : { ...annotation, stale: true };
+    }
+    const current = lines.find(
+      (line) => line.side === annotation.side && line.line === annotation.line,
+    );
+    if (current?.quote === annotation.quote) {
+      if (!annotation.stale && current.hunk === annotation.hunk)
+        return annotation;
+      return { ...annotation, hunk: current.hunk, stale: false };
+    }
+    const match = chooseNearestLine(
+      lines.filter(
+        (line) =>
+          line.side === annotation.side && line.quote === annotation.quote,
+      ),
+      annotation.line,
+    );
+    if (!match) {
+      return annotation.stale ? annotation : { ...annotation, stale: true };
+    }
+    return {
+      ...annotation,
+      line: match.line,
+      hunk: match.hunk,
+      stale: false,
+    };
+  });
+}
+
+function normalizedSearchText(value: string) {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+export function reanchorFileReviewAnnotations(
+  annotations: readonly ReviewAnnotation[],
+  path: string,
+  text: string,
+): ReviewAnnotation[] {
+  const fileLines = text.split(/\r\n?|\n/);
+  const normalizedText = normalizedSearchText(text);
+  return annotations.map((annotation) => {
+    if (annotation.source !== "file" || annotation.path !== path) {
+      return annotation;
+    }
+    if (annotation.anchor === "quote") {
+      const anchored =
+        annotation.quote.length > 0 &&
+        normalizedText.includes(normalizedSearchText(annotation.quote));
+      if (anchored === !annotation.stale) return annotation;
+      return { ...annotation, stale: !anchored };
+    }
+    if (fileLines[annotation.line - 1] === annotation.quote) {
+      return annotation.stale ? { ...annotation, stale: false } : annotation;
+    }
+    const candidates = fileLines.flatMap((quote, index) =>
+      quote === annotation.quote ? [{ line: index + 1 }] : [],
+    );
+    const match = chooseNearestLine(candidates, annotation.line);
+    if (!match) {
+      return annotation.stale ? annotation : { ...annotation, stale: true };
+    }
+    return { ...annotation, line: match.line, stale: false };
+  });
+}
+
+function quotedPath(path: string) {
+  return `\`${path.replace(/`/g, "\\`")}\``;
+}
+
+function quoteBlock(value: string) {
+  return value
+    .split("\n")
+    .map((line) => `> ${line}`)
+    .join("\n");
+}
+
+export function compileReviewFeedback(
+  annotations: readonly ReviewAnnotation[],
+): string {
+  const items = annotations
+    .filter((annotation) => annotation.comment.trim())
+    .map((annotation, index) => {
+      const stale = annotation.stale ? "; anchor may be stale" : "";
+      const location =
+        annotation.source === "diff"
+          ? `${quotedPath(annotation.path)} (${diffReviewLineLabel(annotation)}${stale})`
+          : annotation.anchor === "line"
+            ? `${quotedPath(annotation.path)} (line ${annotation.line}${stale})`
+            : annotation.section.length
+              ? `${quotedPath(annotation.path)} § "${annotation.section.join(" › ")}"${annotation.stale ? " (anchor may be stale)" : ""}`
+              : `${quotedPath(annotation.path)} (selected passage${stale})`;
+      return `${index + 1}. ${location}:\n${quoteBlock(annotation.quote)}\n\n${annotation.comment.trim()}`;
+    });
+  return items.length ? `Review feedback:\n\n${items.join("\n\n")}` : "";
+}
+
+export function reviewAgentPanes(
+  panes: readonly Pane[],
+  workspaceId: string,
+  preferredPaneId?: string,
+): Pane[] {
+  return panes
+    .filter(
+      (pane) =>
+        pane.workspace_id === workspaceId &&
+        typeof pane.agent === "string" &&
+        pane.agent.trim().length > 0,
+    )
+    .sort((left, right) => {
+      const leftRank =
+        left.pane_id === preferredPaneId ? 0 : left.focused ? 1 : 2;
+      const rightRank =
+        right.pane_id === preferredPaneId ? 0 : right.focused ? 1 : 2;
+      return leftRank - rightRank || left.pane_id.localeCompare(right.pane_id);
+    });
+}

--- a/web/src/components/AnnotationComposerPopover.tsx
+++ b/web/src/components/AnnotationComposerPopover.tsx
@@ -1,0 +1,125 @@
+import { useLayoutEffect, useRef, useState, type FormEvent } from "react";
+import { createPortal } from "react-dom";
+
+export type AnnotationComposerDraft = {
+  x: number;
+  y: number;
+  title: string;
+  quote: string;
+};
+
+export function AnnotationComposerPopover({
+  draft,
+  onSave,
+  onClose,
+}: {
+  draft: AnnotationComposerDraft | null;
+  onSave: (comment: string) => void;
+  onClose: () => void;
+}) {
+  const formRef = useRef<HTMLFormElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [comment, setComment] = useState("");
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const draftX = draft?.x;
+  const draftY = draft?.y;
+  const draftTitle = draft?.title;
+  const draftQuote = draft?.quote;
+
+  useLayoutEffect(() => {
+    if (
+      draftX === undefined ||
+      draftY === undefined ||
+      draftTitle === undefined ||
+      draftQuote === undefined
+    ) {
+      return;
+    }
+    setComment("");
+    setPosition({ x: draftX, y: draftY });
+    const frame = requestAnimationFrame(() => {
+      const form = formRef.current;
+      if (!form) return;
+      const rect = form.getBoundingClientRect();
+      const margin = 8;
+      setPosition({
+        x: Math.min(
+          Math.max(margin, draftX),
+          Math.max(margin, window.innerWidth - rect.width - margin),
+        ),
+        y: Math.min(
+          Math.max(margin, draftY),
+          Math.max(margin, window.innerHeight - rect.height - margin),
+        ),
+      });
+      textareaRef.current?.focus({ preventScroll: true });
+    });
+    const closeOnPointerDown = (event: PointerEvent) => {
+      const target = event.target instanceof Node ? event.target : null;
+      if (target && formRef.current?.contains(target)) return;
+      onClose();
+    };
+    window.addEventListener("pointerdown", closeOnPointerDown, {
+      capture: true,
+    });
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener("pointerdown", closeOnPointerDown, {
+        capture: true,
+      });
+    };
+  }, [draftQuote, draftTitle, draftX, draftY, onClose]);
+
+  if (!draft) return null;
+
+  const save = () => {
+    const value = comment.trim();
+    if (value) onSave(value);
+  };
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    save();
+  };
+
+  return createPortal(
+    <form
+      ref={formRef}
+      className="annotation-composer-popover"
+      style={{ left: position.x, top: position.y }}
+      role="dialog"
+      aria-label="Add review comment"
+      onSubmit={submit}
+      onKeyDown={(event) => {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          event.stopPropagation();
+          onClose();
+        } else if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+          event.preventDefault();
+          save();
+        }
+      }}
+    >
+      <strong>{draft.title}</strong>
+      <blockquote>{draft.quote || "Blank line"}</blockquote>
+      <textarea
+        ref={textareaRef}
+        value={comment}
+        onChange={(event) => setComment(event.currentTarget.value)}
+        placeholder="Add a review comment"
+        rows={3}
+        maxLength={10_000}
+      />
+      <div className="annotation-composer-actions">
+        <button type="button" className="ghost" onClick={onClose}>
+          Cancel
+        </button>
+        <button type="submit" disabled={!comment.trim()}>
+          Add comment
+        </button>
+      </div>
+      <small>Cmd/Ctrl+Enter to add</small>
+    </form>,
+    document.body,
+  );
+}

--- a/web/src/components/AnnotationPanel.tsx
+++ b/web/src/components/AnnotationPanel.tsx
@@ -1,0 +1,242 @@
+import {
+  ArrowDown,
+  ArrowUp,
+  Clipboard,
+  MessageSquareText,
+  Send,
+  Trash2,
+  X,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+import { diffReviewLineLabel, type ReviewAnnotation } from "../annotations";
+import type { Pane } from "../types";
+import { ConfirmDialog } from "./ModalDialogs";
+
+function annotationLocation(annotation: ReviewAnnotation) {
+  if (annotation.source === "diff") {
+    return `${annotation.path} · ${diffReviewLineLabel(annotation)}`;
+  }
+  if (annotation.anchor === "line") {
+    return `${annotation.path} · line ${annotation.line}`;
+  }
+  return annotation.section.length
+    ? `${annotation.path} · ${annotation.section.join(" › ")}`
+    : `${annotation.path} · selected passage`;
+}
+
+function paneLabel(pane: Pane) {
+  const id = pane.pane_id.length > 8 ? pane.pane_id.slice(0, 8) : pane.pane_id;
+  return `${pane.agent ?? "Agent"} · ${id}`;
+}
+
+export function AnnotationPanel({
+  open,
+  annotations,
+  agentPanes,
+  preferredPaneId,
+  busy,
+  focusedAnnotationId,
+  onClose,
+  onUpdateComment,
+  onDelete,
+  onMove,
+  onClear,
+  onCopy,
+  onSend,
+}: {
+  open: boolean;
+  annotations: readonly ReviewAnnotation[];
+  agentPanes: readonly Pane[];
+  preferredPaneId?: string;
+  busy: boolean;
+  focusedAnnotationId?: string | null;
+  onClose: () => void;
+  onUpdateComment: (id: string, comment: string) => void;
+  onDelete: (id: string) => void;
+  onMove: (id: string, delta: -1 | 1) => void;
+  onClear: () => void;
+  onCopy: () => void;
+  onSend: (paneId: string | null) => void;
+}) {
+  const [targetPaneId, setTargetPaneId] = useState("");
+  const [confirmClear, setConfirmClear] = useState(false);
+
+  useEffect(() => {
+    const preferred = agentPanes.find(
+      (pane) => pane.pane_id === preferredPaneId,
+    );
+    setTargetPaneId((current) => {
+      if (agentPanes.some((pane) => pane.pane_id === current)) return current;
+      return preferred?.pane_id ?? agentPanes[0]?.pane_id ?? "";
+    });
+  }, [agentPanes, preferredPaneId]);
+
+  useEffect(() => {
+    if (!open || !focusedAnnotationId) return;
+    requestAnimationFrame(() => {
+      const card = Array.from(
+        document.querySelectorAll<HTMLElement>("[data-review-annotation-id]"),
+      ).find(
+        (element) => element.dataset.reviewAnnotationId === focusedAnnotationId,
+      );
+      card?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+      card?.querySelector("textarea")?.focus({ preventScroll: true });
+    });
+  }, [focusedAnnotationId, open]);
+
+  if (!open) return null;
+
+  return (
+    <aside className="annotation-panel" aria-label="Review annotations">
+      <header className="annotation-panel-head">
+        <div>
+          <strong>Review feedback</strong>
+          <span>
+            {annotations.length} comment{annotations.length === 1 ? "" : "s"}
+          </span>
+        </div>
+        <button
+          type="button"
+          className="annotation-icon-button"
+          aria-label="Close review feedback"
+          title="Close"
+          onClick={onClose}
+        >
+          <X size={16} />
+        </button>
+      </header>
+
+      <div className="annotation-panel-list">
+        {annotations.length === 0 ? (
+          <div className="annotation-panel-empty">
+            <MessageSquareText size={24} />
+            <strong>No review comments yet</strong>
+            <span>
+              Click or drag across diff line numbers, click a source gutter, or
+              select rendered Markdown text.
+            </span>
+          </div>
+        ) : (
+          annotations.map((annotation, index) => (
+            <article
+              key={annotation.id}
+              data-review-annotation-id={annotation.id}
+              className={`annotation-card ${
+                annotation.id === focusedAnnotationId ? "is-focused" : ""
+              }`}
+            >
+              <div className="annotation-card-head">
+                <strong title={annotationLocation(annotation)}>
+                  {index + 1}. {annotationLocation(annotation)}
+                </strong>
+                {annotation.stale ? <span>Stale anchor</span> : null}
+              </div>
+              <blockquote>{annotation.quote || "Blank line"}</blockquote>
+              <textarea
+                value={annotation.comment}
+                rows={3}
+                maxLength={10_000}
+                aria-label={`Comment ${index + 1}`}
+                onChange={(event) =>
+                  onUpdateComment(annotation.id, event.currentTarget.value)
+                }
+              />
+              <div className="annotation-card-actions">
+                <button
+                  type="button"
+                  className="annotation-icon-button"
+                  disabled={index === 0}
+                  aria-label={`Move comment ${index + 1} up`}
+                  title="Move up"
+                  onClick={() => onMove(annotation.id, -1)}
+                >
+                  <ArrowUp size={14} />
+                </button>
+                <button
+                  type="button"
+                  className="annotation-icon-button"
+                  disabled={index === annotations.length - 1}
+                  aria-label={`Move comment ${index + 1} down`}
+                  title="Move down"
+                  onClick={() => onMove(annotation.id, 1)}
+                >
+                  <ArrowDown size={14} />
+                </button>
+                <button
+                  type="button"
+                  className="annotation-icon-button is-danger"
+                  aria-label={`Delete comment ${index + 1}`}
+                  title="Delete"
+                  onClick={() => onDelete(annotation.id)}
+                >
+                  <Trash2 size={14} />
+                </button>
+              </div>
+            </article>
+          ))
+        )}
+      </div>
+
+      <footer className="annotation-panel-footer">
+        {agentPanes.length > 1 ? (
+          <label className="annotation-target-picker">
+            <span>Agent pane</span>
+            <select
+              value={targetPaneId}
+              onChange={(event) => setTargetPaneId(event.currentTarget.value)}
+            >
+              {agentPanes.map((pane) => (
+                <option key={pane.pane_id} value={pane.pane_id}>
+                  {paneLabel(pane)}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : agentPanes.length === 1 ? (
+          <div className="annotation-target-summary">
+            Agent pane: {paneLabel(agentPanes[0])}
+          </div>
+        ) : (
+          <div className="annotation-target-summary">
+            No agent pane; Send uses the clipboard.
+          </div>
+        )}
+        <div className="annotation-delivery-actions">
+          <button
+            type="button"
+            className="ghost"
+            disabled={busy || annotations.length === 0}
+            onClick={onCopy}
+          >
+            <Clipboard size={14} /> Copy
+          </button>
+          <button
+            type="button"
+            disabled={busy || annotations.length === 0}
+            onClick={() => onSend(targetPaneId || null)}
+          >
+            {agentPanes.length ? <Send size={14} /> : <Clipboard size={14} />}
+            {agentPanes.length ? "Pre-fill agent" : "Copy feedback"}
+          </button>
+        </div>
+        <button
+          type="button"
+          className="annotation-clear-button"
+          disabled={busy || annotations.length === 0}
+          onClick={() => setConfirmClear(true)}
+        >
+          Clear draft
+        </button>
+      </footer>
+      <ConfirmDialog
+        open={confirmClear}
+        title="Clear review feedback?"
+        message="This removes every unsent review comment from this draft."
+        confirmLabel="Clear feedback"
+        danger
+        onConfirm={onClear}
+        onClose={() => setConfirmClear(false)}
+      />
+    </aside>
+  );
+}

--- a/web/src/components/DiffContentView.tsx
+++ b/web/src/components/DiffContentView.tsx
@@ -1,4 +1,4 @@
-import { DEFAULT_THEMES } from "@pierre/diffs";
+import { DEFAULT_THEMES, type SelectedLineRange } from "@pierre/diffs";
 import {
   PatchDiff,
   Virtualizer,
@@ -11,6 +11,7 @@ import {
   ChevronRight,
   ChevronUp,
   FolderOpen,
+  MessageSquareText,
   Search,
   X,
 } from "lucide-react";
@@ -27,9 +28,25 @@ import {
   type ReactNode,
 } from "react";
 import type { ConnectionClient } from "../api";
-import type { FilePreview, GitDiffEntry, GitDiffFile } from "../types";
+import {
+  diffReviewLineLabel,
+  findDiffReviewSelection,
+  type DiffReviewAnnotation,
+  type NewReviewAnnotation,
+  type ReviewAnnotation,
+} from "../annotations";
+import type {
+  FilePreview,
+  GitDiffEntry,
+  GitDiffFile,
+  GitDiffKind,
+} from "../types";
 import { connectionClientScopeKey } from "../useConnectionClient";
 import { requestFilePreview } from "./FileExplorerDialog";
+import {
+  AnnotationComposerPopover,
+  type AnnotationComposerDraft,
+} from "./AnnotationComposerPopover";
 import {
   diffAutoCollapseInfo,
   type DiffAutoCollapseInfo,
@@ -42,7 +59,7 @@ import {
 type DiffViewMode = "split" | "unified";
 type AppTheme = "dark" | "light";
 type PierreDiffOptions = NonNullable<
-  ComponentProps<typeof PatchDiff>["options"]
+  ComponentProps<typeof PatchDiff<DiffReviewAnnotation>>["options"]
 >;
 
 const DIFF_VIEW_MODE_KEY = "diffViewMode";
@@ -63,6 +80,34 @@ const DIFF_HIGHLIGHTER_OPTIONS: WorkerInitializationRenderOptions = {
   theme: DEFAULT_THEMES,
   preferredHighlighter: "shiki-wasm",
 };
+const DIFF_SELECTION_CSS = `
+  [data-line][data-selected-line] {
+    background-color: color-mix(
+      in srgb,
+      var(--diffs-selection-base) 32%,
+      var(--diffs-computed-diff-line-bg)
+    ) !important;
+    box-shadow: inset 3px 0 0 var(--diffs-selection-base);
+  }
+  [data-column-number][data-selected-line] {
+    background-color: color-mix(
+      in srgb,
+      var(--diffs-selection-base) 46%,
+      var(--diffs-bg)
+    ) !important;
+    color: var(--diffs-fg) !important;
+    font-weight: 800;
+  }
+  [data-line][data-selected-line="first"] {
+    border-top: 1px solid var(--diffs-selection-base);
+  }
+  [data-line][data-selected-line="last"] {
+    border-bottom: 1px solid var(--diffs-selection-base);
+  }
+  [data-line][data-selected-line="single"] {
+    border-block: 1px solid var(--diffs-selection-base);
+  }
+`;
 
 const PREVIEWABLE_IMAGE_EXTENSIONS = new Set([
   "png",
@@ -112,6 +157,19 @@ function startImagePreviewRequest(
 
 type DiffSearchGroup = {
   key: string;
+};
+
+type DiffAnnotationRequest = {
+  x: number;
+  y: number;
+  path: string;
+  kind: GitDiffKind;
+  side: "old" | "new";
+  line: number;
+  endSide?: "old" | "new";
+  endLine?: number;
+  quote: string;
+  hunk: string;
 };
 
 type DiffSection = {
@@ -362,9 +420,13 @@ type DiffFileSectionProps = {
   options: PierreDiffOptions;
   currentSearchMatch: boolean;
   embedded: boolean;
+  annotations: readonly DiffReviewAnnotation[];
+  annotationSelectionActive: boolean;
   onToggle: (key: string, collapsed: boolean) => void;
   onSelectFile?: (entry: GitDiffEntry) => void;
   onOpenFile?: (entry: GitDiffEntry) => void;
+  onRequestAnnotation?: (request: DiffAnnotationRequest) => void;
+  onEditAnnotation?: (id: string) => void;
 };
 
 const DiffFileSection = memo(function DiffFileSection({
@@ -374,10 +436,75 @@ const DiffFileSection = memo(function DiffFileSection({
   options,
   currentSearchMatch,
   embedded,
+  annotations,
+  annotationSelectionActive,
   onToggle,
   onSelectFile,
   onOpenFile,
+  onRequestAnnotation,
+  onEditAnnotation,
 }: DiffFileSectionProps) {
+  const pointerPositionRef = useRef({ x: 0, y: 0 });
+  const [selectedLines, setSelectedLines] = useState<SelectedLineRange | null>(
+    null,
+  );
+  const sectionOptions = useMemo<PierreDiffOptions>(
+    () => ({
+      ...options,
+      lineHoverHighlight: onRequestAnnotation ? "number" : "disabled",
+      enableLineSelection: Boolean(onRequestAnnotation),
+      controlledSelection: Boolean(onRequestAnnotation),
+      onLineSelectionStart: onRequestAnnotation ? setSelectedLines : undefined,
+      onLineSelectionChange: onRequestAnnotation ? setSelectedLines : undefined,
+      onLineSelectionEnd: onRequestAnnotation
+        ? (range) => {
+            if (!section.file || !range) {
+              setSelectedLines(null);
+              return;
+            }
+            const target = findDiffReviewSelection(
+              section.file.diff,
+              range,
+              options.diffStyle === "unified" ? "unified" : "split",
+            );
+            if (!target) {
+              setSelectedLines(null);
+              return;
+            }
+            onRequestAnnotation({
+              x: pointerPositionRef.current.x + 6,
+              y: pointerPositionRef.current.y + 8,
+              path: section.entry.path,
+              kind: section.entry.kind,
+              ...target,
+            });
+          }
+        : undefined,
+    }),
+    [
+      onRequestAnnotation,
+      options,
+      section.entry.kind,
+      section.entry.path,
+      section.file,
+    ],
+  );
+  useEffect(() => {
+    if (!annotationSelectionActive) setSelectedLines(null);
+  }, [annotationSelectionActive]);
+
+  const pierreAnnotations = useMemo(
+    () =>
+      annotations.map((annotation) => ({
+        side:
+          annotation.side === "old"
+            ? ("deletions" as const)
+            : ("additions" as const),
+        lineNumber: annotation.line,
+        metadata: annotation,
+      })),
+    [annotations],
+  );
   const toggle = () => {
     if (section.active) {
       onToggle(section.key, section.collapsed);
@@ -392,6 +519,12 @@ const DiffFileSection = memo(function DiffFileSection({
       className={`diff-file-section ${embedded ? "is-embedded" : ""} ${currentSearchMatch ? "is-search-current" : ""}`}
       data-diff-entry-key={section.key}
       aria-current={currentSearchMatch ? "true" : undefined}
+      onPointerDownCapture={(event) => {
+        pointerPositionRef.current = { x: event.clientX, y: event.clientY };
+      }}
+      onPointerMoveCapture={(event) => {
+        pointerPositionRef.current = { x: event.clientX, y: event.clientY };
+      }}
     >
       {embedded ? null : (
         <header className="diff-file-section-head">
@@ -482,7 +615,54 @@ const DiffFileSection = memo(function DiffFileSection({
                 fallback={<RawPatch patch={section.file.diff} />}
                 resetKey={section.file.diff}
               >
-                <PatchDiff patch={section.file.diff} options={options} />
+                <PatchDiff<DiffReviewAnnotation>
+                  patch={section.file.diff}
+                  options={sectionOptions}
+                  lineAnnotations={pierreAnnotations}
+                  selectedLines={
+                    onRequestAnnotation ? selectedLines : undefined
+                  }
+                  renderAnnotation={({ metadata }) => (
+                    <button
+                      type="button"
+                      className={`diff-review-annotation ${metadata.stale ? "is-stale" : ""}`}
+                      style={{
+                        maxWidth: "min(440px, 100%)",
+                        minHeight: 24,
+                        display: "inline-flex",
+                        alignItems: "center",
+                        gap: 6,
+                        overflow: "hidden",
+                        padding: "3px 8px",
+                        border: `1px solid ${metadata.stale ? "var(--warning-text)" : "color-mix(in srgb, var(--accent) 48%, transparent)"}`,
+                        borderRadius: 999,
+                        background: metadata.stale
+                          ? "var(--warning-soft)"
+                          : "var(--accent-soft)",
+                        color: metadata.stale
+                          ? "var(--warning-text)"
+                          : "var(--text-strong)",
+                        font: "11px/1.2 var(--sans-font)",
+                      }}
+                      title="Open review comment"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onEditAnnotation?.(metadata.id);
+                      }}
+                    >
+                      <MessageSquareText size={13} />
+                      <span
+                        style={{
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {metadata.comment || "Review comment"}
+                      </span>
+                    </button>
+                  )}
+                />
               </DiffRenderBoundary>
             </div>
           ) : null}
@@ -512,9 +692,13 @@ function areDiffFileSectionPropsEqual(
     previous.options === next.options &&
     previous.currentSearchMatch === next.currentSearchMatch &&
     previous.embedded === next.embedded &&
+    previous.annotations === next.annotations &&
+    previous.annotationSelectionActive === next.annotationSelectionActive &&
     previous.onToggle === next.onToggle &&
     previous.onSelectFile === next.onSelectFile &&
-    previous.onOpenFile === next.onOpenFile
+    previous.onOpenFile === next.onOpenFile &&
+    previous.onRequestAnnotation === next.onRequestAnnotation &&
+    previous.onEditAnnotation === next.onEditAnnotation
   );
 }
 
@@ -530,8 +714,12 @@ export function DiffContentView({
   mobile = false,
   resourceKey = "default",
   connectionClient,
+  annotations = [],
   onSelectFile,
   onOpenFile,
+  onCreateAnnotation,
+  onReanchorAnnotations,
+  onEditAnnotation,
   embedded = false,
 }: {
   entry: GitDiffEntry | null;
@@ -545,8 +733,16 @@ export function DiffContentView({
   mobile?: boolean;
   resourceKey?: string;
   connectionClient: ConnectionClient;
+  annotations?: readonly ReviewAnnotation[];
   onSelectFile?: (entry: GitDiffEntry) => void;
   onOpenFile?: (entry: GitDiffEntry) => void;
+  onCreateAnnotation?: (annotation: NewReviewAnnotation) => void;
+  onReanchorAnnotations?: (
+    path: string,
+    kind: GitDiffKind,
+    patch: string,
+  ) => void;
+  onEditAnnotation?: (id: string) => void;
   embedded?: boolean;
 }) {
   const sectionRef = useRef<HTMLElement | null>(null);
@@ -559,6 +755,8 @@ export function DiffContentView({
   const [desktopWrap, setDesktopWrap] = useState(() => loadDesktopDiffWrap());
   const [mobileWrap, setMobileWrap] = useState(() => loadMobileDiffWrap());
   const [searchQuery, setSearchQuery] = useState("");
+  const [pendingAnnotation, setPendingAnnotation] =
+    useState<DiffAnnotationRequest | null>(null);
   const deferredSearchQuery = useDeferredValue(searchQuery);
   const [searchIndex, setSearchIndex] = useState(-1);
   const [hunkIndex, setHunkIndex] = useState(-1);
@@ -586,6 +784,17 @@ export function DiffContentView({
     () => diffContentEntries(entries, entry),
     [entries, entry],
   );
+  const annotationsByPath = useMemo(() => {
+    const grouped = new Map<string, DiffReviewAnnotation[]>();
+    for (const annotation of annotations) {
+      if (annotation.source !== "diff") continue;
+      const key = `${annotation.kind}:${annotation.path}`;
+      const pathAnnotations = grouped.get(key);
+      if (pathAnnotations) pathAnnotations.push(annotation);
+      else grouped.set(key, [annotation]);
+    }
+    return grouped;
+  }, [annotations]);
   const changedFileCount = entries.length || visibleEntries.length;
   const renderedSections = useMemo<DiffSection[]>(
     () =>
@@ -664,6 +873,46 @@ export function DiffContentView({
   const handleOpenFile = useCallback((target: GitDiffEntry) => {
     openFileRef.current?.(target);
   }, []);
+  const handleRequestAnnotation = useCallback(
+    (target: DiffAnnotationRequest) => setPendingAnnotation(target),
+    [],
+  );
+  const closeAnnotationComposer = useCallback(
+    () => setPendingAnnotation(null),
+    [],
+  );
+  const saveAnnotation = useCallback(
+    (comment: string) => {
+      if (!pendingAnnotation || !onCreateAnnotation) return;
+      onCreateAnnotation({
+        source: "diff",
+        path: pendingAnnotation.path,
+        kind: pendingAnnotation.kind,
+        side: pendingAnnotation.side,
+        line: pendingAnnotation.line,
+        ...(pendingAnnotation.endSide === undefined
+          ? {}
+          : { endSide: pendingAnnotation.endSide }),
+        ...(pendingAnnotation.endLine === undefined
+          ? {}
+          : { endLine: pendingAnnotation.endLine }),
+        quote: pendingAnnotation.quote,
+        hunk: pendingAnnotation.hunk,
+        comment,
+      });
+      setPendingAnnotation(null);
+    },
+    [onCreateAnnotation, pendingAnnotation],
+  );
+  const annotationComposerDraft: AnnotationComposerDraft | null =
+    pendingAnnotation
+      ? {
+          x: pendingAnnotation.x,
+          y: pendingAnnotation.y,
+          title: `${pendingAnnotation.path} · ${diffReviewLineLabel(pendingAnnotation)}`,
+          quote: pendingAnnotation.quote,
+        }
+      : null;
   const goToHunk = useCallback(
     (delta: -1 | 1) => {
       if (!hunkTargets.length) return;
@@ -758,6 +1007,7 @@ export function DiffContentView({
       tokenizeMaxLineLength: 4_000,
       tokenizeMaxLength: 250_000,
       preferredHighlighter: "shiki-wasm",
+      unsafeCSS: DIFF_SELECTION_CSS,
     }),
     [effectiveViewMode, theme, wrapEnabled],
   );
@@ -766,7 +1016,21 @@ export function DiffContentView({
     hunkIndexRef.current = -1;
     hunkNavigationRevisionRef.current += 1;
     setHunkIndex(-1);
+    setPendingAnnotation(null);
   }, [activeEntryKey, file?.diff]);
+
+  useEffect(() => {
+    if (!onReanchorAnnotations) return;
+    for (const section of renderedSections) {
+      if (section.file?.diff && !section.file.truncated) {
+        onReanchorAnnotations(
+          section.entry.path,
+          section.entry.kind,
+          section.file.diff,
+        );
+      }
+    }
+  }, [onReanchorAnnotations, renderedSections]);
 
   useEffect(() => {
     selectFileRef.current = onSelectFile;
@@ -941,9 +1205,18 @@ export function DiffContentView({
           options={pierreOptions}
           currentSearchMatch={currentSearchEntryKey === section.key}
           embedded={embedded}
+          annotations={annotationsByPath.get(section.key) ?? []}
+          annotationSelectionActive={
+            pendingAnnotation?.path === section.entry.path &&
+            pendingAnnotation.kind === section.entry.kind
+          }
           onToggle={toggleSectionCollapsed}
           onSelectFile={onSelectFile ? handleSelectFile : undefined}
           onOpenFile={onOpenFile ? handleOpenFile : undefined}
+          onRequestAnnotation={
+            onCreateAnnotation ? handleRequestAnnotation : undefined
+          }
+          onEditAnnotation={onEditAnnotation}
         />
       ))}
     </Virtualizer>
@@ -1141,6 +1414,11 @@ export function DiffContentView({
       ) : (
         diffList
       )}
+      <AnnotationComposerPopover
+        draft={annotationComposerDraft}
+        onSave={saveAnnotation}
+        onClose={closeAnnotationComposer}
+      />
     </section>
   );
 }

--- a/web/src/components/DiffContentView.tsx
+++ b/web/src/components/DiffContentView.tsx
@@ -65,6 +65,7 @@ type PierreDiffOptions = NonNullable<
 const DIFF_VIEW_MODE_KEY = "diffViewMode";
 const DESKTOP_DIFF_WRAP_KEY = "desktopDiffWrap";
 const MOBILE_DIFF_WRAP_KEY = "mobileDiffWrap";
+const EMPTY_DIFF_REVIEW_ANNOTATIONS: readonly DiffReviewAnnotation[] = [];
 const DIFF_WORKER_POOL_OPTIONS: WorkerPoolOptions = {
   poolSize: Math.min(
     Math.max(1, (globalThis.navigator?.hardwareConcurrency ?? 2) - 1),
@@ -626,24 +627,6 @@ const DiffFileSection = memo(function DiffFileSection({
                     <button
                       type="button"
                       className={`diff-review-annotation ${metadata.stale ? "is-stale" : ""}`}
-                      style={{
-                        maxWidth: "min(440px, 100%)",
-                        minHeight: 24,
-                        display: "inline-flex",
-                        alignItems: "center",
-                        gap: 6,
-                        overflow: "hidden",
-                        padding: "3px 8px",
-                        border: `1px solid ${metadata.stale ? "var(--warning-text)" : "color-mix(in srgb, var(--accent) 48%, transparent)"}`,
-                        borderRadius: 999,
-                        background: metadata.stale
-                          ? "var(--warning-soft)"
-                          : "var(--accent-soft)",
-                        color: metadata.stale
-                          ? "var(--warning-text)"
-                          : "var(--text-strong)",
-                        font: "11px/1.2 var(--sans-font)",
-                      }}
                       title="Open review comment"
                       onClick={(event) => {
                         event.stopPropagation();
@@ -651,15 +634,7 @@ const DiffFileSection = memo(function DiffFileSection({
                       }}
                     >
                       <MessageSquareText size={13} />
-                      <span
-                        style={{
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        {metadata.comment || "Review comment"}
-                      </span>
+                      <span>{metadata.comment || "Review comment"}</span>
                     </button>
                   )}
                 />
@@ -1205,7 +1180,9 @@ export function DiffContentView({
           options={pierreOptions}
           currentSearchMatch={currentSearchEntryKey === section.key}
           embedded={embedded}
-          annotations={annotationsByPath.get(section.key) ?? []}
+          annotations={
+            annotationsByPath.get(section.key) ?? EMPTY_DIFF_REVIEW_ANNOTATIONS
+          }
           annotationSelectionActive={
             pendingAnnotation?.path === section.entry.path &&
             pendingAnnotation.kind === section.entry.kind

--- a/web/src/components/FilePreviewContent.tsx
+++ b/web/src/components/FilePreviewContent.tsx
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -6,14 +7,24 @@ import {
   type MutableRefObject,
   type ReactNode,
 } from "react";
+import { createPortal } from "react-dom";
 import type { EditorView as CodeMirrorEditorView } from "@codemirror/view";
+import type {
+  FileLineReviewAnnotation,
+  NewReviewAnnotation,
+  ReviewAnnotation,
+} from "../annotations";
 import type { FileExplorerEntry, FilePreview } from "../types";
 import { useConnectionClient } from "../useConnectionClient";
 import {
   resolveWorkspaceMarkdownImageUrl,
   workspaceFileUrl,
 } from "../workspaceFileUrl";
-import { MarkdownPreview } from "./markdown";
+import { MarkdownPreview, type MarkdownSelectionTarget } from "./markdown";
+import {
+  AnnotationComposerPopover,
+  type AnnotationComposerDraft,
+} from "./AnnotationComposerPopover";
 import { MermaidDiagram } from "./MermaidDiagram";
 import {
   handlePreviewEditorCopy,
@@ -40,6 +51,24 @@ type AppTheme = "dark" | "light";
 
 const PDF_INLINE_PREVIEW_MAX_BYTES = 25 * 1024 * 1024;
 
+type PendingFileAnnotation =
+  | {
+      kind: "line";
+      x: number;
+      y: number;
+      path: string;
+      line: number;
+      quote: string;
+    }
+  | {
+      kind: "quote";
+      x: number;
+      y: number;
+      path: string;
+      quote: string;
+      section: string[];
+    };
+
 type CodeMirrorPreviewDeps = Awaited<
   ReturnType<typeof importCodeMirrorPreviewDeps>
 >;
@@ -58,6 +87,9 @@ async function importCodeMirrorPreviewDeps() {
     basicSetup: codemirror.basicSetup,
     Compartment: state.Compartment,
     Decoration: view.Decoration,
+    RangeSet: state.RangeSet,
+    GutterMarker: view.GutterMarker,
+    gutter: view.gutter,
     EditorState: state.EditorState,
     EditorView: view.EditorView,
     keymap: view.keymap,
@@ -124,7 +156,10 @@ export function FilePreviewContent({
   error,
   changesContent,
   changesKey,
+  annotations = [],
   onOpenChanges,
+  onCreateAnnotation,
+  onReanchorAnnotations,
 }: {
   entry: FileExplorerEntry | null;
   preview: FilePreview | null;
@@ -132,7 +167,10 @@ export function FilePreviewContent({
   error: string | null;
   changesContent?: ReactNode;
   changesKey?: string;
+  annotations?: readonly ReviewAnnotation[];
   onOpenChanges?: () => void;
+  onCreateAnnotation?: (annotation: NewReviewAnnotation) => void;
+  onReanchorAnnotations?: (path: string, text: string) => void;
 }) {
   const connectionClient = useConnectionClient();
   const previewSectionRef = useRef<HTMLElement | null>(null);
@@ -144,6 +182,10 @@ export function FilePreviewContent({
     "rendered",
   );
   const [detailTab, setDetailTab] = useState<"file" | "changes">("file");
+  const [pendingAnnotation, setPendingAnnotation] =
+    useState<PendingFileAnnotation | null>(null);
+  const [markdownSelection, setMarkdownSelection] =
+    useState<MarkdownSelectionTarget | null>(null);
   const theme = useDocumentTheme();
   const previewText = preview?.text ?? null;
   const previewPath = preview?.path ?? "";
@@ -188,10 +230,46 @@ export function FilePreviewContent({
   const changesAvailable =
     changesContent !== undefined && !!changesKey && !!onOpenChanges;
   const showingChanges = detailTab === "changes" && changesAvailable;
+  const lineAnnotations = useMemo(
+    () =>
+      annotations.filter(
+        (annotation): annotation is FileLineReviewAnnotation =>
+          annotation.source === "file" &&
+          annotation.anchor === "line" &&
+          annotation.path === previewPath,
+      ),
+    [annotations, previewPath],
+  );
+  const annotationComposerDraft: AnnotationComposerDraft | null =
+    pendingAnnotation
+      ? {
+          x: pendingAnnotation.x,
+          y: pendingAnnotation.y,
+          title:
+            pendingAnnotation.kind === "line"
+              ? `${pendingAnnotation.path} · line ${pendingAnnotation.line}`
+              : pendingAnnotation.section.length
+                ? `${pendingAnnotation.path} · ${pendingAnnotation.section.join(" › ")}`
+                : `${pendingAnnotation.path} · selected passage`,
+          quote: pendingAnnotation.quote,
+        }
+      : null;
 
   useEffect(() => {
     setPreviewMode("rendered");
+    setPendingAnnotation(null);
+    setMarkdownSelection(null);
   }, [previewPath]);
+
+  useEffect(() => {
+    if (previewText === null || !previewPath || preview?.truncated) return;
+    onReanchorAnnotations?.(previewPath, previewText);
+  }, [onReanchorAnnotations, preview?.truncated, previewPath, previewText]);
+
+  useEffect(() => {
+    if (hasMarkdownPreview && renderRichPreview && !showingChanges) return;
+    setMarkdownSelection(null);
+  }, [hasMarkdownPreview, renderRichPreview, showingChanges]);
 
   useEffect(() => {
     if (detailTab === "changes" && changesAvailable) {
@@ -238,6 +316,40 @@ export function FilePreviewContent({
     section.addEventListener("copy", onCopy);
     return () => section.removeEventListener("copy", onCopy);
   }, []);
+
+  const closeAnnotationComposer = useCallback(() => {
+    setPendingAnnotation(null);
+  }, []);
+
+  const saveAnnotation = useCallback(
+    (comment: string) => {
+      const pending = pendingAnnotation;
+      if (!pending || !onCreateAnnotation) return;
+      if (pending.kind === "line") {
+        onCreateAnnotation({
+          source: "file",
+          anchor: "line",
+          path: pending.path,
+          line: pending.line,
+          quote: pending.quote,
+          comment,
+        });
+      } else {
+        onCreateAnnotation({
+          source: "file",
+          anchor: "quote",
+          path: pending.path,
+          quote: pending.quote,
+          section: pending.section,
+          comment,
+        });
+      }
+      setPendingAnnotation(null);
+      setMarkdownSelection(null);
+      window.getSelection()?.removeAllRanges();
+    },
+    [onCreateAnnotation, pendingAnnotation],
+  );
 
   const copyPreviewText = async () => {
     if (previewText === null) return;
@@ -392,6 +504,9 @@ export function FilePreviewContent({
             <MarkdownPreview
               text={previewText}
               imageUrlResolver={markdownImageUrlResolver}
+              onSelectionChange={
+                onCreateAnnotation ? setMarkdownSelection : undefined
+              }
             />
           ) : null}
           {!loading && !error && hasMermaidPreview && renderRichPreview ? (
@@ -409,27 +524,203 @@ export function FilePreviewContent({
               text={previewText}
               path={previewPath}
               theme={theme}
+              annotations={lineAnnotations}
               editorViewRef={editorViewRef}
+              onRequestAnnotation={
+                onCreateAnnotation
+                  ? ({ line, quote, x, y }) =>
+                      setPendingAnnotation({
+                        kind: "line",
+                        path: previewPath,
+                        line,
+                        quote,
+                        x,
+                        y,
+                      })
+                  : undefined
+              }
             />
           ) : null}
         </div>
       )}
+      {markdownSelection &&
+      onCreateAnnotation &&
+      hasMarkdownPreview &&
+      renderRichPreview &&
+      !showingChanges
+        ? createPortal(
+            <button
+              type="button"
+              className="markdown-annotate-button"
+              style={{
+                left: Math.min(
+                  Math.max(8, markdownSelection.x),
+                  Math.max(8, window.innerWidth - 154),
+                ),
+                top: Math.min(
+                  Math.max(8, markdownSelection.y),
+                  Math.max(8, window.innerHeight - 42),
+                ),
+              }}
+              onPointerDown={(event) => event.preventDefault()}
+              onClick={() => {
+                setPendingAnnotation({
+                  kind: "quote",
+                  path: previewPath,
+                  quote: markdownSelection.quote,
+                  section: markdownSelection.section,
+                  x: markdownSelection.x,
+                  y: markdownSelection.y,
+                });
+                setMarkdownSelection(null);
+              }}
+            >
+              Annotate selection
+            </button>,
+            document.body,
+          )
+        : null}
+      <AnnotationComposerPopover
+        draft={annotationComposerDraft}
+        onSave={saveAnnotation}
+        onClose={closeAnnotationComposer}
+      />
     </section>
   );
+}
+
+type CodeMirrorAnnotationRequest = {
+  line: number;
+  quote: string;
+  x: number;
+  y: number;
+};
+
+type CodeMirrorAnnotationRuntime = {
+  deps: CodeMirrorPreviewDeps;
+  compartment: InstanceType<CodeMirrorPreviewDeps["Compartment"]>;
+  view: CodeMirrorEditorView;
+};
+
+function codeMirrorAnnotationExtensions(
+  deps: CodeMirrorPreviewDeps,
+  text: string,
+  annotations: readonly FileLineReviewAnnotation[],
+  onRequestAnnotation?: (request: CodeMirrorAnnotationRequest) => void,
+) {
+  if (!onRequestAnnotation && annotations.length === 0) return [];
+  const annotationsByLine = new Map<number, FileLineReviewAnnotation[]>();
+  for (const annotation of annotations) {
+    const current = annotationsByLine.get(annotation.line);
+    if (current) current.push(annotation);
+    else annotationsByLine.set(annotation.line, [annotation]);
+  }
+
+  const normalizedText = text.replace(/\r\n?/g, "\n");
+  const lineStarts = [0];
+  for (let index = 0; index < normalizedText.length; index += 1) {
+    if (normalizedText[index] === "\n") lineStarts.push(index + 1);
+  }
+
+  class ReviewGutterMarker extends deps.GutterMarker {
+    constructor(
+      private count: number,
+      private stale: boolean,
+    ) {
+      super();
+    }
+
+    toDOM() {
+      const marker = document.createElement("span");
+      marker.className = `cm-review-annotation-marker ${
+        this.stale ? "is-stale" : ""
+      }`;
+      marker.textContent = String(this.count);
+      marker.title = `${this.count} review comment${this.count === 1 ? "" : "s"}`;
+      return marker;
+    }
+  }
+
+  return [
+    deps.gutter({
+      class: "cm-review-annotation-gutter",
+      markers: (view) =>
+        deps.RangeSet.of(
+          Array.from(annotationsByLine.entries())
+            .sort(([left], [right]) => left - right)
+            .flatMap(([lineNumber, matches]) => {
+              if (lineNumber > view.state.doc.lines) return [];
+              const line = view.state.doc.line(lineNumber);
+              return [
+                new ReviewGutterMarker(
+                  matches.length,
+                  matches.every((annotation) => annotation.stale),
+                ).range(line.from),
+              ];
+            }),
+          true,
+        ),
+      domEventHandlers: {
+        mousedown: (view, line, event) => {
+          if (
+            !(event instanceof MouseEvent) ||
+            event.button !== 0 ||
+            !onRequestAnnotation
+          ) {
+            return false;
+          }
+          event.preventDefault();
+          const documentLine = view.state.doc.lineAt(line.from);
+          onRequestAnnotation({
+            line: documentLine.number,
+            quote: documentLine.text,
+            x: event.clientX + 6,
+            y: event.clientY + 8,
+          });
+          return true;
+        },
+      },
+    }),
+    deps.EditorView.decorations.of(
+      deps.Decoration.set(
+        Array.from(annotationsByLine.keys())
+          .sort((left, right) => left - right)
+          .flatMap((lineNumber) => {
+            const from = lineStarts[lineNumber - 1];
+            return from === undefined
+              ? []
+              : [
+                  deps.Decoration.line({
+                    attributes: { "data-review-annotated": "true" },
+                  }).range(from),
+                ];
+          }),
+      ),
+    ),
+  ];
 }
 
 function CodeMirrorPreview({
   text,
   path,
   theme,
+  annotations,
   editorViewRef,
+  onRequestAnnotation,
 }: {
   text: string;
   path: string;
   theme: AppTheme;
+  annotations: readonly FileLineReviewAnnotation[];
   editorViewRef: MutableRefObject<CodeMirrorEditorView | null>;
+  onRequestAnnotation?: (request: CodeMirrorAnnotationRequest) => void;
 }) {
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const annotationRuntimeRef = useRef<CodeMirrorAnnotationRuntime | null>(null);
+  const annotationsRef = useRef(annotations);
+  const requestAnnotationRef = useRef(onRequestAnnotation);
+  annotationsRef.current = annotations;
+  requestAnnotationRef.current = onRequestAnnotation;
 
   useEffect(() => {
     const parent = containerRef.current;
@@ -442,6 +733,7 @@ function CodeMirrorPreview({
       if (cancelled || !containerRef.current) return;
       parent.textContent = "";
       const syntaxCompartment = new deps.Compartment();
+      const annotationCompartment = new deps.Compartment();
       view = new deps.EditorView({
         parent,
         state: deps.EditorState.create({
@@ -454,6 +746,14 @@ function CodeMirrorPreview({
             deps.EditorView.editable.of(false),
             deps.EditorView.contentAttributes.of({ tabindex: "0" }),
             syntaxCompartment.of([]),
+            annotationCompartment.of(
+              codeMirrorAnnotationExtensions(
+                deps,
+                text,
+                annotationsRef.current,
+                (request) => requestAnnotationRef.current?.(request),
+              ),
+            ),
             deps.EditorView.theme(
               {
                 "&": {
@@ -602,6 +902,11 @@ function CodeMirrorPreview({
         }),
       });
       editorViewRef.current = view;
+      annotationRuntimeRef.current = {
+        deps,
+        compartment: annotationCompartment,
+        view,
+      };
       const activeView = view;
 
       void highlightCodeTokens(text, path)
@@ -627,9 +932,27 @@ function CodeMirrorPreview({
     return () => {
       cancelled = true;
       if (editorViewRef.current === view) editorViewRef.current = null;
+      if (annotationRuntimeRef.current?.view === view) {
+        annotationRuntimeRef.current = null;
+      }
       view?.destroy();
     };
   }, [editorViewRef, path, text, theme]);
+
+  useEffect(() => {
+    const runtime = annotationRuntimeRef.current;
+    if (!runtime) return;
+    runtime.view.dispatch({
+      effects: runtime.compartment.reconfigure(
+        codeMirrorAnnotationExtensions(
+          runtime.deps,
+          text,
+          annotations,
+          (request) => requestAnnotationRef.current?.(request),
+        ),
+      ),
+    });
+  }, [annotations, text]);
 
   return (
     <div ref={containerRef} className="file-preview-code syntax-highlighted" />

--- a/web/src/components/WorkspaceInspectorHost.tsx
+++ b/web/src/components/WorkspaceInspectorHost.tsx
@@ -5,6 +5,7 @@ import {
   GitFork,
   History,
   Maximize2,
+  MessageSquareText,
   Minimize2,
   PanelBottom,
   PanelRight,
@@ -17,6 +18,7 @@ import {
   useEffect,
   useId,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   type CSSProperties,
@@ -24,6 +26,22 @@ import {
   type PointerEvent as ReactPointerEvent,
 } from "react";
 import type { ConnectionClient } from "../api";
+import {
+  annotationDraftStorageKey,
+  compileReviewFeedback,
+  createReviewAnnotation,
+  moveReviewAnnotation,
+  readReviewAnnotations,
+  reanchorDiffReviewAnnotations,
+  reanchorFileReviewAnnotations,
+  reviewAgentPanes,
+  writeReviewAnnotations,
+  type NewReviewAnnotation,
+  type ReviewAnnotation,
+} from "../annotations";
+import { store, useStoreSelector } from "../store";
+import { copyTextFromUserGesture } from "../terminalClipboard";
+import { terminalPasteRequest } from "../terminalPaste";
 import type { GitDiffEntry, Pane, Workspace } from "../types";
 import {
   DEFAULT_INSPECTOR_NAVIGATION_RATIO,
@@ -38,6 +56,7 @@ import {
   type WorkspaceInspectorState,
 } from "../workspaceResource";
 import { AgentHistoryDrawer } from "./AgentHistoryDrawer";
+import { AnnotationPanel } from "./AnnotationPanel";
 import { paneHasAgentHistory } from "./agentSession";
 import {
   type ActiveDiffSelection,
@@ -220,7 +239,18 @@ export function WorkspaceInspectorHost({
   const changesTabRef = useRef<HTMLButtonElement | null>(null);
   const historyTabRef = useRef<HTMLButtonElement | null>(null);
   const diffViewerRef = useRef<DiffViewerPanelHandle | null>(null);
+  const annotationStorageFailureRef = useRef(false);
   const splitId = useId();
+  const allPanes = useStoreSelector((snapshot) => snapshot.panes);
+  const annotationStorageKey = annotationDraftStorageKey(state.scope);
+  const [annotations, setAnnotations] = useState<ReviewAnnotation[]>(() =>
+    readReviewAnnotations(localStorage, annotationStorageKey),
+  );
+  const [annotationsOpen, setAnnotationsOpen] = useState(false);
+  const [focusedAnnotationId, setFocusedAnnotationId] = useState<string | null>(
+    null,
+  );
+  const [annotationDeliveryBusy, setAnnotationDeliveryBusy] = useState(false);
   const [hostWidth, setHostWidth] = useState(0);
   const [fileDiffState, setFileDiffState] = useState<{
     resourceKey: string;
@@ -235,6 +265,156 @@ export function WorkspaceInspectorHost({
   }));
   const resourceKey = resourceOwnerKey(state.scope);
   const contentResourceKey = resourceStateKey(state.scope);
+  const agentPanes = useMemo(
+    () =>
+      reviewAgentPanes(
+        allPanes,
+        workspace?.workspace_id ?? "",
+        state.originPaneId,
+      ),
+    [allPanes, state.originPaneId, workspace?.workspace_id],
+  );
+  const commitAnnotations = useCallback(
+    (
+      update:
+        | ReviewAnnotation[]
+        | ((current: ReviewAnnotation[]) => ReviewAnnotation[]),
+    ) => {
+      setAnnotations((current) => {
+        const next = typeof update === "function" ? update(current) : update;
+        if (
+          next.length === current.length &&
+          next.every((annotation, index) => annotation === current[index])
+        ) {
+          return current;
+        }
+        const persisted = writeReviewAnnotations(
+          localStorage,
+          annotationStorageKey,
+          next,
+        );
+        if (!persisted && !annotationStorageFailureRef.current) {
+          annotationStorageFailureRef.current = true;
+          queueMicrotask(() =>
+            store.notify({
+              kind: "error",
+              message: "Review draft could not be saved",
+              detail:
+                "Browser storage is unavailable. Keep this page open or copy the feedback now.",
+            }),
+          );
+        } else if (persisted) {
+          annotationStorageFailureRef.current = false;
+        }
+        return next;
+      });
+    },
+    [annotationStorageKey],
+  );
+  const addAnnotation = useCallback(
+    (input: NewReviewAnnotation) => {
+      const annotation = createReviewAnnotation(input);
+      commitAnnotations((current) => [...current, annotation]);
+      setFocusedAnnotationId(annotation.id);
+      setAnnotationsOpen(true);
+    },
+    [commitAnnotations],
+  );
+  const reanchorFileAnnotations = useCallback(
+    (path: string, text: string) => {
+      commitAnnotations((current) =>
+        reanchorFileReviewAnnotations(current, path, text),
+      );
+    },
+    [commitAnnotations],
+  );
+  const reanchorDiffAnnotations = useCallback(
+    (path: string, kind: GitDiffEntry["kind"], patch: string) => {
+      commitAnnotations((current) =>
+        reanchorDiffReviewAnnotations(current, path, kind, patch),
+      );
+    },
+    [commitAnnotations],
+  );
+  const clearAnnotations = useCallback(() => {
+    commitAnnotations([]);
+    setFocusedAnnotationId(null);
+    setAnnotationsOpen(false);
+  }, [commitAnnotations]);
+  const copyFeedback = useCallback(
+    async (fallback = false) => {
+      const message = compileReviewFeedback(annotations);
+      if (!message) {
+        store.notify({
+          kind: "error",
+          message: "Add text to a review comment before delivery",
+        });
+        return;
+      }
+      setAnnotationDeliveryBusy(true);
+      try {
+        await copyTextFromUserGesture(message);
+        clearAnnotations();
+        store.notify({
+          kind: "success",
+          message: fallback
+            ? "No agent pane found; feedback copied"
+            : "Review feedback copied",
+          detail: `${annotations.length} comment${annotations.length === 1 ? "" : "s"}`,
+          autoDismissMs: 5000,
+        });
+      } catch (error) {
+        store.notify({
+          kind: "error",
+          message: "Failed to copy review feedback",
+          detail: error instanceof Error ? error.message : String(error),
+        });
+      } finally {
+        setAnnotationDeliveryBusy(false);
+      }
+    },
+    [annotations, clearAnnotations],
+  );
+  const sendFeedback = useCallback(
+    async (paneId: string | null) => {
+      const target = agentPanes.find((pane) => pane.pane_id === paneId);
+      if (!target) {
+        await copyFeedback(true);
+        return;
+      }
+      const message = compileReviewFeedback(annotations);
+      if (!message) {
+        store.notify({
+          kind: "error",
+          message: "Add text to a review comment before delivery",
+        });
+        return;
+      }
+      setAnnotationDeliveryBusy(true);
+      try {
+        const request = terminalPasteRequest(target.pane_id, message);
+        await connectionClient.call(request.method, request.params);
+        if (!connectionClient.isCurrent()) return;
+        clearAnnotations();
+        store.notify({
+          kind: "success",
+          message: "Feedback pre-filled in the agent pane",
+          detail: "Review the message there, then press Enter to submit it.",
+          autoDismissMs: 6000,
+        });
+      } catch (error) {
+        if (!connectionClient.isCurrent()) return;
+        store.notify({
+          kind: "error",
+          message: "Failed to pre-fill review feedback",
+          detail: error instanceof Error ? error.message : String(error),
+        });
+      } finally {
+        setAnnotationDeliveryBusy(false);
+      }
+    },
+    [agentPanes, annotations, clearAnnotations, connectionClient, copyFeedback],
+  );
   const fileDiffEntries =
     fileDiffState.resourceKey === contentResourceKey
       ? fileDiffState.entries
@@ -298,6 +478,12 @@ export function WorkspaceInspectorHost({
   const fileChangesKey = fileChangesEntries
     .map((entry) => `${entry.kind}:${entry.status}:${entry.path}`)
     .join("|");
+
+  useEffect(() => {
+    setAnnotations(readReviewAnnotations(localStorage, annotationStorageKey));
+    setAnnotationsOpen(false);
+    setFocusedAnnotationId(null);
+  }, [annotationStorageKey]);
 
   useEffect(() => {
     if (state.view !== "files" || !fileSelection.entry) return;
@@ -442,6 +628,21 @@ export function WorkspaceInspectorHost({
         <div className="workspace-inspector-actions">
           <button
             type="button"
+            className={`workspace-inspector-annotation-action ${annotationsOpen ? "is-active" : ""}`}
+            title="Review feedback"
+            aria-label={`Review feedback, ${annotations.length} comment${annotations.length === 1 ? "" : "s"}`}
+            aria-pressed={annotationsOpen}
+            onClick={() => setAnnotationsOpen((open) => !open)}
+          >
+            <MessageSquareText size={15} />
+            {annotations.length ? (
+              <span className="workspace-inspector-annotation-count">
+                {annotations.length}
+              </span>
+            ) : null}
+          </button>
+          <button
+            type="button"
             className="workspace-inspector-dock-action"
             title={state.dock === "right" ? "Dock at bottom" : "Dock at right"}
             aria-label={
@@ -555,6 +756,9 @@ export function WorkspaceInspectorHost({
                 preview={fileSelection.preview}
                 loading={fileSelection.loading}
                 error={fileSelection.error}
+                annotations={annotations}
+                onCreateAnnotation={addAnnotation}
+                onReanchorAnnotations={reanchorFileAnnotations}
                 onOpenChanges={
                   primaryFileChangesEntry
                     ? () =>
@@ -601,6 +805,13 @@ export function WorkspaceInspectorHost({
                         }
                         resourceKey={`${contentResourceKey}:file:${fileChangesKey}`}
                         connectionClient={connectionClient}
+                        annotations={annotations}
+                        onCreateAnnotation={addAnnotation}
+                        onReanchorAnnotations={reanchorDiffAnnotations}
+                        onEditAnnotation={(id) => {
+                          setFocusedAnnotationId(id);
+                          setAnnotationsOpen(true);
+                        }}
                         onSelectFile={(entry) =>
                           diffViewerRef.current?.selectWorkingEntry(entry)
                         }
@@ -672,6 +883,13 @@ export function WorkspaceInspectorHost({
                     mobile={compact}
                     resourceKey={contentResourceKey}
                     connectionClient={connectionClient}
+                    annotations={annotations}
+                    onCreateAnnotation={addAnnotation}
+                    onReanchorAnnotations={reanchorDiffAnnotations}
+                    onEditAnnotation={(id) => {
+                      setFocusedAnnotationId(id);
+                      setAnnotationsOpen(true);
+                    }}
                     onSelectFile={(target) =>
                       diffViewerRef.current?.selectEntry(target)
                     }
@@ -702,6 +920,38 @@ export function WorkspaceInspectorHost({
               </div>
             )}
           </div>
+          <AnnotationPanel
+            open={annotationsOpen}
+            annotations={annotations}
+            agentPanes={agentPanes}
+            preferredPaneId={state.originPaneId}
+            busy={annotationDeliveryBusy}
+            focusedAnnotationId={focusedAnnotationId}
+            onClose={() => setAnnotationsOpen(false)}
+            onUpdateComment={(id, comment) =>
+              commitAnnotations((current) =>
+                current.map((annotation) =>
+                  annotation.id === id
+                    ? { ...annotation, comment }
+                    : annotation,
+                ),
+              )
+            }
+            onDelete={(id) => {
+              commitAnnotations((current) =>
+                current.filter((annotation) => annotation.id !== id),
+              );
+              if (focusedAnnotationId === id) setFocusedAnnotationId(null);
+            }}
+            onMove={(id, delta) =>
+              commitAnnotations((current) =>
+                moveReviewAnnotation(current, id, delta),
+              )
+            }
+            onClear={clearAnnotations}
+            onCopy={() => void copyFeedback()}
+            onSend={(paneId) => void sendFeedback(paneId)}
+          />
         </div>
       )}
     </aside>

--- a/web/src/components/markdown.tsx
+++ b/web/src/components/markdown.tsx
@@ -63,6 +63,70 @@ type MarkdownRenderOptions = {
   imageUrlResolver?: (source: string) => string | null;
 };
 
+export type MarkdownSelectionTarget = {
+  quote: string;
+  section: string[];
+  x: number;
+  y: number;
+};
+
+function selectionElement(node: Node): Element | null {
+  return node instanceof Element ? node : node.parentElement;
+}
+
+export function markdownHeadingPath(root: Element, node: Node): string[] {
+  const target = selectionElement(node);
+  if (!target || !root.contains(target)) return [];
+  const path: string[] = [];
+  for (const heading of root.querySelectorAll<HTMLElement>(
+    "h1, h2, h3, h4, h5, h6",
+  )) {
+    const beforeTarget =
+      heading === target ||
+      heading.contains(target) ||
+      Boolean(
+        heading.compareDocumentPosition(target) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      );
+    if (!beforeTarget) break;
+    const level = Number(heading.tagName.slice(1));
+    path.length = Math.min(path.length, level - 1);
+    path[level - 1] = heading.textContent?.trim() ?? "";
+  }
+  return path.filter(Boolean);
+}
+
+export function markdownSelectionTarget(
+  root: HTMLElement,
+  selection: Selection | null = window.getSelection(),
+): MarkdownSelectionTarget | null {
+  if (!selection || selection.rangeCount !== 1 || selection.isCollapsed) {
+    return null;
+  }
+  const range = selection.getRangeAt(0);
+  const start = selectionElement(range.startContainer);
+  const end = selectionElement(range.endContainer);
+  if (!start || !end || !root.contains(start) || !root.contains(end)) {
+    return null;
+  }
+  if (start.closest(".mermaid-diagram") || end.closest(".mermaid-diagram")) {
+    return null;
+  }
+  const quote = selection
+    .toString()
+    .replace(/[ \t]+\n/g, "\n")
+    .trim();
+  if (!quote || quote.length > 20_000) return null;
+  const rect = range.getBoundingClientRect();
+  if (!rect.width && !rect.height) return null;
+  return {
+    quote,
+    section: markdownHeadingPath(root, range.startContainer),
+    x: rect.left,
+    y: rect.bottom + 6,
+  };
+}
+
 export function sanitizeMarkdownHtml(
   html: string,
   options: Pick<MarkdownRenderOptions, "imageUrlResolver"> = {},
@@ -156,11 +220,13 @@ export function MarkdownPreview({
   className = "",
   breaks = false,
   imageUrlResolver,
+  onSelectionChange,
 }: {
   text: string;
   className?: string;
   breaks?: boolean;
   imageUrlResolver?: (source: string) => string | null;
+  onSelectionChange?: (target: MarkdownSelectionTarget | null) => void;
 }) {
   const html = useMemo(
     () => renderMarkdown(text, { breaks, imageUrlResolver }),
@@ -212,10 +278,38 @@ export function MarkdownPreview({
     };
   }, [html]);
 
+  useEffect(() => {
+    if (!onSelectionChange) return;
+    let frame = 0;
+    const updateSelection = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        const root = articleRef.current;
+        onSelectionChange(root ? markdownSelectionTarget(root) : null);
+      });
+    };
+    document.addEventListener("selectionchange", updateSelection);
+    return () => {
+      cancelAnimationFrame(frame);
+      document.removeEventListener("selectionchange", updateSelection);
+    };
+  }, [onSelectionChange]);
+
   return (
     <article
       ref={articleRef}
       className={`file-preview-markdown ${className}`.trim()}
+      onPointerDown={() => onSelectionChange?.(null)}
+      onPointerUp={() => {
+        requestAnimationFrame(() => {
+          const root = articleRef.current;
+          onSelectionChange?.(root ? markdownSelectionTarget(root) : null);
+        });
+      }}
+      onKeyUp={() => {
+        const root = articleRef.current;
+        onSelectionChange?.(root ? markdownSelectionTarget(root) : null);
+      }}
       dangerouslySetInnerHTML={{ __html: html }}
     />
   );

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1901,6 +1901,314 @@ textarea:focus {
 .workspace-inspector-unavailable strong {
   color: var(--text-strong);
 }
+.workspace-inspector-annotation-action {
+  position: relative;
+}
+.workspace-inspector-actions
+  button.workspace-inspector-annotation-action.is-active {
+  background: var(--accent-soft);
+  color: var(--text-strong);
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+.workspace-inspector-annotation-count {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 15px;
+  height: 15px;
+  display: grid;
+  place-items: center;
+  padding: 0 3px;
+  border: 1px solid var(--viewer-header-bg);
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--accent-contrast, #fff);
+  font-size: 8px;
+  font-weight: 800;
+  line-height: 1;
+}
+.annotation-panel {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  bottom: 8px;
+  z-index: 20;
+  width: min(380px, calc(100% - 16px));
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--viewer-border);
+  border-radius: 10px;
+  background: var(--viewer-panel-bg);
+  box-shadow: var(--shadow-lg);
+}
+.annotation-panel-head {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 48px;
+  padding: 8px 10px 8px 12px;
+  border-bottom: 1px solid var(--viewer-border);
+  background: var(--viewer-header-bg);
+}
+.annotation-panel-head > div {
+  min-width: 0;
+  display: grid;
+  gap: 1px;
+}
+.annotation-panel-head strong {
+  color: var(--text-strong);
+  font-size: 13px;
+}
+.annotation-panel-head span {
+  color: var(--muted);
+  font-size: 10px;
+}
+.annotation-icon-button {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border-color: transparent;
+  background: transparent;
+  color: var(--muted);
+}
+.annotation-icon-button:hover:not(:disabled) {
+  background: var(--accent-soft);
+  color: var(--text-strong);
+}
+.annotation-icon-button.is-danger:hover:not(:disabled) {
+  background: var(--danger-soft);
+  color: var(--danger-text);
+}
+.annotation-icon-button:disabled {
+  cursor: default;
+  opacity: 0.32;
+}
+.annotation-panel-list {
+  min-height: 0;
+  flex: 1 1 auto;
+  display: grid;
+  align-content: start;
+  gap: 8px;
+  overflow: auto;
+  padding: 10px;
+}
+.annotation-panel-empty {
+  min-height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 7px;
+  padding: 20px;
+  color: var(--muted);
+  text-align: center;
+}
+.annotation-panel-empty strong {
+  color: var(--text-strong);
+  font-size: 13px;
+}
+.annotation-panel-empty span {
+  max-width: 280px;
+  font-size: 11px;
+  line-height: 1.45;
+}
+.annotation-card {
+  display: grid;
+  gap: 7px;
+  padding: 9px;
+  border: 1px solid var(--viewer-border);
+  border-radius: 8px;
+  background: var(--viewer-content-bg);
+}
+.annotation-card.is-focused {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+.annotation-card-head {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.annotation-card-head strong {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-strong);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.annotation-card-head span {
+  flex: 0 0 auto;
+  padding: 2px 5px;
+  border-radius: 999px;
+  background: var(--warning-soft);
+  color: var(--warning-text);
+  font-size: 8px;
+  font-weight: 800;
+}
+.annotation-card blockquote,
+.annotation-composer-popover blockquote {
+  max-height: 82px;
+  margin: 0;
+  overflow: auto;
+  padding: 6px 8px;
+  border-left: 2px solid var(--accent);
+  background: var(--viewer-code-bg);
+  color: var(--text-code);
+  font: 10px / 1.45 var(--mono-font);
+  white-space: pre-wrap;
+}
+.annotation-card textarea,
+.annotation-composer-popover textarea {
+  width: 100%;
+  min-height: 64px;
+  resize: vertical;
+  padding: 7px 8px;
+  border: 1px solid var(--viewer-border);
+  border-radius: 7px;
+  outline: none;
+  background: var(--input-bg);
+  color: var(--text);
+  font: inherit;
+  font-size: 12px;
+}
+.annotation-card textarea:focus,
+.annotation-composer-popover textarea:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+.annotation-card-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 2px;
+}
+.annotation-panel-footer {
+  flex: 0 0 auto;
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border-top: 1px solid var(--viewer-border);
+  background: var(--viewer-header-bg);
+}
+.annotation-target-picker {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 10px;
+}
+.annotation-target-picker select {
+  min-width: 0;
+  height: 30px;
+  padding: 0 7px;
+  border: 1px solid var(--viewer-border);
+  border-radius: 7px;
+  background: var(--input-bg);
+  color: var(--text);
+  font-size: 11px;
+}
+.annotation-target-summary {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.annotation-delivery-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr);
+  gap: 7px;
+}
+.annotation-delivery-actions button {
+  min-width: 0;
+  min-height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  font-size: 11px;
+}
+.annotation-clear-button {
+  justify-self: center;
+  padding: 2px 6px;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  font-size: 10px;
+}
+.annotation-clear-button:hover:not(:disabled) {
+  color: var(--danger-text);
+}
+.annotation-composer-popover {
+  position: fixed;
+  z-index: 1200;
+  width: min(340px, calc(100vw - 16px));
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid var(--viewer-border);
+  border-radius: 9px;
+  background: var(--viewer-panel-bg);
+  color: var(--text);
+  box-shadow: var(--shadow-lg);
+}
+.annotation-composer-popover > strong {
+  overflow: hidden;
+  color: var(--text-strong);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.annotation-composer-popover small {
+  color: var(--muted);
+  font-size: 9px;
+  text-align: right;
+}
+.annotation-composer-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+.annotation-composer-actions button {
+  min-height: 30px;
+  padding: 0 9px;
+  font-size: 11px;
+}
+.markdown-annotate-button {
+  position: fixed;
+  z-index: 1190;
+  min-height: 34px;
+  padding: 0 10px;
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--accent-contrast, #fff);
+  font-size: 11px;
+  font-weight: 700;
+  box-shadow: var(--shadow-md);
+}
+.workspace-inspector.is-compact .annotation-panel {
+  inset: 0;
+  width: 100%;
+  border: 0;
+  border-radius: 0;
+}
+.workspace-inspector.is-compact .annotation-icon-button {
+  width: 36px;
+  height: 36px;
+}
+.workspace-inspector.is-compact .annotation-delivery-actions button {
+  min-height: 42px;
+}
 .workspace-inspector.is-compact .workspace-inspector-head {
   grid-template-columns: minmax(0, 1fr) auto;
 }
@@ -4796,6 +5104,51 @@ textarea:focus {
 .file-preview-code .cm-focused {
   outline: none;
 }
+.file-preview-code .cm-review-annotation-gutter {
+  min-width: 28px;
+  border-right: 1px solid var(--border-soft);
+  background: var(--viewer-code-bg);
+}
+.file-preview-code .cm-review-annotation-gutter .cm-gutterElement {
+  min-width: 28px;
+  display: grid;
+  place-items: center;
+  color: var(--muted);
+  cursor: pointer;
+}
+.file-preview-code
+  .cm-review-annotation-gutter
+  .cm-gutterElement:not(:has(.cm-review-annotation-marker))::before {
+  opacity: 0;
+  color: var(--accent);
+  content: "+";
+  font-size: 15px;
+  font-weight: 800;
+}
+.file-preview-code
+  .cm-review-annotation-gutter:hover
+  .cm-gutterElement::before {
+  opacity: 0.72;
+}
+.cm-review-annotation-marker {
+  min-width: 17px;
+  height: 17px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  background: var(--accent);
+  color: var(--accent-contrast, #fff);
+  font-size: 9px;
+  font-weight: 800;
+}
+.cm-review-annotation-marker.is-stale {
+  background: var(--warning-soft);
+  color: var(--warning-text);
+  box-shadow: inset 0 0 0 1px var(--warning-border, var(--border));
+}
+.file-preview-code .cm-line[data-review-annotated="true"] {
+  background: color-mix(in srgb, var(--accent) 9%, transparent);
+}
 .file-preview-markdown {
   flex: 1 1 auto;
   min-height: 0;
@@ -5516,6 +5869,30 @@ textarea:focus {
 }
 .pierre-diff-surface > diffs-container {
   display: block;
+}
+.diff-review-annotation {
+  max-width: min(440px, 100%);
+  min-height: 24px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  overflow: hidden;
+  padding: 3px 8px;
+  border: 1px solid color-mix(in srgb, var(--accent) 48%, transparent);
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--text-strong);
+  font: 11px / 1.2 var(--sans-font);
+}
+.diff-review-annotation span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.diff-review-annotation.is-stale {
+  border-color: var(--warning-text);
+  background: var(--warning-soft);
+  color: var(--warning-text);
 }
 .diff-raw-patch {
   max-width: 100%;


### PR DESCRIPTION
## Summary

- add shared annotations for diff lines and ranges, source-file lines, and rendered Markdown selections
- persist, re-anchor, edit, reorder, clear, and compile review feedback per checkout
- copy compiled feedback or pre-fill an agent terminal without submitting it
- keep dragged diff ranges visibly highlighted while composing comments

## Verification

- `bun run precommit`
- `bun run build:web`
- `git diff --check`
- public-content and deliverable-residue audits

## Screenshots

Not included; automated browser capture is unavailable in this environment.

Closes #38
