### PR TITLE
Polish Inspector, Files explorer, and Diff Viewer chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@
   mutating so stale menus can't destroy newer work.
 - Dim Git-ignored files in the Files explorer.
 
+### Changed
+
+- Pressing Esc no longer collapses or closes the Inspector now that it docks
+  beside the content instead of covering it; use the header buttons to
+  expand, restore, or close it.
+- Simplify the Files explorer rows to show only the file or folder name; the
+  full path remains available as a hover tooltip.
+
 ### Fixed
 
 - Parse C-style quoted Git paths (spaces, quotes, backslashes) in Changes

--- a/docs/workspace-resource-inspector-design.md
+++ b/docs/workspace-resource-inspector-design.md
@@ -557,8 +557,8 @@ Existing shortcuts keep their key bindings but become context-resolved:
 - Ctrl+Shift+G: toggle Changes for the active tab workspace.
 - Ctrl+Shift+W: focus Workspace navigation.
 - Cmd/Ctrl+F: search the currently focused terminal/resource surface.
-- Escape: close transient search/menu state first, then close expanded mode or
-  the Inspector according to existing escape priority.
+- Escape: close transient search/menu/notification state; it no longer
+  closes expanded mode or the Inspector (use the header buttons instead).
 
 Focus rules:
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2039,20 +2039,6 @@ export default function App() {
           if (canDismissUpdate) store.dismissUpdate();
           return;
         }
-        const inspector = inspectorStateRef.current;
-        if (inspector?.expanded) {
-          e.preventDefault();
-          e.stopPropagation();
-          const next = { ...inspector, expanded: false };
-          commitInspectorState(next);
-          writeInspectorPreferences(localStorage, next);
-          return;
-        }
-        if (inspector?.open) {
-          e.preventDefault();
-          e.stopPropagation();
-          closeInspector();
-        }
         return;
       }
       const tabAction = tabShortcutAction(e);
@@ -2190,10 +2176,7 @@ export default function App() {
       window.removeEventListener("blur", onBlur);
     };
   }, [
-    activateTerminalSurface,
-    closeInspector,
     closePaneJump,
-    commitInspectorState,
     commitPaneJump,
     defaultPaneJumpIndex,
     movePaneJumpSelection,

--- a/web/src/components/DiffContentView.tsx
+++ b/web/src/components/DiffContentView.tsx
@@ -42,6 +42,7 @@ import type {
   GitDiffKind,
 } from "../types";
 import { connectionClientScopeKey } from "../useConnectionClient";
+import { gitDiffCode, gitDiffCodeLabel } from "../gitDiffStatus";
 import { requestFilePreview } from "./FileExplorerDialog";
 import {
   AnnotationComposerPopover,
@@ -515,6 +516,15 @@ const DiffFileSection = memo(function DiffFileSection({
     onSelectFile?.(section.entry);
   };
 
+  const statusCode = gitDiffCode(section.entry);
+  const metaNote = [
+    section.autoCollapse?.label ?? null,
+    section.file?.truncated ? "truncated" : null,
+    section.collapsed && section.autoCollapse ? "auto-collapsed" : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
   return (
     <article
       className={`diff-file-section ${embedded ? "is-embedded" : ""} ${currentSearchMatch ? "is-search-current" : ""}`}
@@ -546,14 +556,17 @@ const DiffFileSection = memo(function DiffFileSection({
           </button>
           <div className="diff-file-section-title">
             <strong>{section.entry.path}</strong>
-            <span>
-              {section.entry.kind} · {section.entry.status}
-              {section.autoCollapse ? ` · ${section.autoCollapse.label}` : ""}
-              {section.file?.truncated ? " · truncated" : ""}
-              {section.collapsed && section.autoCollapse
-                ? " · auto-collapsed"
-                : ""}
+            <span
+              className={`git-status-code git-status-${statusCode.toLowerCase()}`}
+              role="img"
+              aria-label={gitDiffCodeLabel(statusCode)}
+              title={gitDiffCodeLabel(statusCode)}
+            >
+              {statusCode}
             </span>
+            {metaNote ? (
+              <span className="diff-file-section-meta">{metaNote}</span>
+            ) : null}
           </div>
           <button
             type="button"
@@ -1336,37 +1349,37 @@ export function DiffContentView({
               ) : null}
             </div>
           ) : null}
-          {!mobile ? (
-            <div className="diff-display-controls">
-              <div className="diff-view-toggle" aria-label="Diff view mode">
-                <button
-                  type="button"
-                  className={viewMode === "split" ? "is-active" : ""}
-                  onClick={() => setViewMode("split")}
-                  aria-pressed={viewMode === "split"}
-                >
-                  Split
-                </button>
-                <button
-                  type="button"
-                  className={viewMode === "unified" ? "is-active" : ""}
-                  onClick={() => setViewMode("unified")}
-                  aria-pressed={viewMode === "unified"}
-                >
-                  Unified
-                </button>
-              </div>
+        </div>
+        {!mobile ? (
+          <div className="diff-display-controls">
+            <div className="diff-view-toggle" aria-label="Diff view mode">
               <button
                 type="button"
-                className={`diff-wrap-toggle ${desktopWrap ? "is-active" : ""}`}
-                onClick={() => setDesktopWrap((value) => !value)}
-                aria-pressed={desktopWrap}
+                className={viewMode === "split" ? "is-active" : ""}
+                onClick={() => setViewMode("split")}
+                aria-pressed={viewMode === "split"}
               >
-                {desktopWrap ? "Wrap" : "No wrap"}
+                Split
+              </button>
+              <button
+                type="button"
+                className={viewMode === "unified" ? "is-active" : ""}
+                onClick={() => setViewMode("unified")}
+                aria-pressed={viewMode === "unified"}
+              >
+                Unified
               </button>
             </div>
-          ) : null}
-        </div>
+            <button
+              type="button"
+              className={`diff-wrap-toggle ${desktopWrap ? "is-active" : ""}`}
+              onClick={() => setDesktopWrap((value) => !value)}
+              aria-pressed={desktopWrap}
+            >
+              {desktopWrap ? "Wrap" : "No wrap"}
+            </button>
+          </div>
+        ) : null}
       </div>
 
       {error && !visibleEntries.length ? (

--- a/web/src/components/FileExplorerDialog.tsx
+++ b/web/src/components/FileExplorerDialog.tsx
@@ -2102,14 +2102,13 @@ function FileExplorerContent({
               <File size={16} />
             )}
           </span>
-          <span className="file-main">
-            <span
-              className="file-name"
-              title={entry.ignored ? "Ignored by Git" : undefined}
-            >
-              {entry.name}
-            </span>
-            <span className="file-path">{entry.path}</span>
+          <span
+            className="file-name"
+            title={
+              entry.ignored ? `${entry.path} · Ignored by Git` : entry.path
+            }
+          >
+            {entry.name}
           </span>
           {gitStatus ? (
             <span

--- a/web/src/components/WorkspaceInspectorHost.tsx
+++ b/web/src/components/WorkspaceInspectorHost.tsx
@@ -663,7 +663,9 @@ export function WorkspaceInspectorHost({
           <button
             type="button"
             className="workspace-inspector-expand-action"
-            title={state.expanded ? "Restore dock" : "Expand Inspector"}
+            title={
+              state.expanded ? "Restore Inspector dock" : "Expand Inspector"
+            }
             aria-label={
               state.expanded ? "Restore Inspector dock" : "Expand Inspector"
             }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4823,12 +4823,12 @@ textarea:focus {
   color: var(--text-strong);
 }
 .file-row.is-ignored .file-icon,
-.file-row.is-ignored .file-main,
+.file-row.is-ignored .file-name,
 .file-row.is-ignored .file-meta {
   opacity: 0.48;
 }
 .file-row.is-ignored:hover .file-icon,
-.file-row.is-ignored:hover .file-main,
+.file-row.is-ignored:hover .file-name,
 .file-row.is-ignored:hover .file-meta {
   opacity: 0.7;
 }
@@ -5536,8 +5536,10 @@ textarea:focus {
   justify-content: space-between;
   flex-wrap: wrap;
   gap: 10px;
-  min-height: 42px;
-  padding: 8px 12px;
+  /* Same height as the navigation header (scope toggle block + its
+     margin), so both header rows read as one line. */
+  min-height: 46px;
+  padding: 7px 12px;
   border-bottom: 1px solid var(--viewer-border);
   background: var(--viewer-header-bg);
 }
@@ -5549,9 +5551,13 @@ textarea:focus {
 .diff-content-view.is-embedded .diff-content-actions {
   flex-basis: auto;
 }
+.diff-content-view.is-embedded .diff-display-controls {
+  order: 3;
+}
 .diff-content-title {
   min-width: 0;
-  flex: 1 1 160px;
+  /* Grow so the display controls and search cluster stay right-aligned. */
+  flex: 1 1 auto;
   display: grid;
   gap: 1px;
 }
@@ -5568,8 +5574,11 @@ textarea:focus {
 }
 .diff-content-actions {
   min-width: 0;
-  max-width: 100%;
-  flex: 1 1 420px;
+  max-width: min(560px, 100%);
+  /* After the display controls: on narrow widths the search wraps to its
+     own full-width row below the title row. */
+  order: 2;
+  flex: 1 1 220px;
   display: inline-flex;
   align-items: center;
   justify-content: flex-end;
@@ -5587,8 +5596,8 @@ textarea:focus {
   background: var(--viewer-content-bg);
 }
 .diff-hunk-navigation button {
-  width: 26px;
-  height: 26px;
+  width: 24px;
+  height: 24px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -5623,6 +5632,7 @@ textarea:focus {
 }
 .diff-display-controls {
   flex: 0 0 auto;
+  order: 1;
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -5766,22 +5776,23 @@ textarea:focus {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  min-height: 48px;
-  padding: 8px 12px;
+  gap: 8px;
+  min-height: 38px;
+  padding: 5px 10px;
   border-bottom: 1px solid var(--viewer-border);
   background: color-mix(in srgb, var(--viewer-header-bg) 88%, var(--diff-bg));
 }
 .diff-file-section-title {
   flex: 1 1 auto;
   min-width: 0;
-  display: grid;
-  gap: 2px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 .diff-file-collapse {
   flex: 0 0 auto;
-  width: 36px;
-  height: 36px;
+  width: 28px;
+  height: 28px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -5800,7 +5811,7 @@ textarea:focus {
   opacity: 0.45;
 }
 .diff-file-section-title strong,
-.diff-file-section-title span {
+.diff-file-section-meta {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -5810,7 +5821,8 @@ textarea:focus {
   color: var(--text-strong);
   font-size: 13px;
 }
-.diff-file-section-title span {
+.diff-file-section-meta {
+  flex: 0 1 auto;
   color: var(--muted);
   font-size: 11px;
 }
@@ -5819,7 +5831,7 @@ textarea:focus {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  min-height: 30px;
+  min-height: 28px;
   padding: 0 9px;
   border-radius: 8px;
   background: var(--viewer-content-bg);
@@ -6409,26 +6421,13 @@ textarea:focus {
   justify-content: center;
   color: var(--muted);
 }
-.file-main {
-  min-width: 0;
-  display: grid;
-  gap: 1px;
-}
-.file-name,
-.file-path {
+.file-name {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-.file-name {
   color: var(--text);
   font-weight: 600;
-}
-.file-path {
-  color: var(--muted);
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 11px;
 }
 .file-meta {
   color: var(--muted);
@@ -8695,6 +8694,7 @@ textarea:focus {
   .diff-content-actions {
     flex: 1 1 100%;
     min-width: 0;
+    max-width: 100%;
   }
   .diff-search-controls {
     flex-basis: 100%;
@@ -8705,9 +8705,6 @@ textarea:focus {
   }
   .diff-search-count {
     min-width: 36px;
-  }
-  .diff-file-section-head {
-    align-items: flex-start;
   }
   .diff-file-open span {
     display: none;


### PR DESCRIPTION
## Summary

- **Escape no longer closes the Inspector.** Now that the Inspector docks beside the content instead of covering it fullscreen, dropping the Esc-to-dismiss behavior avoids accidental closes; expand, restore, and close stay on the header buttons.
- **Files explorer rows show only the entry name.** The relative path under each name was redundant with the basename; the full path is now a hover tooltip (ignored files keep their marker).
- **Diff Viewer header alignment and tidy wrapping.** The content header matches the Changes list header height so both columns start on the same line, and the view/wrap controls reorder so narrow widths wrap into a clean title row plus a full-width search row instead of orphaned buttons.
- **Slimmer changed-file section headers.** Each collapsible diff file header is now a single row and reuses the existing `git-status-code` badge (M/A/D/U/C with tooltip) instead of the `kind · status` text subtitle.
- Tooltip for the Inspector expand button now matches its aria-label; the inspector design doc and changelog are updated.

## Verification

- `bun run precommit` (format, lint, typecheck, 855 unit tests) — green
- `bun run build:web` — green
- Public-content audit — clean

Reviewed by a 3-angle automated review round (correctness, layout cascade, tests/simplicity): no blockers; P2 notes either applied (stale effect deps, header-height comment, hunk-nav sizing, design-doc drift) or deferred (pre-existing dead `.diff-file-row` CSS).

## Screenshots

UI changes — verified locally via `bun run dev:web` across wide and narrow Inspector widths; screenshots to follow in comments if needed.