### PR TITLE
Add configurable log levels and reduce bridge log noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Add a responsive GitHub Pages landing page with a product tour, mobile
   previews, install guidance, social metadata, and automated deployment.
+- Add configurable server log levels with concise, timestamped default output,
+  deduplicated retry failures and recovery summaries, and debug-only request,
+  event, terminal, and successful auto-sync diagnostics.
 - Add inline review annotations for diff lines, source lines, and rendered
   Markdown selections. A shared review panel edits and orders comments,
   preserves drafts per checkout, copies compiled feedback, or pre-fills an

--- a/deploy/herdr-gui.env.example
+++ b/deploy/herdr-gui.env.example
@@ -5,6 +5,9 @@ PORT=8787
 # Optional fixed password. By default, service install creates a generated token.
 # HERDR_GUI_PASSWORD=replace-with-a-strong-password
 
+# Operational logs default to info. Use debug only while diagnosing an issue.
+# HERDR_GUI_LOG_LEVEL=info
+
 # Optional: use a custom HTTPS flat release mirror for checks and installs.
 # Mirror the platform archive, .sha256, and .update.json assets together.
 # HERDR_GUI_UPDATE_BASE_URL=https://releases.example.com/herdr-gui

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -76,6 +76,7 @@ Flags override environment variables, which override defaults. Run
 | `--ssh-host <user@host>` | `HERDR_SSH_HOST` | Disabled; supported on Linux and macOS |
 | `--session <name>` | `HERDR_SESSION` | Named Herdr session, if set |
 | `--public-dir <path>` | `PUBLIC_DIR` | Embedded assets |
+| `--log-level <level>` | `HERDR_GUI_LOG_LEVEL` | `info` |
 | `--open` | `OPEN_BROWSER=1` | Disabled |
 
 Additional runtime settings:
@@ -106,6 +107,27 @@ herdr-gui --host 0.0.0.0 --port 8787 --password 's3cr3t'
 ```
 
 Read [SECURITY.md](../SECURITY.md) before using a non-loopback bind.
+
+## Logging
+
+Runtime logs use one line per event with an ISO timestamp, severity, scope, and
+bounded key/value context. The default `info` level records startup, connection
+readiness and recovery, degraded states, and fatal failures without routine RPC,
+Herdr event, terminal frame, or successful auto-sync traffic.
+
+Use `debug` temporarily when diagnosing request or lifecycle behavior:
+
+```bash
+herdr-gui --log-level debug
+# or in herdr-gui.env
+HERDR_GUI_LOG_LEVEL=debug
+```
+
+For a managed service, restart after changing `herdr-gui.env`. Debug context can
+include workspace paths and connection or terminal identifiers, so return to
+`info` after collecting the required diagnostics. Runtime logs print browser
+and LAN URLs without authentication tokens; generated tokens remain in the
+protected token file described below.
 
 ## Multiple and remote Herdr connections
 

--- a/server/src/bridge/ssh-tunnel.ts
+++ b/server/src/bridge/ssh-tunnel.ts
@@ -1,4 +1,5 @@
 import { existsSync, rmSync } from "node:fs";
+import { type Logger, silentLogger } from "../utils/logger";
 import { sshCommandArgv, sshTunnelArgv } from "./ssh-command";
 
 const SSH_STDERR_MAX_BYTES = 16 * 1024;
@@ -161,6 +162,7 @@ class SocketWaitCancelledError extends Error {}
 export function createSshTunnelManager(args: {
   connectionId?: string;
   formatError?: (error: unknown) => string;
+  logger?: Logger;
   config: SshTunnelConfig;
   runProcess: RunProcess;
   onUnexpectedExit?: (error: SshTunnelError) => void;
@@ -178,6 +180,7 @@ export function createSshTunnelManager(args: {
     platform?: string;
   };
 }) {
+  const logger = args.logger ?? silentLogger;
   const platform = args.dependencies?.platform ?? process.platform;
   const exists = args.dependencies?.exists ?? existsSync;
   const formatError =
@@ -341,17 +344,19 @@ export function createSshTunnelManager(args: {
       try {
         proc.kill();
       } catch (error) {
-        console.warn(
-          `[bridge] unable to stop SSH tunnel ${connectionDetail}: ${formatError(error)}`,
-        );
+        logger.warn("unable to stop SSH tunnel", {
+          connection: args.connectionId ?? "legacy-default",
+          error: formatError(error),
+        });
       }
       if (await processExitedWithin(proc, processStopTimeoutMs)) return;
       try {
         proc.kill(9);
       } catch (error) {
-        console.warn(
-          `[bridge] unable to force-stop SSH tunnel ${connectionDetail}: ${formatError(error)}`,
-        );
+        logger.warn("unable to force-stop SSH tunnel", {
+          connection: args.connectionId ?? "legacy-default",
+          error: formatError(error),
+        });
       }
       if (!(await processExitedWithin(proc, processForceKillTimeoutMs))) {
         throw new Error(
@@ -412,13 +417,17 @@ export function createSshTunnelManager(args: {
 
     const argv = sshTunnelArgv(host, forwards);
 
-    console.log(
-      `[bridge] starting SSH tunnel ${connectionDetail} to ${formatError(host)}`,
-    );
+    logger.debug("starting SSH tunnel", {
+      connection: args.connectionId ?? "legacy-default",
+      destination: formatError(host),
+    });
     for (const forward of forwards) {
-      console.log(
-        `[bridge]   ${connectionDetail} ${forward.label}: ${forward.local} -> ${forward.remote}`,
-      );
+      logger.debug("SSH tunnel forwarding socket", {
+        connection: args.connectionId ?? "legacy-default",
+        label: forward.label,
+        local: forward.local,
+        remote: forward.remote,
+      });
     }
 
     const proc = spawn(argv);
@@ -482,7 +491,9 @@ export function createSshTunnelManager(args: {
         );
       });
 
-    console.log("[bridge] SSH tunnel ready", connectionDetail);
+    logger.debug("SSH tunnel ready", {
+      connection: args.connectionId ?? "legacy-default",
+    });
   }
 
   function cleanupAutoSshTunnel(): Promise<void> {

--- a/server/src/bridge/terminal-bridge.ts
+++ b/server/src/bridge/terminal-bridge.ts
@@ -4,6 +4,7 @@ import {
   serializeConnectionEnvelope,
 } from "../connections/protocol";
 import { type Logger, silentLogger } from "../utils/logger";
+import { NO_TERMINAL_ATTACHED_MESSAGE } from "../utils/rpc-logging";
 import { ThinClient } from "./thin-client";
 
 type TerminalSession = {
@@ -38,10 +39,6 @@ type ClipboardTarget = {
 const CLIPBOARD_INPUT_WINDOW_MS = 30_000;
 const CLIPBOARD_RELAY_READY_WAIT_MS = 500;
 const TERMINAL_FIRST_FRAME_WAIT_MS = 20_000;
-// RPC error text for terminal calls made before a terminal is attached. The
-// websocket layer classifies this message as an expected detach race, so keep
-// it in sync with utils/rpc-logging.ts.
-export const NO_TERMINAL_ATTACHED_MESSAGE = "no terminal attached";
 // Herdr rejects OSC 52 bodies above 256 KiB before emitting Clipboard.
 const MAX_TERMINAL_CLIPBOARD_BASE64_CHARS = 256 * 1024;
 const STANDARD_BASE64_RE =

--- a/server/src/bridge/terminal-bridge.ts
+++ b/server/src/bridge/terminal-bridge.ts
@@ -3,6 +3,7 @@ import {
   CONNECTION_CHANGED_DURING_REQUEST,
   serializeConnectionEnvelope,
 } from "../connections/protocol";
+import { type Logger, silentLogger } from "../utils/logger";
 import { ThinClient } from "./thin-client";
 
 type TerminalSession = {
@@ -37,6 +38,10 @@ type ClipboardTarget = {
 const CLIPBOARD_INPUT_WINDOW_MS = 30_000;
 const CLIPBOARD_RELAY_READY_WAIT_MS = 500;
 const TERMINAL_FIRST_FRAME_WAIT_MS = 20_000;
+// RPC error text for terminal calls made before a terminal is attached. The
+// websocket layer classifies this message as an expected detach race, so keep
+// it in sync with utils/rpc-logging.ts.
+export const NO_TERMINAL_ATTACHED_MESSAGE = "no terminal attached";
 // Herdr rejects OSC 52 bodies above 256 KiB before emitting Clipboard.
 const MAX_TERMINAL_CLIPBOARD_BASE64_CHARS = 256 * 1024;
 const STANDARD_BASE64_RE =
@@ -45,6 +50,7 @@ const STANDARD_BASE64_RE =
 export function createTerminalBridge(args: {
   connectionId?: string;
   connectionGeneration?: number;
+  logger?: Logger;
   formatError?: (error: unknown) => string;
   clientSocketPath: string;
   herdrProtocol: () => Promise<number>;
@@ -65,6 +71,7 @@ export function createTerminalBridge(args: {
     paneId: string | null;
   }) => Promise<boolean>;
 }) {
+  const logger = args.logger ?? silentLogger;
   const terminals = new Map<ServerWebSocket<unknown>, TerminalSession>();
   const terminalViewers = new Map<ServerWebSocket<unknown>, Set<string>>();
   const sharedTerminals = new Map<string, SharedTerminalSession>();
@@ -84,7 +91,6 @@ export function createTerminalBridge(args: {
           args.connectionGeneration,
         )
       : JSON.stringify(message);
-  const connectionDetail = `connection=${args.connectionId ?? "legacy-default"}`;
   const formatError =
     args.formatError ??
     ((error: unknown) =>
@@ -110,10 +116,9 @@ export function createTerminalBridge(args: {
       data.length > MAX_TERMINAL_CLIPBOARD_BASE64_CHARS ||
       !STANDARD_BASE64_RE.test(data)
     ) {
-      console.warn(
-        "[bridge] dropped invalid terminal clipboard payload",
-        connectionDetail,
-      );
+      logger.warn("dropped invalid terminal clipboard payload", {
+        connection: args.connectionId ?? "legacy-default",
+      });
       return;
     }
 
@@ -128,11 +133,10 @@ export function createTerminalBridge(args: {
         ? clipboardTarget
         : null;
     if (!recentTarget) {
-      console.warn(
-        "[bridge] dropped terminal clipboard without matching recent input",
-        connectionDetail,
-        ...(terminalId ? [`terminal=${terminalId}`] : []),
-      );
+      logger.warn("dropped terminal clipboard without recent input", {
+        connection: args.connectionId ?? "legacy-default",
+        terminal: terminalId,
+      });
       return;
     }
     const targetTerminalId = recentTarget.terminalId;
@@ -144,13 +148,12 @@ export function createTerminalBridge(args: {
         data,
       },
     });
-    console.log(
-      "[bridge] terminal clipboard",
-      connectionDetail,
-      `terminal=${targetTerminalId}`,
-      `payload=${formatBytes(data.length)}`,
-      `target=${args.clientLabel(target)}`,
-    );
+    logger.debug("terminal clipboard", {
+      connection: args.connectionId ?? "legacy-default",
+      terminal: targetTerminalId,
+      payload: formatBytes(data.length),
+      target: args.clientLabel(target),
+    });
     args.safeSend(target, payload, "terminal-clipboard");
   }
 
@@ -236,7 +239,10 @@ export function createTerminalBridge(args: {
     clipboardRelaySize = { cols, rows };
     relay.on("clipboard", ({ data }) => forwardClipboard(data));
     relay.on("error", (error) =>
-      console.error("[clipboard-relay]", connectionDetail, formatError(error)),
+      logger.warn("clipboard relay error", {
+        connection: args.connectionId ?? "legacy-default",
+        error: formatError(error),
+      }),
     );
     relay.on("close", () => {
       if (clipboardRelay !== relay) return;
@@ -256,7 +262,9 @@ export function createTerminalBridge(args: {
           relay.close();
           return;
         }
-        console.log("[bridge] clipboard relay connected", connectionDetail);
+        logger.debug("clipboard relay connected", {
+          connection: args.connectionId ?? "legacy-default",
+        });
       })
       .catch((error) => {
         if (clipboardRelay === relay) {
@@ -264,11 +272,10 @@ export function createTerminalBridge(args: {
           clipboardRelaySize = null;
         }
         if (!disposed && sharedTerminals.size > 0) {
-          console.error(
-            "[clipboard-relay] connect failed:",
-            connectionDetail,
-            formatError(error),
-          );
+          logger.warn("clipboard relay connection failed", {
+            connection: args.connectionId ?? "legacy-default",
+            error: formatError(error),
+          });
         }
       })
       .finally(() => {
@@ -298,10 +305,9 @@ export function createTerminalBridge(args: {
     if (timer) clearTimeout(timer);
     if (disposed) return false;
     if (timedOut) {
-      console.warn(
-        "[clipboard-relay] still connecting; terminal attach will continue",
-        connectionDetail,
-      );
+      logger.debug("clipboard relay still connecting", {
+        connection: args.connectionId ?? "legacy-default",
+      });
       return false;
     }
     if (!clipboardRelay || clipboardRelay.isClosed) return false;
@@ -330,11 +336,11 @@ export function createTerminalBridge(args: {
     ]);
     if (timer) clearTimeout(timer);
     if (timedOut) {
-      console.warn(
-        "[bridge] terminal first frame still pending; clipboard relay deferred",
-        connectionDetail,
-        `terminal=${shared.terminalId}`,
-      );
+      logger.warn("terminal first frame still pending", {
+        connection: args.connectionId ?? "legacy-default",
+        terminal: shared.terminalId,
+        clipboard_relay: "deferred",
+      });
     }
     return seen;
   }
@@ -426,13 +432,12 @@ export function createTerminalBridge(args: {
       lastError: null,
     };
     sharedTerminals.set(terminalId, shared);
-    console.log(
-      "[bridge] thin connecting",
-      connectionDetail,
-      `terminal=${terminalId}`,
-      `size=${cols}x${rows}`,
-      `socket=${args.clientSocketPath}`,
-    );
+    logger.debug("terminal stream connecting", {
+      connection: args.connectionId ?? "legacy-default",
+      terminal: terminalId,
+      size: `${cols}x${rows}`,
+      socket: args.clientSocketPath,
+    });
 
     thin.on("terminal", (t) => {
       const resolve = shared.resolveFirstFrame;
@@ -445,16 +450,15 @@ export function createTerminalBridge(args: {
       shared.bytes += t.bytes.length;
       const now = Date.now();
       if (!shared.firstFrameLogged || now - shared.lastFrameLogAt >= 30_000) {
-        console.log(
-          "[bridge] thin frame",
-          connectionDetail,
-          `terminal=${terminalId}`,
-          `size=${t.width}x${t.height}`,
-          `full=${t.full}`,
-          `frames=${shared.frames}`,
-          `bytes=${formatBytes(shared.bytes)}`,
-          `viewers=${shared.viewers.size}`,
-        );
+        logger.debug("terminal frame", {
+          connection: args.connectionId ?? "legacy-default",
+          terminal: terminalId,
+          size: `${t.width}x${t.height}`,
+          full: t.full,
+          frames: shared.frames,
+          bytes: formatBytes(shared.bytes),
+          viewers: shared.viewers.size,
+        });
         shared.firstFrameLogged = true;
         shared.lastFrameLogAt = now;
       }
@@ -479,24 +483,21 @@ export function createTerminalBridge(args: {
     // side effects directly to the terminal attachment.
     thin.on("clipboard", ({ data }) => forwardClipboard(data, terminalId));
     thin.on("welcome", (w) => {
-      const parts = [
-        "[bridge] thin welcome",
-        connectionDetail,
-        `terminal=${terminalId}`,
-        `version=${w.version}`,
-        `encoding=${w.encoding}`,
-      ];
-      if (w.error) parts.push(`error=${formatError(w.error)}`);
-      console.log(...parts);
+      logger.debug("terminal stream welcome", {
+        connection: args.connectionId ?? "legacy-default",
+        terminal: terminalId,
+        version: w.version,
+        encoding: w.encoding,
+        error: w.error ? formatError(w.error) : undefined,
+      });
     });
     thin.on("error", (error) => {
       shared.lastError = formatError(error);
-      console.error(
-        "[thin]",
-        connectionDetail,
-        formatError(terminalId),
-        formatError(error),
-      );
+      logger.warn("terminal stream error", {
+        connection: args.connectionId ?? "legacy-default",
+        terminal: formatError(terminalId),
+        error: formatError(error),
+      });
     });
     thin.on("close", () => {
       const resolve = shared.resolveFirstFrame;
@@ -504,13 +505,12 @@ export function createTerminalBridge(args: {
         shared.resolveFirstFrame = null;
         resolve(false);
       }
-      console.log(
-        "[bridge] thin closed",
-        connectionDetail,
-        `terminal=${terminalId}`,
-        `frames=${shared.frames}`,
-        `bytes=${formatBytes(shared.bytes)}`,
-      );
+      logger.debug("terminal stream closed", {
+        connection: args.connectionId ?? "legacy-default",
+        terminal: terminalId,
+        frames: shared.frames,
+        bytes: formatBytes(shared.bytes),
+      });
       if (sharedTerminals.get(terminalId)?.thin === thin) {
         sharedTerminals.delete(terminalId);
       }
@@ -519,12 +519,11 @@ export function createTerminalBridge(args: {
       // silence otherwise, so tell them to re-attach instead of leaving a
       // blank terminal behind.
       if (isCurrent(creationRevision) && shared.viewers.size > 0) {
-        console.log(
-          "[bridge] terminal stream closed with live viewers",
-          connectionDetail,
-          `terminal=${terminalId}`,
-          `viewers=${shared.viewers.size}`,
-        );
+        logger.warn("terminal stream closed with live viewers", {
+          connection: args.connectionId ?? "legacy-default",
+          terminal: terminalId,
+          viewers: shared.viewers.size,
+        });
         const closedPayload = serialize({
           terminal_closed: {
             terminal_id: terminalId,
@@ -636,14 +635,14 @@ export function createTerminalBridge(args: {
           shared.thin.resize(cols, rows);
           shared.cols = cols;
           shared.rows = rows;
-          console.log(
-            refreshReusedTerminal
-              ? "[bridge] terminal refreshed"
-              : "[bridge] terminal resized",
-            connectionDetail,
-            `client=${args.clientLabel(ws)}`,
-            `terminal=${terminalId}`,
-            `size=${cols}x${rows}`,
+          logger.debug(
+            refreshReusedTerminal ? "terminal refreshed" : "terminal resized",
+            {
+              connection: args.connectionId ?? "legacy-default",
+              client: args.clientLabel(ws),
+              terminal: terminalId,
+              size: `${cols}x${rows}`,
+            },
           );
         }
         if (relaySize && relayRevision !== null) {
@@ -654,15 +653,14 @@ export function createTerminalBridge(args: {
           shared.thin.close();
           throw new Error("terminal bridge disposed");
         }
-        console.log(
-          "[bridge] terminal attached",
-          connectionDetail,
-          `client=${args.clientLabel(ws)}`,
-          `terminal=${terminalId}`,
-          `viewers=${shared.viewers.size}`,
-          `size=${cols}x${rows}`,
-          `shared=${sharedMode}`,
-        );
+        logger.debug("terminal attached", {
+          connection: args.connectionId ?? "legacy-default",
+          client: args.clientLabel(ws),
+          terminal: terminalId,
+          viewers: shared.viewers.size,
+          size: `${cols}x${rows}`,
+          shared: sharedMode,
+        });
         return reply({ ok: true });
       }
 
@@ -710,19 +708,21 @@ export function createTerminalBridge(args: {
       const thin = shared?.thin;
       if (method === "terminal.detach") {
         detachTerminalViewer(ws, requestedTerminalId ?? null);
-        console.log(
-          "[bridge] terminal detached",
-          connectionDetail,
-          `client=${args.clientLabel(ws)}`,
-          `terminal=${requestedTerminalId ?? "none"}`,
-          requestedTerminalId && sharedTerminals.has(requestedTerminalId)
-            ? `viewers=${sharedTerminals.get(requestedTerminalId)?.viewers.size}`
-            : "viewers=0",
-        );
+        logger.debug("terminal detached", {
+          connection: args.connectionId ?? "legacy-default",
+          client: args.clientLabel(ws),
+          terminal: requestedTerminalId ?? "none",
+          viewers:
+            requestedTerminalId && sharedTerminals.has(requestedTerminalId)
+              ? sharedTerminals.get(requestedTerminalId)?.viewers.size
+              : 0,
+        });
         return reply({ ok: true });
       }
       if (method === "terminal.input") {
-        if (!thin || !requestedTerminalId) return fail("no terminal attached");
+        if (!thin || !requestedTerminalId) {
+          return fail(NO_TERMINAL_ATTACHED_MESSAGE);
+        }
         const b64 = String(params.data ?? "");
         if (!b64 || !STANDARD_BASE64_RE.test(b64)) {
           return fail("invalid terminal input");
@@ -738,7 +738,7 @@ export function createTerminalBridge(args: {
         return reply({ ok: true });
       }
       if (method === "terminal.resize") {
-        if (!thin || !shared) return fail("no terminal attached");
+        if (!thin || !shared) return fail(NO_TERMINAL_ATTACHED_MESSAGE);
         const cols = Number(params.cols ?? 100);
         const rows = Number(params.rows ?? 30);
         const relaySize = relaySizeFromParams(params, { cols, rows });
@@ -749,17 +749,16 @@ export function createTerminalBridge(args: {
           clipboardRelayRevision += 1;
           syncClipboardRelaySize(relaySize.cols, relaySize.rows);
         }
-        console.log(
-          "[bridge] terminal resized",
-          connectionDetail,
-          `client=${args.clientLabel(ws)}`,
-          `terminal=${requestedTerminalId ?? "none"}`,
-          `size=${cols}x${rows}`,
-        );
+        logger.debug("terminal resized", {
+          connection: args.connectionId ?? "legacy-default",
+          client: args.clientLabel(ws),
+          terminal: requestedTerminalId ?? "none",
+          size: `${cols}x${rows}`,
+        });
         return reply({ ok: true });
       }
       if (method === "terminal.scroll") {
-        if (!thin) return fail("no terminal attached");
+        if (!thin) return fail(NO_TERMINAL_ATTACHED_MESSAGE);
         const direction = params.direction === "up" ? "up" : "down";
         const lines = Number(params.lines ?? 3);
         const column =

--- a/server/src/bridge/websocket-send.ts
+++ b/server/src/bridge/websocket-send.ts
@@ -1,4 +1,8 @@
+import { serverLogger } from "../utils/logger";
+
 export const WS_BACKPRESSURE_LIMIT_BYTES = 8 * 1024 * 1024;
+
+const websocketLogger = serverLogger.child("websocket");
 
 interface WebSocketSendTarget {
   close(code?: number, reason?: string): void;
@@ -91,7 +95,10 @@ export function sendWebSocketMessage(
   {
     cleanup,
     context = "message",
-    warn = (message) => console.warn(message),
+    warn = (message) =>
+      websocketLogger.warn("send failed", {
+        detail: message.replace(/^\[bridge\] /, ""),
+      }),
   }: WebSocketSendOptions,
 ): boolean {
   const sendContext = { cleanup, context, warn };

--- a/server/src/config/gui-settings.ts
+++ b/server/src/config/gui-settings.ts
@@ -3,6 +3,7 @@ import { dirname, join } from "node:path";
 import { mkdirSync } from "node:fs";
 import { rename, rm } from "node:fs/promises";
 import { LEGACY_DEFAULT_CONNECTION_ID } from "../connections/types";
+import { serverLogger } from "../utils/logger";
 import { sourceCheckoutPath as workspaceSourceCheckoutPath } from "../workspace/utils";
 
 export type GuiRepoSettings = {
@@ -134,9 +135,10 @@ export async function readGuiSettings(): Promise<GuiSettings> {
   try {
     cachedGuiSettings = normalizeGuiSettings(JSON.parse(await file.text()));
   } catch (e) {
-    console.warn(
-      `[bridge] ignoring invalid Herdr Studio settings at ${path}: ${(e as Error).message}`,
-    );
+    serverLogger.child("settings").warn("ignoring invalid settings", {
+      path,
+      error: e,
+    });
     cachedGuiSettings = defaultGuiSettings();
   }
   return cachedGuiSettings;

--- a/server/src/config/server-config.test.ts
+++ b/server/src/config/server-config.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { herdrConfigDir, nativeSocketPath } from "./server-config";
+import {
+  herdrConfigDir,
+  nativeSocketPath,
+  resolveServerLogLevel,
+} from "./server-config";
 
 describe("herdrConfigDir", () => {
   test("uses APPDATA on win32", () => {
-    const appData = join("C:", "Users", "tester", "AppData", "Roaming");
+    const appData = join("C:", "AppData", "Roaming");
     expect(herdrConfigDir("win32", appData)).toBe(join(appData, "herdr"));
   });
 
@@ -21,10 +25,21 @@ describe("herdrConfigDir", () => {
   });
 });
 
+describe("resolveServerLogLevel", () => {
+  test("prefers the CLI value over the environment", () => {
+    expect(resolveServerLogLevel("debug", "error")).toBe("debug");
+  });
+
+  test("uses the environment and defaults to info", () => {
+    expect(resolveServerLogLevel(undefined, "warn")).toBe("warn");
+    expect(resolveServerLogLevel(undefined, undefined)).toBe("info");
+  });
+});
+
 describe("nativeSocketPath", () => {
   test("maps Herdr's Windows socket name onto its named pipe", () => {
-    const logical = String.raw`C:\Users\tester\AppData\Roaming\herdr\herdr.sock`;
-    const native = String.raw`\\.\pipe\C:\Users\tester\AppData\Roaming\herdr\herdr.sock`;
+    const logical = String.raw`C:\AppData\Roaming\herdr\herdr.sock`;
+    const native = String.raw`\\.\pipe\C:\AppData\Roaming\herdr\herdr.sock`;
 
     expect(nativeSocketPath(logical, "win32")).toBe(native);
     expect(nativeSocketPath(native, "win32")).toBe(native);

--- a/server/src/config/server-config.ts
+++ b/server/src/config/server-config.ts
@@ -6,6 +6,7 @@ import { createHash } from "node:crypto";
 import { validateSshDestination } from "../bridge/ssh-command";
 import { assertSshTunnelPlatformSupported } from "../bridge/ssh-tunnel";
 import { defaultAuthTokenPath, loadOrCreateAuthToken } from "./auth-token";
+import { type LogLevel, parseLogLevel, serverLogger } from "../utils/logger";
 
 type CliArgs = Partial<{
   host: string;
@@ -16,6 +17,7 @@ type CliArgs = Partial<{
   "ssh-host": string;
   session: string;
   "public-dir": string;
+  "log-level": string;
   open: boolean;
   help: boolean;
   version: boolean;
@@ -35,6 +37,7 @@ export type ServerConfig = {
   sshHost?: string;
   session?: string;
   openBrowserRequested: boolean;
+  logLevel: LogLevel;
   hasExplicitSocketPath: boolean;
   hasExplicitClientSocketPath: boolean;
 };
@@ -48,10 +51,18 @@ const cliOptions = {
   "ssh-host": { type: "string" },
   session: { type: "string" },
   "public-dir": { type: "string" },
+  "log-level": { type: "string" },
   open: { type: "boolean" },
   help: { type: "boolean" },
   version: { type: "boolean", short: "V" },
 } as const;
+
+export function resolveServerLogLevel(
+  cliValue: string | undefined,
+  envValue: string | undefined,
+): LogLevel {
+  return parseLogLevel(cliValue ?? envValue ?? "info");
+}
 
 export function loadServerConfig(appVersion: string): ServerConfig {
   let args: CliArgs;
@@ -91,6 +102,7 @@ Options (flags override env vars):
   --ssh-host <user@host>     remote Herdr over SSH (env HERDR_SSH_HOST)
   --session <name>           named herdr session   (env HERDR_SESSION)
   --public-dir <path>        static assets dir     (env PUBLIC_DIR,      default: embedded)
+  --log-level <level>        error|warn|info|debug  (env HERDR_GUI_LOG_LEVEL, default: info)
   --open                     open browser on start (env OPEN_BROWSER=1)
   -V, --version              show version
   --help                     show this help
@@ -101,6 +113,17 @@ Options (flags override env vars):
   if (args.version) {
     console.log(`herdr-gui ${appVersion}`);
     process.exit(0);
+  }
+
+  let logLevel: LogLevel;
+  try {
+    logLevel = resolveServerLogLevel(
+      args["log-level"],
+      process.env.HERDR_GUI_LOG_LEVEL,
+    );
+  } catch (error) {
+    console.error(`[bridge] ${(error as Error).message}`);
+    process.exit(2);
   }
 
   const host = String(args.host ?? process.env.HOST ?? "127.0.0.1");
@@ -164,6 +187,7 @@ Options (flags override env vars):
     session,
     openBrowserRequested:
       args.open === true || process.env.OPEN_BROWSER === "1",
+    logLevel,
     hasExplicitSocketPath,
     hasExplicitClientSocketPath,
   };
@@ -304,6 +328,6 @@ export function openBrowser(config: ServerConfig, url: string) {
   try {
     Bun.spawn([opener, ...openerArgs], { stdout: "ignore", stderr: "ignore" });
   } catch (e) {
-    console.error(`[bridge] failed to open browser: ${(e as Error).message}`);
+    serverLogger.child("browser").warn("failed to open browser", { error: e });
   }
 }

--- a/server/src/config/service-definitions.ts
+++ b/server/src/config/service-definitions.ts
@@ -22,6 +22,9 @@ PORT=8787
 # Optional fixed password. By default, service install creates a generated token.
 # HERDR_GUI_PASSWORD=replace-with-a-strong-password
 
+# Operational logs default to info. Use debug only while diagnosing an issue.
+# HERDR_GUI_LOG_LEVEL=info
+
 # Optional Herdr connection settings.
 # HERDR_SOCKET_PATH=/path/to/herdr.sock
 # HERDR_CLIENT_SOCKET_PATH=/path/to/herdr-client.sock

--- a/server/src/connections/manager.ts
+++ b/server/src/connections/manager.ts
@@ -1,3 +1,4 @@
+import { type Logger, silentLogger } from "../utils/logger";
 import type {
   ConnectionId,
   ConnectionIdentity,
@@ -43,10 +44,6 @@ type ConnectionEntry<Runtime extends ConnectionRuntime> = {
 
 const MAX_STATUS_ERROR_LENGTH = 300;
 
-function reportConnectionManagerError(message: string): void {
-  process.stderr.write(`${message}\n`);
-}
-
 function deferredTask<T = void>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
   let reject!: (error: unknown) => void;
@@ -86,6 +83,7 @@ export class ConnectionManager<
   constructor(
     private defaultConnectionId: ConnectionId,
     private readonly onStatus?: (status: ConnectionStatus) => void,
+    private readonly logger: Logger = silentLogger,
   ) {}
 
   register(args: {
@@ -152,9 +150,10 @@ export class ConnectionManager<
       // cleanup reported an error so the profile can never be reconnected.
       this.entries.delete(connectionId);
       if (cleanupError) {
-        reportConnectionManagerError(
-          `[bridge] connection unregister cleanup failed id=${connectionId}: ${sanitizeConnectionError(cleanupError)}`,
-        );
+        this.logger.error("connection unregister cleanup failed", {
+          connection: connectionId,
+          error: sanitizeConnectionError(cleanupError),
+        });
       }
     } finally {
       this.removing.delete(connectionId);
@@ -213,9 +212,10 @@ export class ConnectionManager<
           result.status === "rejected",
       );
       if (cleanupFailure) {
-        reportConnectionManagerError(
-          `[bridge] failed runtime cleanup id=${entry.identity.id}: ${sanitizeConnectionError(cleanupFailure.reason)}`,
-        );
+        this.logger.error("failed runtime cleanup", {
+          connection: entry.identity.id,
+          error: sanitizeConnectionError(cleanupFailure.reason),
+        });
       }
       if (
         entry.generation === failedGeneration &&
@@ -280,9 +280,10 @@ export class ConnectionManager<
       try {
         callback(runtime);
       } catch (error) {
-        reportConnectionManagerError(
-          `[bridge] connection runtime callback failed id=${runtime.identity.id}: ${sanitizeConnectionError(error)}`,
-        );
+        this.logger.error("connection runtime callback failed", {
+          connection: runtime.identity.id,
+          error: sanitizeConnectionError(error),
+        });
       }
     }
   }
@@ -385,9 +386,10 @@ export class ConnectionManager<
           try {
             await runtime.stop();
           } catch (cleanupError) {
-            reportConnectionManagerError(
-              `[bridge] failed runtime cleanup failed id=${entry.identity.id}: ${sanitizeConnectionError(cleanupError)}`,
-            );
+            this.logger.error("failed runtime cleanup", {
+              connection: entry.identity.id,
+              error: sanitizeConnectionError(cleanupError),
+            });
           } finally {
             if (entry.runtime === runtime) entry.runtime = null;
           }
@@ -510,9 +512,10 @@ export class ConnectionManager<
     void Promise.all(
       Array.from(this.entries.keys(), (connectionId) =>
         this.stop(connectionId).catch((error) => {
-          reportConnectionManagerError(
-            `[bridge] connection stop failed id=${connectionId}: ${sanitizeConnectionError(error)}`,
-          );
+          this.logger.error("connection stop failed", {
+            connection: connectionId,
+            error: sanitizeConnectionError(error),
+          });
         }),
       ),
     ).then(() => deferred.resolve(), deferred.reject);
@@ -564,9 +567,10 @@ export class ConnectionManager<
     try {
       this.onStatus?.(this.toStatus(entry));
     } catch (error) {
-      reportConnectionManagerError(
-        `[bridge] connection status observer failed id=${entry.identity.id}: ${sanitizeConnectionError(error)}`,
-      );
+      this.logger.error("connection status observer failed", {
+        connection: entry.identity.id,
+        error: sanitizeConnectionError(error),
+      });
     }
   }
 }

--- a/server/src/connections/profile-process.test.ts
+++ b/server/src/connections/profile-process.test.ts
@@ -125,7 +125,7 @@ function bridgeListeningPort(stream: ReadableStream<Uint8Array>) {
         if (done) break;
         output += decoder.decode(value, { stream: true });
         const match = output.match(
-          /\[bridge\] listening on http:\/\/.*:(\d+)\s+\(ws \/ws\)/,
+          /\bINFO bridge listening\b[^\r\n]*\burl=http:\/\/[^\s]+:(\d+)\b/,
         );
         if (match && !settled) {
           settled = true;

--- a/server/src/connections/runtime.ts
+++ b/server/src/connections/runtime.ts
@@ -12,6 +12,11 @@ import { createTerminalBridge } from "../bridge/terminal-bridge";
 import { createHerdrInfoHandler } from "../http/herdr-info";
 import { createImageUploadHandler } from "../http/image-upload";
 import {
+  createRecoveryReporter,
+  type Logger,
+  silentLogger,
+} from "../utils/logger";
+import {
   runProcess,
   runProcessWithCode,
   runProcessWithCodeTimeout,
@@ -74,6 +79,7 @@ export function createLegacyConnectionRuntime(args: {
   identity?: ConnectionIdentity;
   connectionGeneration?: number;
   config: SshTunnelConfig;
+  logger?: Logger;
   safeSend: SafeSend;
   clientLabel: (ws: ServerWebSocket<unknown>) => string;
   markRpcError: MarkRpcError;
@@ -86,6 +92,7 @@ export function createLegacyConnectionRuntime(args: {
   lastStepTransitionDebounceMs?: number;
 }) {
   const { config } = args;
+  const logger = args.logger ?? silentLogger;
   const identity = { ...(args.identity ?? LEGACY_DEFAULT_CONNECTION) };
   const socketPath = config.socketPath;
   const clientSocketPath = config.clientSocketPath;
@@ -130,6 +137,7 @@ export function createLegacyConnectionRuntime(args: {
   });
   const workspaceAutoSync = createWorkspaceAutoSync({
     connectionId: identity.id,
+    logger: logger.child("auto-sync"),
     formatError: sanitizeConnectionError,
     herdr,
     sshHost,
@@ -156,6 +164,7 @@ export function createLegacyConnectionRuntime(args: {
   const handleImageUpload = createImageUploadHandler({ sshHost });
   const sshTunnel = createSshTunnelManager({
     connectionId: identity.id,
+    logger: logger.child("ssh"),
     formatError: sanitizeConnectionError,
     config,
     runProcess,
@@ -176,6 +185,7 @@ export function createLegacyConnectionRuntime(args: {
   });
   const terminalBridge = createTerminalBridge({
     connectionId: identity.id,
+    logger: logger.child("terminal"),
     connectionGeneration: args.connectionGeneration,
     formatError: sanitizeConnectionError,
     clientSocketPath,
@@ -232,34 +242,42 @@ export function createLegacyConnectionRuntime(args: {
       );
     },
     onCaptureError: (error, workspaceId) =>
-      console.error(
-        `[bridge] last-step baseline failed connection=${identity.id} workspace=${workspaceId}:`,
-        sanitizeConnectionError(error),
-      ),
+      logger.warn("last-step baseline failed", {
+        connection: identity.id,
+        workspace: workspaceId,
+        error: sanitizeConnectionError(error),
+      }),
     onCompleteError: (error, workspaceId) =>
-      console.error(
-        `[bridge] last-step completion failed connection=${identity.id} workspace=${workspaceId}:`,
-        sanitizeConnectionError(error),
-      ),
+      logger.warn("last-step completion failed", {
+        connection: identity.id,
+        workspace: workspaceId,
+        error: sanitizeConnectionError(error),
+      }),
     transitionDebounceMs: args.lastStepTransitionDebounceMs ?? 150,
+  });
+  const agentStatusRecovery = createRecoveryReporter({
+    logger: logger.child("agent-status"),
+    failureMessage: "agent status subscription failed",
+    recoveryMessage: "agent status subscription recovered",
   });
   const agentStatusSubscriptions = createAgentStatusSubscriptionLoop({
     herdr,
     connectionId: identity.id,
     onSubscribeError: (error) =>
-      console.error(
-        `[bridge] agent status subscribe failed connection=${identity.id}:`,
-        sanitizeConnectionError(error),
-        "- retrying",
-      ),
+      agentStatusRecovery.failure(sanitizeConnectionError(error), {
+        connection: identity.id,
+      }),
     onListError: (error) =>
-      console.error(
-        `[bridge] agent status pane list failed connection=${identity.id}:`,
-        sanitizeConnectionError(error),
-      ),
+      agentStatusRecovery.failure(sanitizeConnectionError(error), {
+        connection: identity.id,
+        operation: "pane list",
+      }),
     onPaneListStart: lastStepTurns.beginPaneList,
     onPaneList: lastStepTurns.reconcilePaneList,
-    log: (message) => console.log(`[bridge] ${message}`),
+    log: (message) => {
+      agentStatusRecovery.recovered({ connection: identity.id });
+      logger.debug(message, { connection: identity.id });
+    },
   });
 
   const onHerdrEvent = (event: unknown) => {
@@ -271,22 +289,28 @@ export function createLegacyConnectionRuntime(args: {
   herdr.on("event", onHerdrEvent);
   herdr.on("error", onHerdrError);
 
+  const eventSubscriptionRecovery = createRecoveryReporter({
+    logger: logger.child("events"),
+    failureMessage: "event subscription failed",
+    recoveryMessage: "event subscription recovered",
+  });
   const subscriptionLoop = createEventSubscriptionLoop({
     subscribe: () => herdr.subscribe(DEFAULT_EVENTS),
-    onReady: () =>
-      console.log(
-        `[bridge] subscribed to herdr events connection=${identity.id}`,
-      ),
+    onReady: () => {
+      if (!eventSubscriptionRecovery.recovered({ connection: identity.id })) {
+        logger.info("subscribed to Herdr events", { connection: identity.id });
+      }
+    },
     onSubscribeError: (error) =>
-      console.error(
-        `[bridge] subscribe failed connection=${identity.id}:`,
-        sanitizeConnectionError(error),
-        "- retrying in 2s",
-      ),
+      eventSubscriptionRecovery.failure(sanitizeConnectionError(error), {
+        connection: identity.id,
+        retry_ms: 2_000,
+      }),
     onSubscriptionClosed: () =>
-      console.log(
-        `[bridge] subscription closed connection=${identity.id}, reconnecting in 2s...`,
-      ),
+      eventSubscriptionRecovery.failure("subscription closed", {
+        connection: identity.id,
+        retry_ms: 2_000,
+      }),
   });
 
   let transportStart: Promise<void> | null = null;

--- a/server/src/connections/shutdown.ts
+++ b/server/src/connections/shutdown.ts
@@ -1,3 +1,5 @@
+import { serverLogger } from "../utils/logger";
+
 type ShutdownControllerOptions = {
   stop: () => void | Promise<void>;
   exit: (code: number) => void;
@@ -39,10 +41,11 @@ export function createShutdownController(options: ShutdownControllerOptions) {
           try {
             options.onStopError?.(error);
           } catch (observerError) {
-            console.error(
-              "[bridge] shutdown error observer failed:",
-              observerError,
-            );
+            serverLogger
+              .child("connections")
+              .error("shutdown error observer failed", {
+                error: observerError,
+              });
           }
         } finally {
           cancelForceExit();

--- a/server/src/connections/ssh-profile-process.test.ts
+++ b/server/src/connections/ssh-profile-process.test.ts
@@ -137,7 +137,7 @@ function bridgeListeningPort(stream: ReadableStream<Uint8Array>) {
         if (done) break;
         output += decoder.decode(value, { stream: true });
         const match = output.match(
-          /\[bridge\] listening on http:\/\/.*:(\d+)\s+\(ws \/ws\)/,
+          /\bINFO bridge listening\b[^\r\n]*\burl=http:\/\/[^\s]+:(\d+)\b/,
         );
         if (match && !settled) {
           settled = true;

--- a/server/src/connections/startup.ts
+++ b/server/src/connections/startup.ts
@@ -1,3 +1,5 @@
+import { serverLogger } from "../utils/logger";
+
 export function bindListenerBeforeConnectionStart<Listener>(args: {
   bindListener: () => Listener;
   startConnection: () => void | Promise<void>;
@@ -8,10 +10,11 @@ export function bindListenerBeforeConnectionStart<Listener>(args: {
     try {
       args.onConnectionError(error);
     } catch (observerError) {
-      console.error(
-        "[bridge] connection startup error observer failed:",
-        observerError,
-      );
+      serverLogger
+        .child("connections")
+        .error("connection startup error observer failed", {
+          error: observerError,
+        });
     }
   };
   try {

--- a/server/src/http/auth.test.ts
+++ b/server/src/http/auth.test.ts
@@ -121,7 +121,7 @@ describe("generated token login", () => {
     ).toBe(true);
   });
 
-  test("builds an encoded token URL for local and LAN startup output", () => {
+  test("builds an encoded token URL for browser launch", () => {
     expect(withLoginToken(browserUrlFor("0.0.0.0", 8787), "secret token")).toBe(
       "http://localhost:8787/?token=secret+token",
     );

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -308,7 +308,7 @@ try {
 }
 
 const connectionFailureReporters = new Map<string, RecoveryReporter>();
-const readyConnectionGenerations = new Set<string>();
+const readyConnectionGenerations = new Map<string, number>();
 
 function connectionFailureReporter(connectionId: string): RecoveryReporter {
   let reporter = connectionFailureReporters.get(connectionId);
@@ -344,11 +344,12 @@ const connectionManager = new ConnectionManager<LegacyConnectionRuntime>(
       return;
     }
     if (status.state !== "ready") return;
-    const generationKey = `${status.id}\0${status.generation}`;
     if (reporter.recovered(fields)) {
-      readyConnectionGenerations.add(generationKey);
-    } else if (!readyConnectionGenerations.has(generationKey)) {
-      readyConnectionGenerations.add(generationKey);
+      readyConnectionGenerations.set(status.id, status.generation);
+    } else if (
+      readyConnectionGenerations.get(status.id) !== status.generation
+    ) {
+      readyConnectionGenerations.set(status.id, status.generation);
       logger.info("connection ready", fields);
     }
   },

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -483,7 +483,9 @@ function safeSend(
     },
     context,
     warn: (message) =>
-      logger.warn("websocket send failed", { detail: message }),
+      logger.warn("websocket send failed", {
+        detail: message.replace(/^\[bridge\] /, ""),
+      }),
   });
 }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -71,7 +71,14 @@ import {
   createUpdateHandlers,
   UPDATE_HTTP_IDLE_TIMEOUT_SECONDS,
 } from "./http/update";
+import {
+  configureServerLogger,
+  createRecoveryReporter,
+  type RecoveryReporter,
+  serverLogger,
+} from "./utils/logger";
 import { runProcessWithCodeTimeout, shQuote } from "./utils/process-utils";
+import { rpcLogLevel } from "./utils/rpc-logging";
 import { syncWorktreeBase } from "./worktree/create";
 import {
   removeWorktreeWithRecovery,
@@ -86,6 +93,8 @@ if (serviceCommandResult === SERVICE_COMMAND_CONTINUE) {
   process.exit(serviceCommandResult);
 }
 const config = loadServerConfig(APP_VERSION);
+configureServerLogger(config.logLevel);
+const logger = serverLogger;
 const downstreamConnectionConfig = {
   socketPath: config.socketPath,
   clientSocketPath: config.clientSocketPath,
@@ -140,7 +149,8 @@ const IMPORTANT_RPC_METHODS = new Set([
 ]);
 const SLOW_RPC_LOG_MS = 750;
 const legacyRoutingLogger = createLegacyRoutingLogger({
-  log: (message) => console.warn(message),
+  log: (message) =>
+    logger.warn("deprecated request routing", { detail: message }),
 });
 
 function clientLabel(ws: ServerWebSocket<unknown>): string {
@@ -233,15 +243,15 @@ function logRpc(
   const elapsedMs = Date.now() - startedAt;
   const failed = status === "error";
   if (!shouldLogRpc(method, elapsedMs, failed)) return;
-  const parts = [
-    `[bridge] rpc ${status}`,
-    `client=${clientLabel(ws)}`,
-    `method=${method ? logDetail(method) : "unknown"}`,
-    ...(connectionId ? [`connection=${logDetail(connectionId)}`] : []),
-    `duration=${elapsedMs}ms`,
-  ];
-  if (detail) parts.push(`detail=${logDetail(detail)}`);
-  console.log(parts.join(" "));
+  const level = rpcLogLevel({ method, status, detail });
+  logger[level]("rpc completed", {
+    status,
+    client: clientLabel(ws),
+    method: method ? logDetail(method) : "unknown",
+    connection: connectionId ? logDetail(connectionId) : undefined,
+    duration_ms: elapsedMs,
+    detail: detail ? logDetail(detail) : undefined,
+  });
 }
 
 function summarizeHerdrEvent(event: any): string {
@@ -282,9 +292,10 @@ try {
   });
 } catch (error) {
   const registryLoadError = sanitizeConnectionError(error);
-  console.error(
-    `[bridge] invalid connection registry preserved; profile mutations are disabled: ${registryLoadError}`,
-  );
+  logger.error("invalid connection registry preserved", {
+    error: registryLoadError,
+    profile_mutations: "disabled",
+  });
   connectionBootstrap = {
     defaultConnectionId: LEGACY_DEFAULT_CONNECTION_ID,
     explicitLegacyOverride,
@@ -296,16 +307,52 @@ try {
   };
 }
 
+const connectionFailureReporters = new Map<string, RecoveryReporter>();
+const readyConnectionGenerations = new Set<string>();
+
+function connectionFailureReporter(connectionId: string): RecoveryReporter {
+  let reporter = connectionFailureReporters.get(connectionId);
+  if (!reporter) {
+    reporter = createRecoveryReporter({
+      logger: logger.child("connections"),
+      failureMessage: "connection degraded",
+      recoveryMessage: "connection recovered",
+    });
+    connectionFailureReporters.set(connectionId, reporter);
+  }
+  return reporter;
+}
+
 const connectionManager = new ConnectionManager<LegacyConnectionRuntime>(
   connectionBootstrap.defaultConnectionId,
   (status) => {
-    const error = status.error
-      ? ` error=${logDetail(status.error.message)}`
-      : "";
-    console.log(
-      `[bridge] connection status id=${status.id} state=${status.state} generation=${status.generation}${error}`,
-    );
+    const fields = {
+      connection: status.id,
+      state: status.state,
+      generation: status.generation,
+    };
+    logger.debug("connection status", {
+      ...fields,
+      error: status.error?.message,
+    });
+    const reporter = connectionFailureReporter(status.id);
+    if (
+      (status.state === "error" || status.state === "reconnecting") &&
+      status.error
+    ) {
+      reporter.failure(status.error.message, fields);
+      return;
+    }
+    if (status.state !== "ready") return;
+    const generationKey = `${status.id}\0${status.generation}`;
+    if (reporter.recovered(fields)) {
+      readyConnectionGenerations.add(generationKey);
+    } else if (!readyConnectionGenerations.has(generationKey)) {
+      readyConnectionGenerations.add(generationKey);
+      logger.info("connection ready", fields);
+    }
   },
+  logger.child("connections"),
 );
 
 function runtimeFactoryForProfile(
@@ -333,16 +380,16 @@ function runtimeFactoryForProfile(
         identity,
         connectionGeneration: context.generation,
         config: profileConfig,
+        logger: logger.child("connection"),
         safeSend,
         clientLabel,
         markRpcError,
         onEvent: (event, eventIdentity) => {
           if (!context.isCurrent()) return;
-          console.log(
-            "[bridge] herdr event",
-            `connection=${eventIdentity.id}`,
-            summarizeHerdrEvent(event),
-          );
+          logger.debug("Herdr event", {
+            connection: eventIdentity.id,
+            detail: summarizeHerdrEvent(event),
+          });
           try {
             const line = serializeHerdrEventEnvelope(
               eventIdentity.id,
@@ -351,17 +398,11 @@ function runtimeFactoryForProfile(
             );
             for (const ws of clients) safeSend(ws, line, "event");
           } catch (error) {
-            console.error(
-              `[bridge] dropped invalid Herdr event connection=${eventIdentity.id}: ${sanitizeConnectionError(error)}`,
-            );
+            logger.warn("dropped invalid Herdr event", {
+              connection: eventIdentity.id,
+              error: sanitizeConnectionError(error),
+            });
           }
-        },
-        onError: (error, eventIdentity) => {
-          if (!context.isCurrent()) return;
-          console.error(
-            `[herdr connection=${eventIdentity.id}]`,
-            sanitizeConnectionError(error),
-          );
         },
         onTransportExit: profileConfig.sshHost
           ? (error) => {
@@ -441,6 +482,8 @@ function safeSend(
       webSocketCleanup.cleanup(ws);
     },
     context,
+    warn: (message) =>
+      logger.warn("websocket send failed", { detail: message }),
   });
 }
 
@@ -842,9 +885,10 @@ async function handleRpc(ws: ServerWebSocket<unknown>, raw: string) {
         .rememberWorktreeParent(result, workspaceId, requestIsCurrent)
         .catch((error) => {
           if (!requestIsCurrent()) return;
-          console.warn(
-            `[bridge] unable to persist worktree parent connection=${connectionId}: ${sanitizeConnectionError(error)}`,
-          );
+          logger.warn("unable to persist worktree parent", {
+            connection: connectionId,
+            error: sanitizeConnectionError(error),
+          });
         });
       const hookSourceWorkspace = sourceWorkspace
         ? {
@@ -883,9 +927,10 @@ async function handleRpc(ws: ServerWebSocket<unknown>, raw: string) {
         .rememberWorktreeParent(result, workspaceId, requestIsCurrent)
         .catch((error) => {
           if (!requestIsCurrent()) return;
-          console.warn(
-            `[bridge] unable to persist opened worktree parent connection=${connectionId}: ${sanitizeConnectionError(error)}`,
-          );
+          logger.warn("unable to persist opened worktree parent", {
+            connection: connectionId,
+            error: sanitizeConnectionError(error),
+          });
         });
       const openedHook = await runWorktreeOpenedHook(result, sourceWorkspace);
       sendReply(
@@ -947,18 +992,20 @@ async function handleRpc(ws: ServerWebSocket<unknown>, raw: string) {
             runtime: worktreeRemovalRuntime,
           });
           if (removal.cleanup?.preserved_path) {
-            console.warn(
-              `[bridge] preserved stale worktree files connection=${connectionId} at ${removal.cleanup.preserved_path}`,
-            );
+            logger.warn("preserved stale worktree files", {
+              connection: connectionId,
+              path: removal.cleanup.preserved_path,
+            });
           }
           if (removeHookContext?.checkoutPath) {
             await worktreeParents
               .forgetWorktree(removeHookContext.checkoutPath, requestIsCurrent)
               .catch((error) => {
                 if (!requestIsCurrent()) return;
-                console.warn(
-                  `[bridge] unable to remove worktree parent connection=${connectionId}: ${sanitizeConnectionError(error)}`,
-                );
+                logger.warn("unable to remove worktree parent", {
+                  connection: connectionId,
+                  error: sanitizeConnectionError(error),
+                });
               });
           }
           const removedHook = await runWorktreeRemovedHook(removeHookContext);
@@ -1172,11 +1219,10 @@ function main() {
           open(ws) {
             clients.add(ws);
             const label = assignClientId(ws);
-            console.log(
-              "[bridge] client connected",
-              `client=${label}`,
-              `clients=${clients.size}`,
-            );
+            logger.debug("client connected", {
+              client: label,
+              clients: clients.size,
+            });
             notifyBrowserClientCount();
             safeSend(
               ws,
@@ -1257,14 +1303,13 @@ function main() {
           },
           close(ws) {
             const { client, viewedTerminals } = webSocketCleanup.complete(ws);
-            console.log(
-              "[bridge] client disconnected",
-              `client=${client}`,
-              `clients=${clients.size}`,
-              viewedTerminals.length
-                ? `terminals=${viewedTerminals.join(",")}`
-                : "terminals=none",
-            );
+            logger.debug("client disconnected", {
+              client,
+              clients: clients.size,
+              terminals: viewedTerminals.length
+                ? viewedTerminals.join(",")
+                : "none",
+            });
           },
         },
       }),
@@ -1275,59 +1320,60 @@ function main() {
       void runtime?.herdr
         .ping()
         .then((ping) =>
-          console.log(
-            `[bridge] herdr connection=${runtime.identity.id} ${ping.version} (protocol ${ping.protocol}) reachable`,
-          ),
+          logger.info("Herdr reachable", {
+            connection: runtime.identity.id,
+            version: ping.version,
+            protocol: ping.protocol,
+          }),
         )
         .catch((error) =>
-          console.error(
-            `[bridge] herdr connection=${runtime.identity.id} not reachable yet (${sanitizeConnectionError(error)}); ` +
-              "start a server with `herdr server`. RPCs will retry per request.",
-          ),
+          logger.warn("Herdr not reachable yet", {
+            connection: runtime.identity.id,
+            error: sanitizeConnectionError(error),
+            action: "start `herdr server`; RPCs retry per request",
+          }),
         );
     },
     onConnectionError: (error) => {
-      console.error(
-        `[bridge] default connection startup failed: ${sanitizeConnectionError(error)}`,
-      );
+      logger.warn("default connection startup failed", {
+        error: sanitizeConnectionError(error),
+      });
     },
   });
   const listeningPort = server.port ?? config.port;
-  console.log(
-    `[bridge] listening on http://${config.host}:${listeningPort}  (ws /ws)`,
-  );
+  const publicBrowserUrl = browserUrlFor(config.host, listeningPort);
+  logger.info("listening", {
+    url: publicBrowserUrl,
+    websocket: "/ws",
+    log_level: config.logLevel,
+  });
   if (config.authRequired) {
     if (config.generatedAuthTokenPath) {
-      console.log(
-        `[bridge] auth required (generated token stored at ${config.generatedAuthTokenPath})`,
-      );
+      logger.info("authentication required", {
+        mode: "generated token",
+        path: config.generatedAuthTokenPath,
+      });
     } else {
-      console.log("[bridge] auth required (password login enabled)");
+      logger.info("authentication required", { mode: "password" });
     }
   }
-  console.log(`[bridge] herdr socket: ${config.socketPath}`);
-  console.log(`[bridge] herdr client socket: ${config.clientSocketPath}`);
-  console.log(`[bridge] public dir: ${config.publicDir}`);
+  logger.debug("Herdr sockets configured", {
+    control_socket: config.socketPath,
+    client_socket: config.clientSocketPath,
+    public_dir: config.publicDir,
+  });
+  logger.info("browser URL", { url: publicBrowserUrl });
 
   const browserUrl = withLoginToken(
-    browserUrlFor(config.host, listeningPort),
+    publicBrowserUrl,
     config.generatedAuthToken,
   );
-  console.log(`[bridge] browser URL: ${browserUrl}`);
   if (isAnyHost(config.host)) {
-    const lanUrls = getLanIPs().map((ip) =>
-      withLoginToken(
-        `http://${ip}:${listeningPort}`,
-        config.generatedAuthToken,
-      ),
-    );
+    const lanUrls = getLanIPs().map((ip) => `http://${ip}:${listeningPort}`);
     if (lanUrls.length > 0) {
-      console.log("[bridge] accessible from your LAN at:");
-      for (const url of lanUrls) console.log(`[bridge]   ${url}`);
+      for (const url of lanUrls) logger.info("LAN URL", { url });
     } else {
-      console.log(
-        `[bridge] listening on all interfaces; no LAN IPv4 address was detected.`,
-      );
+      logger.warn("no LAN IPv4 address detected");
     }
   }
   openBrowser(config, browserUrl);
@@ -1344,9 +1390,9 @@ const shutdownController = createShutdownController({
   stop: stopManagerOnce,
   exit: (code) => process.exit(code),
   onStopError: (error) => {
-    console.error(
-      `[bridge] connection shutdown failed: ${sanitizeConnectionError(error)}`,
-    );
+    logger.error("connection shutdown failed", {
+      error: sanitizeConnectionError(error),
+    });
   },
 });
 
@@ -1370,6 +1416,6 @@ process.on("SIGTERM", () => {
 try {
   main();
 } catch (e) {
-  console.error(`[bridge] FATAL: ${(e as Error).message}`);
+  logger.error("fatal startup error", { error: e });
   void shutdownController.request(1);
 }

--- a/server/src/utils/logger.test.ts
+++ b/server/src/utils/logger.test.ts
@@ -85,6 +85,17 @@ describe("log level parsing", () => {
       'invalid log level "trace"; expected error, warn, info, debug',
     );
   });
+
+  test("rejects unstringifiable values without masking the error", () => {
+    expect(() => parseLogLevel(10n)).toThrow(
+      "invalid log level 10; expected error, warn, info, debug",
+    );
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(() => parseLogLevel(circular)).toThrow(
+      "invalid log level [object Object]; expected error, warn, info, debug",
+    );
+  });
 });
 
 describe("recovery reporter", () => {

--- a/server/src/utils/logger.test.ts
+++ b/server/src/utils/logger.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createLogger,
+  createRecoveryReporter,
+  formatLogLine,
+  parseLogLevel,
+} from "./logger";
+
+const NOW = new Date("2026-01-02T03:04:05.678Z");
+
+describe("server logger", () => {
+  test("filters below the configured level and routes warnings to stderr", () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const logger = createLogger({
+      level: "info",
+      scope: "bridge",
+      stdout: (line) => stdout.push(line),
+      stderr: (line) => stderr.push(line),
+      now: () => NOW,
+    });
+
+    logger.debug("hidden request", { method: "workspace.list" });
+    logger.info("listening", { port: 8787 });
+    logger.warn("degraded", { connection: "default" });
+
+    expect(stdout).toEqual([
+      "2026-01-02T03:04:05.678Z INFO bridge listening port=8787",
+    ]);
+    expect(stderr).toEqual([
+      "2026-01-02T03:04:05.678Z WARN bridge degraded connection=default",
+    ]);
+  });
+
+  test("formats child scopes and sanitizes bounded context", () => {
+    const lines: string[] = [];
+    const logger = createLogger({
+      level: "debug",
+      scope: "bridge",
+      stdout: (line) => lines.push(line),
+      now: () => NOW,
+    }).child("terminal");
+
+    logger.debug("frame\nreceived", {
+      terminal: "term-1",
+      detail: `token=private-value ${"x".repeat(400)}`,
+      token: "private-value",
+      url: "https://example.com/login?token=private-value&next=%2F",
+    });
+
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toStartWith(
+      "2026-01-02T03:04:05.678Z DEBUG bridge.terminal frame received",
+    );
+    expect(lines[0]).toContain("terminal=term-1");
+    expect(lines[0]).toContain("token=***");
+    expect(lines[0]).toContain("?token=***&next=%2F");
+    expect(lines[0]).not.toContain("private-value");
+    expect(lines[0]!.length).toBeLessThan(800);
+  });
+
+  test("formats arbitrary lines without control-character injection", () => {
+    expect(
+      formatLogLine({
+        timestamp: NOW,
+        level: "error",
+        scope: "bridge\nspoofed",
+        message: "failed\r\nFAKE ERROR",
+        fields: { "bad key": "a\tb" },
+      }),
+    ).toBe(
+      '2026-01-02T03:04:05.678Z ERROR bridge spoofed failed FAKE ERROR bad_key="a b"',
+    );
+  });
+});
+
+describe("log level parsing", () => {
+  test("accepts supported levels case-insensitively", () => {
+    expect(parseLogLevel("DEBUG")).toBe("debug");
+    expect(parseLogLevel(" warn ")).toBe("warn");
+  });
+
+  test("rejects unsupported levels with the accepted values", () => {
+    expect(() => parseLogLevel("trace")).toThrow(
+      'invalid log level "trace"; expected error, warn, info, debug',
+    );
+  });
+});
+
+describe("recovery reporter", () => {
+  test("deduplicates equivalent failures and summarizes recovery", () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    let now = 1_000;
+    const logger = createLogger({
+      level: "info",
+      scope: "bridge.events",
+      stdout: (line) => stdout.push(line),
+      stderr: (line) => stderr.push(line),
+      now: () => NOW,
+    });
+    const reporter = createRecoveryReporter({
+      logger,
+      failureMessage: "subscription failed",
+      recoveryMessage: "subscription recovered",
+      now: () => now,
+    });
+
+    reporter.failure(new Error("socket unavailable"), {
+      connection: "default",
+    });
+    now += 500;
+    reporter.failure(new Error("socket unavailable"), {
+      connection: "default",
+    });
+    now += 1_500;
+    expect(reporter.recovered({ connection: "default" })).toBe(true);
+    expect(reporter.recovered({ connection: "default" })).toBe(false);
+
+    expect(stderr).toEqual([
+      '2026-01-02T03:04:05.678Z WARN bridge.events subscription failed connection=default error="socket unavailable"',
+    ]);
+    expect(stdout).toEqual([
+      "2026-01-02T03:04:05.678Z INFO bridge.events subscription recovered connection=default failures=2 suppressed=1 duration_ms=2000",
+    ]);
+  });
+});

--- a/server/src/utils/logger.ts
+++ b/server/src/utils/logger.ts
@@ -1,0 +1,263 @@
+export const LOG_LEVELS = ["error", "warn", "info", "debug"] as const;
+
+export type LogLevel = (typeof LOG_LEVELS)[number];
+export type LogFields = Record<string, unknown>;
+
+type LogSink = (line: string) => void;
+
+type LoggerState = {
+  level: LogLevel;
+  stdout: LogSink;
+  stderr: LogSink;
+  now: () => Date;
+};
+
+export type Logger = {
+  enabled(level: LogLevel): boolean;
+  error(message: string, fields?: LogFields): void;
+  warn(message: string, fields?: LogFields): void;
+  info(message: string, fields?: LogFields): void;
+  debug(message: string, fields?: LogFields): void;
+  child(scope: string): Logger;
+};
+
+const LEVEL_RANK: Record<LogLevel, number> = {
+  error: 0,
+  warn: 1,
+  info: 2,
+  debug: 3,
+};
+const MAX_MESSAGE_LENGTH = 500;
+const MAX_FIELD_LENGTH = 300;
+const MAX_FIELDS = 24;
+const SENSITIVE_FIELD =
+  /^(?:password|passphrase|token|secret|cookie|authorization|api[_-]?key|access[_-]?token|refresh[_-]?token)$/i;
+
+function defaultStdout(line: string): void {
+  process.stdout.write(`${line}\n`);
+}
+
+function defaultStderr(line: string): void {
+  process.stderr.write(`${line}\n`);
+}
+
+export function parseLogLevel(value: unknown): LogLevel {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  if ((LOG_LEVELS as readonly string[]).includes(normalized)) {
+    return normalized as LogLevel;
+  }
+  throw new Error(
+    `invalid log level ${JSON.stringify(value)}; expected ${LOG_LEVELS.join(", ")}`,
+  );
+}
+
+function redactSensitiveText(value: string): string {
+  return value
+    .replace(/([a-z][a-z\d+.-]*:\/\/)([^@\s/]+)@/gi, "$1***@")
+    .replace(
+      /([?&](?:access[_-]?token|refresh[_-]?token|api[_-]?key|password|token|secret)=)[^&#\s]+/gi,
+      "$1***",
+    )
+    .replace(
+      /\b((?:proxy-)?authorization)\s*:\s*(bearer|basic)\s+[^\s,;]+/gi,
+      "$1: $2 ***",
+    )
+    .replace(
+      /(["']?)(access[_-]?token|refresh[_-]?token|api[_-]?key|password|passphrase|token|secret)\1(\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,;&}\]]+)/gi,
+      "$1$2$1$3***",
+    );
+}
+
+function sanitizeText(value: string, limit: number): string {
+  return redactSensitiveText(value)
+    .replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, "")
+    .replace(/[\u0000-\u001f\u007f-\u009f]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, limit);
+}
+
+function fieldText(key: string, value: unknown): string {
+  if (SENSITIVE_FIELD.test(key)) return "***";
+  if (value instanceof Error)
+    return sanitizeText(value.message, MAX_FIELD_LENGTH);
+  if (typeof value === "string") return sanitizeText(value, MAX_FIELD_LENGTH);
+  if (
+    value === null ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint"
+  ) {
+    return String(value);
+  }
+  try {
+    return sanitizeText(JSON.stringify(value), MAX_FIELD_LENGTH);
+  } catch {
+    try {
+      return sanitizeText(String(value), MAX_FIELD_LENGTH);
+    } catch {
+      return "[unprintable]";
+    }
+  }
+}
+
+function quoteField(value: string): string {
+  return value && !/[\s="\\]/.test(value) ? value : JSON.stringify(value);
+}
+
+export function formatLogLine(args: {
+  timestamp: Date;
+  level: LogLevel;
+  scope: string;
+  message: string;
+  fields?: LogFields;
+}): string {
+  const parts = [
+    args.timestamp.toISOString(),
+    args.level.toUpperCase(),
+    sanitizeText(args.scope, MAX_FIELD_LENGTH) || "bridge",
+    sanitizeText(args.message, MAX_MESSAGE_LENGTH) || "log",
+  ];
+  if (args.fields) {
+    let emitted = 0;
+    for (const [rawKey, value] of Object.entries(args.fields)) {
+      if (value === undefined || emitted >= MAX_FIELDS) continue;
+      const key = rawKey.replace(/[^A-Za-z0-9_.-]/g, "_").slice(0, 64);
+      if (!key) continue;
+      parts.push(`${key}=${quoteField(fieldText(key, value))}`);
+      emitted += 1;
+    }
+  }
+  return parts.join(" ");
+}
+
+function createScopedLogger(state: LoggerState, scope: string): Logger {
+  function enabled(level: LogLevel): boolean {
+    return LEVEL_RANK[level] <= LEVEL_RANK[state.level];
+  }
+
+  function emit(level: LogLevel, message: string, fields?: LogFields): void {
+    if (!enabled(level)) return;
+    const line = formatLogLine({
+      timestamp: state.now(),
+      level,
+      scope,
+      message,
+      fields,
+    });
+    (level === "error" || level === "warn" ? state.stderr : state.stdout)(line);
+  }
+
+  return {
+    enabled,
+    error: (message, fields) => emit("error", message, fields),
+    warn: (message, fields) => emit("warn", message, fields),
+    info: (message, fields) => emit("info", message, fields),
+    debug: (message, fields) => emit("debug", message, fields),
+    child: (childScope) =>
+      createScopedLogger(
+        state,
+        [scope, sanitizeText(childScope, 100)].filter(Boolean).join("."),
+      ),
+  };
+}
+
+export function createLogger(
+  args: {
+    level?: LogLevel;
+    scope?: string;
+    stdout?: LogSink;
+    stderr?: LogSink;
+    now?: () => Date;
+  } = {},
+): Logger {
+  return createScopedLogger(
+    {
+      level: args.level ?? "info",
+      stdout: args.stdout ?? defaultStdout,
+      stderr: args.stderr ?? defaultStderr,
+      now: args.now ?? (() => new Date()),
+    },
+    args.scope ?? "bridge",
+  );
+}
+
+const serverLoggerState: LoggerState = {
+  level: "info",
+  stdout: defaultStdout,
+  stderr: defaultStderr,
+  now: () => new Date(),
+};
+
+export const serverLogger = createScopedLogger(serverLoggerState, "bridge");
+
+export function configureServerLogger(level: LogLevel): void {
+  serverLoggerState.level = level;
+}
+
+export const silentLogger: Logger = {
+  enabled: () => false,
+  error: () => undefined,
+  warn: () => undefined,
+  info: () => undefined,
+  debug: () => undefined,
+  child: () => silentLogger,
+};
+
+type ActiveFailure = {
+  signature: string;
+  failures: number;
+  startedAt: number;
+};
+
+export type RecoveryReporter = {
+  failure(error: unknown, fields?: LogFields): void;
+  recovered(fields?: LogFields): boolean;
+  active(): boolean;
+};
+
+export function createRecoveryReporter(args: {
+  logger: Logger;
+  failureMessage: string;
+  recoveryMessage: string;
+  now?: () => number;
+}): RecoveryReporter {
+  const now = args.now ?? Date.now;
+  let current: ActiveFailure | null = null;
+
+  return {
+    failure(error, fields) {
+      const detail = fieldText("error", error);
+      if (current?.signature === detail) {
+        current.failures += 1;
+        args.logger.debug(args.failureMessage, {
+          ...fields,
+          error: detail,
+          repeat: current.failures,
+        });
+        return;
+      }
+      current = {
+        signature: detail,
+        failures: 1,
+        startedAt: now(),
+      };
+      args.logger.warn(args.failureMessage, { ...fields, error: detail });
+    },
+    recovered(fields) {
+      if (!current) return false;
+      const durationMs = Math.max(0, now() - current.startedAt);
+      args.logger.info(args.recoveryMessage, {
+        ...fields,
+        failures: current.failures,
+        suppressed: Math.max(0, current.failures - 1),
+        duration_ms: durationMs,
+      });
+      current = null;
+      return true;
+    },
+    active: () => current !== null,
+  };
+}

--- a/server/src/utils/logger.ts
+++ b/server/src/utils/logger.ts
@@ -48,8 +48,10 @@ export function parseLogLevel(value: unknown): LogLevel {
   if ((LOG_LEVELS as readonly string[]).includes(normalized)) {
     return normalized as LogLevel;
   }
+  const rendered =
+    typeof value === "string" ? JSON.stringify(value) : renderValue(value);
   throw new Error(
-    `invalid log level ${JSON.stringify(value)}; expected ${LOG_LEVELS.join(", ")}`,
+    `invalid log level ${rendered}; expected ${LOG_LEVELS.join(", ")}`,
   );
 }
 
@@ -79,8 +81,7 @@ function sanitizeText(value: string, limit: number): string {
     .slice(0, limit);
 }
 
-function fieldText(key: string, value: unknown): string {
-  if (SENSITIVE_FIELD.test(key)) return "***";
+function renderValue(value: unknown): string {
   if (value instanceof Error)
     return sanitizeText(value.message, MAX_FIELD_LENGTH);
   if (typeof value === "string") return sanitizeText(value, MAX_FIELD_LENGTH);
@@ -101,6 +102,11 @@ function fieldText(key: string, value: unknown): string {
       return "[unprintable]";
     }
   }
+}
+
+function fieldText(key: string, value: unknown): string {
+  if (SENSITIVE_FIELD.test(key)) return "***";
+  return renderValue(value);
 }
 
 function quoteField(value: string): string {

--- a/server/src/utils/rpc-logging.test.ts
+++ b/server/src/utils/rpc-logging.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { isExpectedRpcError, rpcLogLevel } from "./rpc-logging";
+
+describe("RPC log classification", () => {
+  test("keeps successful summaries at debug", () => {
+    expect(rpcLogLevel({ method: "workspace.list", status: "ok" })).toBe(
+      "debug",
+    );
+  });
+
+  test("classifies expected request-state errors as debug", () => {
+    expect(
+      isExpectedRpcError(
+        "git.diff_summary",
+        "workspace is not inside a git repository",
+      ),
+    ).toBe(true);
+    expect(isExpectedRpcError("terminal.resize", "no terminal attached")).toBe(
+      true,
+    );
+    expect(
+      isExpectedRpcError("workspace.list", "connection changed during request"),
+    ).toBe(true);
+    expect(
+      isExpectedRpcError(
+        "workspace.list",
+        "connection runtime generation is unavailable",
+      ),
+    ).toBe(true);
+  });
+
+  test("keeps unexpected request failures visible as warnings", () => {
+    expect(
+      rpcLogLevel({
+        method: "git.diff_summary",
+        status: "error",
+        detail: "git process timed out",
+      }),
+    ).toBe("warn");
+  });
+});

--- a/server/src/utils/rpc-logging.ts
+++ b/server/src/utils/rpc-logging.ts
@@ -1,5 +1,9 @@
-import { NO_TERMINAL_ATTACHED_MESSAGE } from "../bridge/terminal-bridge";
 import type { LogLevel } from "./logger";
+
+// RPC error text for terminal calls made before a terminal is attached. The
+// terminal bridge throws this exact message and the classifier below treats
+// it as an expected detach race, so both sides share one constant.
+export const NO_TERMINAL_ATTACHED_MESSAGE = "no terminal attached";
 
 export function isExpectedRpcError(
   method: string | null,

--- a/server/src/utils/rpc-logging.ts
+++ b/server/src/utils/rpc-logging.ts
@@ -1,0 +1,39 @@
+import { NO_TERMINAL_ATTACHED_MESSAGE } from "../bridge/terminal-bridge";
+import type { LogLevel } from "./logger";
+
+export function isExpectedRpcError(
+  method: string | null,
+  detail: string | undefined,
+): boolean {
+  const message = detail?.toLowerCase() ?? "";
+  if (!message) return false;
+  if (message.includes("connection changed during request")) return true;
+  if (
+    message.includes("connection runtime generation") ||
+    message.includes("connection is not ready")
+  ) {
+    return true;
+  }
+  if (
+    method === "git.diff_summary" &&
+    /not (?:inside )?a git repository/.test(message)
+  ) {
+    return true;
+  }
+  if (
+    method?.startsWith("terminal.") &&
+    message === NO_TERMINAL_ATTACHED_MESSAGE
+  ) {
+    return true;
+  }
+  return false;
+}
+
+export function rpcLogLevel(args: {
+  method: string | null;
+  status: "ok" | "error";
+  detail?: string;
+}): LogLevel {
+  if (args.status === "ok") return "debug";
+  return isExpectedRpcError(args.method, args.detail) ? "debug" : "warn";
+}

--- a/server/src/workspace/auto-sync.ts
+++ b/server/src/workspace/auto-sync.ts
@@ -8,6 +8,12 @@ import {
   updateGuiSettings,
   workspaceAutoSyncSettingsKey,
 } from "../config/gui-settings";
+import {
+  createRecoveryReporter,
+  type Logger,
+  type RecoveryReporter,
+  silentLogger,
+} from "../utils/logger";
 import { GIT_PULL_TIMEOUT_MS } from "./file-constants";
 import type { RunProcessWithCodeTimeout } from "./file-types";
 
@@ -216,6 +222,7 @@ export async function syncWorkspaceBranch({
 export function createWorkspaceAutoSync(args: {
   connectionId?: string;
   formatError?: (error: unknown) => string;
+  logger?: Logger;
   herdr: HerdrClient;
   sshHost: () => string | undefined;
   shQuote: (value: string) => string;
@@ -226,6 +233,7 @@ export function createWorkspaceAutoSync(args: {
   updateSettings?: typeof updateGuiSettings;
   syncBranch?: typeof syncWorkspaceBranch;
 }) {
+  const logger = args.logger ?? silentLogger;
   const readSettings = args.readSettings ?? readGuiSettings;
   const updateSettings = args.updateSettings ?? updateGuiSettings;
   const syncBranch = args.syncBranch ?? syncWorkspaceBranch;
@@ -236,7 +244,13 @@ export function createWorkspaceAutoSync(args: {
         .replace(/\s+/g, " ")
         .trim()
         .slice(0, 2_000));
-  const connectionDetail = `connection=${args.connectionId ?? "legacy-default"}`;
+  const connectionId = args.connectionId ?? "legacy-default";
+  const syncFailureReporters = new Map<string, RecoveryReporter>();
+  const tickFailureReporter = createRecoveryReporter({
+    logger,
+    failureMessage: "workspace auto-sync tick failed",
+    recoveryMessage: "workspace auto-sync tick recovered",
+  });
   let timer: ReturnType<typeof setInterval> | null = null;
   let started = false;
   let lifecycleGeneration = 0;
@@ -248,6 +262,19 @@ export function createWorkspaceAutoSync(args: {
 
   function current(generation: number) {
     return started && lifecycleGeneration === generation;
+  }
+
+  function syncFailureReporter(key: string): RecoveryReporter {
+    let reporter = syncFailureReporters.get(key);
+    if (!reporter) {
+      reporter = createRecoveryReporter({
+        logger,
+        failureMessage: "workspace auto-sync failed",
+        recoveryMessage: "workspace auto-sync recovered",
+      });
+      syncFailureReporters.set(key, reporter);
+    }
+    return reporter;
   }
 
   async function recordResult(
@@ -374,12 +401,11 @@ export function createWorkspaceAutoSync(args: {
         const { workspace, root } = target;
         forcedKeys.delete(key);
         runningKeys.add(key);
-        console.log(
-          "[bridge] workspace auto-sync started",
-          connectionDetail,
-          `workspace=${workspace.workspace_id ?? "unknown"}`,
-          `path=${root}`,
-        );
+        logger.debug("workspace auto-sync started", {
+          connection: connectionId,
+          workspace: workspace.workspace_id ?? "unknown",
+          path: root,
+        });
         let result: SyncResult;
         try {
           result = await syncBranch({
@@ -401,19 +427,26 @@ export function createWorkspaceAutoSync(args: {
         }
         await recordResult(generation, key, root, host, result);
         if (!current(generation)) return;
-        console.log(
-          "[bridge] workspace auto-sync finished",
-          connectionDetail,
-          `workspace=${workspace.workspace_id ?? "unknown"}`,
-          `status=${result.last_status ?? "failed"}`,
-          `detail=${formatError(result.last_message ?? "")}`,
-        );
+        const resultFields = {
+          connection: connectionId,
+          workspace: workspace.workspace_id ?? "unknown",
+          status: result.last_status ?? "failed",
+          detail: formatError(result.last_message ?? ""),
+        };
+        const reporter = syncFailureReporter(key);
+        if (result.last_status === "failed") {
+          reporter.failure(result.last_message ?? "sync failed", resultFields);
+        } else {
+          reporter.recovered(resultFields);
+          logger.debug("workspace auto-sync finished", resultFields);
+        }
       }
+      tickFailureReporter.recovered({ connection: connectionId });
     } catch (error) {
       if (current(generation)) {
-        console.warn(
-          `[bridge] workspace auto-sync tick failed ${connectionDetail}: ${formatError(error)}`,
-        );
+        tickFailureReporter.failure(formatError(error), {
+          connection: connectionId,
+        });
       }
     }
   }

--- a/server/src/worktree/remove.ts
+++ b/server/src/worktree/remove.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 import { realpath, rename } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { sshCommandArgv } from "../bridge/ssh-command";
+import { serverLogger } from "../utils/logger";
 
 type RunProcessWithCodeTimeout = (
   argv: string[],
@@ -205,7 +206,10 @@ export async function removeWorktreeWithRecovery({
   params,
   checkoutPath,
   runtime,
-  log = console.warn,
+  log = (message) =>
+    serverLogger
+      .child("worktree")
+      .warn("cleanup warning", { detail: message.replace(/^\[bridge\] /, "") }),
 }: {
   call: HerdrCall;
   params: Record<string, unknown>;


### PR DESCRIPTION
## Summary

Implements the logging optimization proposed in #82.

- Add a structured server logger (`TIMESTAMP LEVEL scope message key=value`) with `error`/`warn`/`info`/`debug` levels, bounded field sizes, and redaction of tokens, passwords, and authorization values
- Add `--log-level` CLI flag and `HERDR_GUI_LOG_LEVEL` env var (CLI wins; invalid values exit 2 with a clear error); default is `info`
- Move high-volume normal traffic to `debug`: Herdr events, RPC summaries, terminal frames/resizes, successful auto-sync rounds, client connect/disconnect, SSH tunnel setup
- Classify expected request errors as `debug` (`git.diff_summary` outside git repositories, terminal detach races, connection-generation changes); unexpected request failures stay `warn`
- Deduplicate repeated retry failures per error signature: the first failure warns, repeats are suppressed, and recovery logs one summary with failure count and duration; removes the duplicated `[herdr]` / `[bridge] subscribe` reporting
- Stop printing token-bearing browser/LAN URLs in runtime and service logs; the tokenized URL is only passed to the browser launcher and the token file path is logged instead

## Verification

- `bun run precommit` — 853 tests pass, 0 fail
- `bun run build`
- Startup smoke test of the compiled binary: structured line format, no token in logged URLs, invalid `--log-level` exits 2
- End-to-end against a live Herdr 0.8.2 server: a 5s outage produced one warning per distinct failure signature, and restart logged `event subscription recovered failures=2 suppressed=1 duration_ms=4109`

Closes #82
