### PR TITLE
Add pane focus and split keyboard shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- Add pane keyboard shortcuts: `Cmd+Ctrl+Arrow` focuses the neighboring pane,
+  `Cmd+D` splits the active pane right, and `Cmd+Shift+D` splits it down.
+
 ## 0.5.0 - 2026-09-02
 
 ### Added

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -290,14 +290,17 @@ The in-app reference is available from **Menu → Keyboard shortcuts**.
 | `Cmd+T` | Create a tab in the focused workspace |
 | `Cmd+W` | Close the focused tab |
 | `Cmd+Option+Left` / `Cmd+Option+Right` | Switch tabs, wrapping at either end |
+| `Cmd+Ctrl+Left` / `Cmd+Ctrl+Right` / `Cmd+Ctrl+Up` / `Cmd+Ctrl+Down` | Focus the neighboring pane |
+| `Cmd+D` | Split the active pane right |
+| `Cmd+Shift+D` | Split the active pane down |
 | `Ctrl+1` … `Ctrl+9` | Switch to a numbered tab in the focused workspace |
 | `Ctrl+Shift+W` | Open Workspaces |
 | `Cmd/Ctrl+Shift+E` | Toggle File Explorer |
 | `Ctrl+Shift+G` | Open Diff Viewer |
 | `Esc` | Dismiss the current menu, dialog, notification, or update banner |
 
-A host browser can reserve shortcuts such as `Cmd+T` and `Cmd+W`; they are most
-reliable in an installed PWA or another standalone/webview host.
+A host browser can reserve shortcuts such as `Cmd+T`, `Cmd+W`, and `Cmd+D`;
+they are most reliable in an installed PWA or another standalone/webview host.
 
 ### Terminal
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2109,13 +2109,11 @@ export default function App() {
           current.tabs.find(
             (tab) => tab.tab_id === focusedWorkspace?.active_tab_id,
           ) ?? current.tabs.find((tab) => tab.focused);
+        // Resolve the selection only while it belongs to the visible layout,
+        // then fall back to tab-local panes like the command menu does.
+        const layoutActivePaneId = activePaneIdForSnapshot(current);
         const activePane =
-          current.panes.find(
-            (pane) => pane.pane_id === current.selectedPaneId,
-          ) ??
-          current.panes.find(
-            (pane) => pane.pane_id === current.layout?.focused_pane_id,
-          ) ??
+          current.panes.find((pane) => pane.pane_id === layoutActivePaneId) ??
           current.panes.find(
             (pane) => pane.tab_id === activeTab?.tab_id && pane.focused,
           ) ??

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -90,6 +90,7 @@ import {
   WORKTREE_REMOVED_EVENT,
   type WorktreeRemovedTarget,
 } from "./store";
+import { paneShortcutAction } from "./paneShortcuts";
 import { adjacentTabId, tabShortcutAction } from "./tabShortcuts";
 import { copyTextFromUserGesture } from "./terminalClipboard";
 import {
@@ -2086,6 +2087,48 @@ export default function App() {
         const targetTabId = adjacentTabId(tabs, activeTabId, tabAction);
         if (!targetTabId || targetTabId === activeTabId) return;
         store.focusTab(targetTabId);
+        return;
+      }
+      const paneAction = paneShortcutAction(e);
+      if (paneAction) {
+        // Browser-level Cmd+D may still be reserved by the host browser, but
+        // standalone/webview clients can route it through this handler.
+        e.preventDefault();
+        e.stopPropagation();
+        if (
+          isEditableElement(e.target) ||
+          document.querySelector(".modal-backdrop")
+        ) {
+          return;
+        }
+        if (e.repeat && paneAction.type === "split") return;
+
+        const current = store.get();
+        const focusedWorkspace = current.workspaces.find((w) => w.focused);
+        const activeTab =
+          current.tabs.find(
+            (tab) => tab.tab_id === focusedWorkspace?.active_tab_id,
+          ) ?? current.tabs.find((tab) => tab.focused);
+        const activePane =
+          current.panes.find(
+            (pane) => pane.pane_id === current.selectedPaneId,
+          ) ??
+          current.panes.find(
+            (pane) => pane.pane_id === current.layout?.focused_pane_id,
+          ) ??
+          current.panes.find(
+            (pane) => pane.tab_id === activeTab?.tab_id && pane.focused,
+          ) ??
+          current.panes.find((pane) => pane.tab_id === activeTab?.tab_id);
+        if (!activePane) return;
+        if (paneAction.type === "split") {
+          void store.splitPane(activePane.pane_id, paneAction.direction);
+        } else {
+          void store.focusPaneDirection(
+            activePane.pane_id,
+            paneAction.direction,
+          );
+        }
         return;
       }
       const tabIndex = tabShortcutIndex(e);

--- a/web/src/components/ShortcutLookupDialog.tsx
+++ b/web/src/components/ShortcutLookupDialog.tsx
@@ -31,6 +31,12 @@ const SHORTCUT_GROUPS: ShortcutGroup[] = [
         keys: "Cmd+Option+Left / Right",
         description: "Switch tabs in the focused workspace",
       },
+      {
+        keys: "Cmd+Ctrl+Left / Right / Up / Down",
+        description: "Focus the neighboring pane",
+      },
+      { keys: "Cmd+D", description: "Split the active pane right" },
+      { keys: "Cmd+Shift+D", description: "Split the active pane down" },
       { keys: "Ctrl+Shift+W", description: "Open Workspaces" },
       {
         keys: "Cmd/Ctrl + Shift + E",

--- a/web/src/paneShortcuts.test.ts
+++ b/web/src/paneShortcuts.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { paneShortcutAction } from "./paneShortcuts";
+
+function keyEvent(
+  overrides: Partial<Parameters<typeof paneShortcutAction>[0]> = {},
+): Parameters<typeof paneShortcutAction>[0] {
+  return {
+    key: "",
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    ...overrides,
+  };
+}
+
+describe("pane shortcuts", () => {
+  test("maps Cmd+Ctrl+Arrows to directional pane focus", () => {
+    expect(
+      paneShortcutAction(
+        keyEvent({ key: "ArrowLeft", metaKey: true, ctrlKey: true }),
+      ),
+    ).toEqual({ type: "focus", direction: "left" });
+    expect(
+      paneShortcutAction(
+        keyEvent({ key: "ArrowRight", metaKey: true, ctrlKey: true }),
+      ),
+    ).toEqual({ type: "focus", direction: "right" });
+    expect(
+      paneShortcutAction(
+        keyEvent({ key: "ArrowUp", metaKey: true, ctrlKey: true }),
+      ),
+    ).toEqual({ type: "focus", direction: "up" });
+    expect(
+      paneShortcutAction(
+        keyEvent({ key: "ArrowDown", metaKey: true, ctrlKey: true }),
+      ),
+    ).toEqual({ type: "focus", direction: "down" });
+  });
+
+  test("maps Cmd+D and Cmd+Shift+D to pane splits", () => {
+    expect(paneShortcutAction(keyEvent({ key: "d", metaKey: true }))).toEqual({
+      type: "split",
+      direction: "right",
+    });
+    expect(
+      paneShortcutAction(keyEvent({ key: "D", metaKey: true, shiftKey: true })),
+    ).toEqual({ type: "split", direction: "down" });
+  });
+
+  test("rejects extra or missing modifiers", () => {
+    // Cmd+Option+Arrows belong to tab switching.
+    expect(
+      paneShortcutAction(
+        keyEvent({ key: "ArrowLeft", metaKey: true, altKey: true }),
+      ),
+    ).toBeNull();
+    expect(
+      paneShortcutAction(keyEvent({ key: "ArrowLeft", ctrlKey: true })),
+    ).toBeNull();
+    expect(
+      paneShortcutAction(keyEvent({ key: "ArrowLeft", metaKey: true })),
+    ).toBeNull();
+    expect(
+      paneShortcutAction(keyEvent({ key: "d", ctrlKey: true })),
+    ).toBeNull();
+    expect(
+      paneShortcutAction(keyEvent({ key: "d", metaKey: true, ctrlKey: true })),
+    ).toBeNull();
+    expect(
+      paneShortcutAction(keyEvent({ key: "a", metaKey: true, ctrlKey: true })),
+    ).toBeNull();
+    expect(
+      paneShortcutAction(
+        keyEvent({ key: "D", metaKey: true, ctrlKey: true, shiftKey: true }),
+      ),
+    ).toBeNull();
+    expect(
+      paneShortcutAction(keyEvent({ key: "d", metaKey: true, altKey: true })),
+    ).toBeNull();
+    expect(
+      paneShortcutAction(
+        keyEvent({
+          key: "ArrowLeft",
+          metaKey: true,
+          ctrlKey: true,
+          shiftKey: true,
+        }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/web/src/paneShortcuts.ts
+++ b/web/src/paneShortcuts.ts
@@ -1,0 +1,39 @@
+export type PaneShortcutDirection = "left" | "right" | "up" | "down";
+
+export type PaneShortcutAction =
+  | { type: "focus"; direction: PaneShortcutDirection }
+  | { type: "split"; direction: "right" | "down" };
+
+type PaneShortcutEvent = Pick<
+  KeyboardEvent,
+  "key" | "metaKey" | "ctrlKey" | "altKey" | "shiftKey"
+>;
+
+const ARROW_DIRECTIONS: Record<string, PaneShortcutDirection> = {
+  ArrowLeft: "left",
+  ArrowRight: "right",
+  ArrowUp: "up",
+  ArrowDown: "down",
+};
+
+/**
+ * Maps macOS pane shortcuts without consuming extra modifier variants.
+ * Cmd+Ctrl+Arrows focus neighboring panes (Cmd+Option+Arrows stay with tab
+ * switching and are also swallowed by some PWA hosts), Cmd+D splits the
+ * active pane right, and Cmd+Shift+D splits it down.
+ */
+export function paneShortcutAction(
+  event: PaneShortcutEvent,
+): PaneShortcutAction | null {
+  if (!event.metaKey || event.altKey) return null;
+
+  if (event.ctrlKey && !event.shiftKey) {
+    const direction = ARROW_DIRECTIONS[event.key];
+    return direction ? { type: "focus", direction } : null;
+  }
+
+  if (!event.ctrlKey && event.key.toLowerCase() === "d") {
+    return { type: "split", direction: event.shiftKey ? "down" : "right" };
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

- `Cmd+Ctrl+Arrow` focuses the neighboring pane via herdr's `pane.focus_direction` RPC
- `Cmd+D` splits the active pane right, `Cmd+Shift+D` splits it down via `pane.split` (new pane takes focus)
- Shortcuts work while the terminal is focused, are ignored in editable elements and open dialogs, and split does not key-repeat
- In-app keyboard shortcut reference (Menu → Keyboard shortcuts) lists the new bindings
- `Cmd+Option+Left/Right` tab switching is unchanged

## Verification

- `bun run precommit` — 857 tests pass, lint, typecheck, and web build clean
- Manually verified `Cmd+Ctrl+Arrow` pane focus in an installed PWA