### PR TITLE
Add Herdr plugin manifest and launcher

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,9 @@ fixes only, and accumulate entries under `## Unreleased` as changes land.
 Stable releases use separate prepare and publish phases:
 
 1. Run the **Prepare Release** workflow with `X.Y.Z` or
-   `patch`/`minor`/`major`. It updates the three `package.json` versions,
-   finalizes `CHANGELOG.md` from `## Unreleased`, and opens a normal release PR.
+   `patch`/`minor`/`major`. It updates the three `package.json` versions plus
+   `herdr-plugin.toml`, finalizes `CHANGELOG.md` from `## Unreleased`, and
+   opens a normal release PR.
    Review and merge that PR after its checks pass; the workflow never merges or
    tags on its own.
 2. Run the **Publish Release** workflow with the merged `X.Y.Z` version. It

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add pane keyboard shortcuts: `Cmd+Ctrl+Arrow` focuses the neighboring pane,
   `Cmd+D` splits the active pane right, and `Cmd+Shift+D` splits it down.
+- Add a Herdr plugin manifest and launcher so Herdr Studio can be installed
+  and managed with `herdr plugin install powerfooI/herdr-studio`, with start,
+  restart, status, URL, version, and uninstall actions on Linux, macOS, and
+  Windows.
 
 ## 0.5.0 - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   and managed with `herdr plugin install powerfooI/herdr-studio`, with start,
   restart, status, URL, version, and uninstall actions on Linux, macOS, and
   Windows.
+- Add an interactive Herdr Studio popup pane (`herdr.studio` plugin `panel`
+  entrypoint) showing service status, the login URL, and start, restart, and
+  uninstall keys.
 
 ## 0.5.0 - 2026-09-02
 

--- a/README.md
+++ b/README.md
@@ -106,16 +106,6 @@ instead of running the script. See the
 fixed-version installation, authentication, remote connections, updates, and
 user-service setup.
 
-Herdr 0.7.2 or newer can also install Herdr Studio as a plugin:
-
-```bash
-herdr plugin install powerfooI/herdr-studio
-```
-
-The plugin builds from source with Bun and manages the same standalone binary
-through plugin actions and an interactive popup pane; see the
-[deployment guide](./docs/DEPLOYMENT.md#herdr-plugin).
-
 ## Install as a PWA
 
 For day-to-day use, install Herdr Studio as a standalone web app after starting

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Click any screenshot to open the full-resolution image.
 
 ## Quick start
 
-Herdr must already be installed and running. On Linux and macOS, install the
-latest standalone Herdr Studio binary with:
+Herdr must already be installed and running. Install the latest standalone
+Herdr Studio binary with:
 
 ```bash
 curl -fsSL \
@@ -98,11 +98,23 @@ Make sure `~/.local/bin` is in `PATH`, then start the application:
 herdr-gui
 ```
 
-Open the URL printed by the process. Windows x64 and ARM64 archives are
-available from the [latest release](https://github.com/powerfooI/herdr-studio/releases/latest).
-See the [deployment guide](./docs/DEPLOYMENT.md) for checksum verification,
+Open the URL printed by the process. On Windows, download the matching x64 or
+ARM64 archive from the
+[latest release](https://github.com/powerfooI/herdr-studio/releases/latest)
+instead of running the script. See the
+[deployment guide](./docs/DEPLOYMENT.md) for checksum verification,
 fixed-version installation, authentication, remote connections, updates, and
 user-service setup.
+
+Herdr 0.7.2 or newer can also install Herdr Studio as a plugin:
+
+```bash
+herdr plugin install powerfooI/herdr-studio
+```
+
+The plugin builds from source with Bun and manages the same standalone binary
+through plugin actions and an interactive popup pane; see the
+[deployment guide](./docs/DEPLOYMENT.md#herdr-plugin).
 
 ## Install as a PWA
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -14,9 +14,9 @@ user services, and standalone builds.
 
 ## Install a release
 
-The installer supports Linux and macOS on x86-64 and arm64. It verifies the
-release checksum and installs the standalone binary to
-`~/.local/bin/herdr-gui`:
+Prebuilt standalone binaries are available for Linux, macOS, and Windows on
+x86-64 and arm64. On Linux and macOS, the installer verifies the release
+checksum and installs the standalone binary to `~/.local/bin/herdr-gui`:
 
 ```bash
 curl -fsSL \
@@ -60,6 +60,39 @@ curl -fsSL \
 must use HTTPS, except for loopback testing, and their URLs cannot contain
 credentials, query strings, or fragments. The installer and in-app updater
 preserve a replaced executable as `herdr-gui.previous` for manual recovery.
+
+## Herdr plugin
+
+Herdr 0.7.2 or newer can install Herdr Studio as a plugin. The plugin builds
+the standalone binary from source, so [Bun](https://bun.sh) must be on `PATH`:
+
+```bash
+herdr plugin install powerfooI/herdr-studio
+```
+
+Plugin actions manage the same user service described in
+[Run as a user service](#run-as-a-user-service):
+
+```bash
+herdr plugin action invoke herdr.studio.start      # install and start the service
+herdr plugin action invoke herdr.studio.url        # print the login URL
+herdr plugin action invoke herdr.studio.status
+herdr plugin action invoke herdr.studio.restart
+herdr plugin action invoke herdr.studio.uninstall  # remove the service
+```
+
+Plugin actions run asynchronously; their output is recorded in the plugin
+command log (`herdr plugin log list --plugin herdr.studio`). For an
+interactive view, open the plugin's popup pane in the Herdr TUI:
+
+```bash
+herdr plugin pane open --plugin herdr.studio --entrypoint panel
+```
+
+The panel shows service status, the login URL, and the version, with
+single-key start, restart, and uninstall controls. It opens as a
+session-modal popup by default; pass `--placement split` (or `tab`, `zoomed`,
+`overlay`) to open it as a regular pane that other Herdr clients can see.
 
 ## Basic runtime configuration
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,0 +1,51 @@
+id = "herdr.studio"
+name = "Herdr Studio"
+version = "0.5.0"
+min_herdr_version = "0.7.2"
+description = "Browser and PWA client for Herdr: workspaces, tabs, panes, agent status, session inspection, diffs, and review annotations"
+platforms = ["linux", "macos", "windows"]
+
+# Thin launcher: every action delegates to scripts/studio-plugin.ts, which
+# builds server/herdr-gui on demand and forwards to its service CLI
+# (systemd, launchd, or Windows Task Scheduler). The verb set is a frozen
+# contract; see scripts/studio-plugin.ts. Builds need Bun on PATH; the
+# compiled binary runs standalone afterwards.
+
+[[build]]
+command = ["bun", "scripts/studio-plugin.ts", "build"]
+
+[[actions]]
+id = "start"
+title = "Start Herdr Studio"
+contexts = ["workspace"]
+command = ["bun", "scripts/studio-plugin.ts", "start"]
+
+[[actions]]
+id = "restart"
+title = "Restart Herdr Studio"
+contexts = ["workspace"]
+command = ["bun", "scripts/studio-plugin.ts", "restart"]
+
+[[actions]]
+id = "status"
+title = "Herdr Studio status"
+contexts = ["workspace"]
+command = ["bun", "scripts/studio-plugin.ts", "status"]
+
+[[actions]]
+id = "url"
+title = "Show Herdr Studio URL"
+contexts = ["workspace"]
+command = ["bun", "scripts/studio-plugin.ts", "url"]
+
+[[actions]]
+id = "version"
+title = "Show Herdr Studio version"
+contexts = ["workspace"]
+command = ["bun", "scripts/studio-plugin.ts", "version"]
+
+[[actions]]
+id = "uninstall"
+title = "Uninstall Herdr Studio service"
+contexts = ["workspace"]
+command = ["bun", "scripts/studio-plugin.ts", "uninstall"]

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -14,6 +14,14 @@ platforms = ["linux", "macos", "windows"]
 [[build]]
 command = ["bun", "scripts/studio-plugin.ts", "build"]
 
+[[panes]]
+id = "panel"
+title = "Herdr Studio"
+placement = "popup"
+width = "72%"
+height = 12
+command = ["bun", "scripts/studio-plugin.ts", "panel"]
+
 [[actions]]
 id = "start"
 title = "Start Herdr Studio"

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -10,6 +10,9 @@ platforms = ["linux", "macos", "windows"]
 # (systemd, launchd, or Windows Task Scheduler). The verb set is a frozen
 # contract; see scripts/studio-plugin.ts. Builds need Bun on PATH; the
 # compiled binary runs standalone afterwards.
+# The panel opens as a session-modal popup in the Herdr TUI by default. Open
+# it with --placement split (or tab/zoomed/overlay) to get a regular pane
+# that other Herdr clients, including Herdr Studio itself, can see.
 
 [[build]]
 command = ["bun", "scripts/studio-plugin.ts", "build"]

--- a/scripts/prepare-release.test.ts
+++ b/scripts/prepare-release.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
+  parseManifestVersion,
   parsePackageVersion,
+  replaceManifestVersion,
   replacePackageVersion,
   resolveNextVersion,
   rotateChangelog,
@@ -14,6 +16,12 @@ const PACKAGE_JSON = `{
     "test": "bun test"
   }
 }
+`;
+
+const PLUGIN_MANIFEST = `id = "herdr.studio"
+name = "Herdr Studio"
+version = "0.4.1"
+min_herdr_version = "0.7.2"
 `;
 
 const CHANGELOG = `# Changelog
@@ -62,6 +70,32 @@ describe("replacePackageVersion", () => {
     expect(() => replacePackageVersion(PACKAGE_JSON, "9.9.9", "0.4.2")).toThrow(
       "expected",
     );
+  });
+});
+
+describe("parseManifestVersion", () => {
+  test("reads the top-level version", () => {
+    expect(parseManifestVersion(PLUGIN_MANIFEST)).toBe("0.4.1");
+  });
+
+  test("rejects a manifest without a version", () => {
+    expect(() => parseManifestVersion(`id = "x"`)).toThrow("version");
+  });
+});
+
+describe("replaceManifestVersion", () => {
+  test("replaces only the version line and preserves the rest", () => {
+    const next = replaceManifestVersion(PLUGIN_MANIFEST, "0.4.1", "0.4.2");
+    expect(parseManifestVersion(next)).toBe("0.4.2");
+    expect(next).toBe(
+      PLUGIN_MANIFEST.replace('version = "0.4.1"', 'version = "0.4.2"'),
+    );
+  });
+
+  test("rejects an unexpected current version", () => {
+    expect(() =>
+      replaceManifestVersion(PLUGIN_MANIFEST, "9.9.9", "0.4.2"),
+    ).toThrow("expected");
   });
 });
 

--- a/scripts/prepare-release.test.ts
+++ b/scripts/prepare-release.test.ts
@@ -81,6 +81,17 @@ describe("parseManifestVersion", () => {
   test("rejects a manifest without a version", () => {
     expect(() => parseManifestVersion(`id = "x"`)).toThrow("version");
   });
+
+  test("tolerates leading whitespace like the package version parser", () => {
+    const indented = PLUGIN_MANIFEST.replace(
+      'version = "0.4.1"',
+      '  version = "0.4.1"',
+    );
+    expect(parseManifestVersion(indented)).toBe("0.4.1");
+    expect(
+      parseManifestVersion(replaceManifestVersion(indented, "0.4.1", "0.4.2")),
+    ).toBe("0.4.2");
+  });
 });
 
 describe("replaceManifestVersion", () => {

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -54,11 +54,11 @@ export function replacePackageVersion(
 }
 
 export function parseManifestVersion(manifestText: string): string {
-  const match = /^version = "([^"]+)"/m.exec(manifestText);
+  const match = /^(\s*)version = "([^"]+)"/m.exec(manifestText);
   if (!match) {
     throw new Error('herdr-plugin.toml has no top-level "version" field');
   }
-  return match[1];
+  return match[2];
 }
 
 export function replaceManifestVersion(
@@ -66,16 +66,16 @@ export function replaceManifestVersion(
   expectedCurrent: string,
   next: string,
 ): string {
-  const match = /^version = "([^"]+)"/m.exec(manifestText);
+  const match = /^(\s*)version = "([^"]+)"/m.exec(manifestText);
   if (!match || match.index === undefined) {
     throw new Error('herdr-plugin.toml has no top-level "version" field');
   }
-  if (match[1] !== expectedCurrent) {
+  if (match[2] !== expectedCurrent) {
     throw new Error(
-      `herdr-plugin.toml version is ${match[1]}, expected ${expectedCurrent}`,
+      `herdr-plugin.toml version is ${match[2]}, expected ${expectedCurrent}`,
     );
   }
-  return `${manifestText.slice(0, match.index)}version = "${next}"${manifestText.slice(
+  return `${manifestText.slice(0, match.index)}${match[1]}version = "${next}"${manifestText.slice(
     match.index + match[0].length,
   )}`;
 }

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
-// Prepare a release PR by bumping the three package.json versions and moving
+// Prepare a release PR by bumping the package.json and herdr-plugin.toml
+// versions and moving
 // the CHANGELOG "Unreleased" entries under the new version. This script only
 // updates the working tree; it does not commit, merge, tag, or push anything.
 //
@@ -20,7 +21,8 @@ const PACKAGE_FILES = [
   "server/package.json",
 ];
 const CHANGELOG_FILE = "CHANGELOG.md";
-const RELEASE_FILES = [...PACKAGE_FILES, CHANGELOG_FILE];
+const PLUGIN_MANIFEST_FILE = "herdr-plugin.toml";
+const RELEASE_FILES = [...PACKAGE_FILES, CHANGELOG_FILE, PLUGIN_MANIFEST_FILE];
 
 const SEMVER_RE = /^(\d+)\.(\d+)\.(\d+)$/;
 
@@ -47,6 +49,33 @@ export function replacePackageVersion(
     );
   }
   return `${packageJsonText.slice(0, match.index)}${match[1]}"version": "${next}"${packageJsonText.slice(
+    match.index + match[0].length,
+  )}`;
+}
+
+export function parseManifestVersion(manifestText: string): string {
+  const match = /^version = "([^"]+)"/m.exec(manifestText);
+  if (!match) {
+    throw new Error('herdr-plugin.toml has no top-level "version" field');
+  }
+  return match[1];
+}
+
+export function replaceManifestVersion(
+  manifestText: string,
+  expectedCurrent: string,
+  next: string,
+): string {
+  const match = /^version = "([^"]+)"/m.exec(manifestText);
+  if (!match || match.index === undefined) {
+    throw new Error('herdr-plugin.toml has no top-level "version" field');
+  }
+  if (match[1] !== expectedCurrent) {
+    throw new Error(
+      `herdr-plugin.toml version is ${match[1]}, expected ${expectedCurrent}`,
+    );
+  }
+  return `${manifestText.slice(0, match.index)}version = "${next}"${manifestText.slice(
     match.index + match[0].length,
   )}`;
 }
@@ -173,6 +202,13 @@ function main() {
       `${mismatchedPackage.file} version is ${mismatchedPackage.version}, expected ${current}`,
     );
   }
+  const manifestPath = join(REPO_ROOT, PLUGIN_MANIFEST_FILE);
+  const manifestText = readFileSync(manifestPath, "utf8");
+  if (parseManifestVersion(manifestText) !== current) {
+    abort(
+      `${PLUGIN_MANIFEST_FILE} version is ${parseManifestVersion(manifestText)}, expected ${current}`,
+    );
+  }
 
   const version = resolveNextVersion(current, input);
   const tag = `v${version}`;
@@ -193,10 +229,12 @@ function main() {
     version,
     date,
   );
+  const manifestWrite = replaceManifestVersion(manifestText, current, version);
   for (const { path, text } of packageWrites) {
     writeFileSync(path, text);
   }
   writeFileSync(changelogPath, changelogWrite);
+  writeFileSync(manifestPath, manifestWrite);
 
   console.log(
     `Prepared release ${version}. Review the changes and submit them as a release PR.`,

--- a/scripts/studio-plugin.test.ts
+++ b/scripts/studio-plugin.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { computeUrl, readServiceEnv } from "./studio-plugin";
+
+describe("readServiceEnv", () => {
+  test("reads plain values", () => {
+    expect(readServiceEnv("HOST=0.0.0.0\nPORT=8791\n", "HOST")).toBe("0.0.0.0");
+    expect(readServiceEnv("HOST=0.0.0.0\nPORT=8791\n", "PORT")).toBe("8791");
+  });
+
+  test("accepts export prefix, whitespace, and quoted values", () => {
+    const contents = "export HOST=\"0.0.0.0\"\n  PORT = '8799'\n";
+    expect(readServiceEnv(contents, "HOST")).toBe("0.0.0.0");
+    expect(readServiceEnv(contents, "PORT")).toBe("8799");
+  });
+
+  test("last occurrence wins and missing keys are undefined", () => {
+    expect(readServiceEnv("PORT=1\nPORT=2\n", "PORT")).toBe("2");
+    expect(readServiceEnv("HOST=x\n", "PORT")).toBeUndefined();
+  });
+
+  test("ignores comments and unrelated keys", () => {
+    const contents =
+      "# HOST=10.0.0.1\nHERDR_GUI_LOG_LEVEL=info\nHOST=127.0.0.1\n";
+    expect(readServiceEnv(contents, "HOST")).toBe("127.0.0.1");
+  });
+});
+
+describe("computeUrl", () => {
+  const dirs: string[] = [];
+  function fixture(files: Record<string, string>): string {
+    const dir = mkdtempSync(join(tmpdir(), "studio-plugin-"));
+    dirs.push(dir);
+    for (const [name, text] of Object.entries(files)) {
+      writeFileSync(join(dir, name), text);
+    }
+    return dir;
+  }
+  afterEach(() => {
+    while (dirs.length) {
+      rmSync(dirs.pop()!, { recursive: true, force: true });
+    }
+  });
+
+  test("defaults to loopback when no env file exists", () => {
+    expect(computeUrl(fixture({}))).toBe("http://127.0.0.1:8787");
+  });
+
+  test("includes the login token only for non-loopback binds", () => {
+    const dir = fixture({
+      "herdr-gui.env": "HOST=0.0.0.0\nPORT=8791\n",
+      "auth-token": "abc123\n",
+    });
+    expect(computeUrl(dir)).toBe("http://localhost:8791/?token=abc123");
+  });
+
+  test("ignores a stale token file on loopback binds", () => {
+    const dir = fixture({
+      "herdr-gui.env": "HOST=127.0.0.1\nPORT=8787\n",
+      "auth-token": "abc123\n",
+    });
+    expect(computeUrl(dir)).toBe("http://127.0.0.1:8787");
+  });
+
+  test("honors exported and quoted entries without a token file", () => {
+    const dir = fixture({
+      "herdr-gui.env": 'export HOST="0.0.0.0"\nPORT = "8799"\n',
+    });
+    expect(computeUrl(dir)).toBe("http://localhost:8799");
+  });
+});

--- a/scripts/studio-plugin.ts
+++ b/scripts/studio-plugin.ts
@@ -5,9 +5,11 @@
 // at install time.
 //
 // Verbs: build, start, restart, status, url, version, uninstall, panel.
-// `build` needs Bun on PATH; every other verb delegates to the compiled
-// standalone binary and builds it first when missing (plugin link mode).
-// `panel` is the interactive popup TUI behind the manifest [[panes]] entry.
+// `build` needs Bun on PATH. The service verbs (start, restart, status,
+// uninstall) delegate to the compiled standalone binary, building it first
+// when missing (plugin link mode). `url` and `version` only read on-disk
+// state and never build. `panel` is the interactive popup TUI behind the
+// manifest [[panes]] entry and builds on demand for its service keys.
 
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
@@ -95,18 +97,36 @@ function configDir(): string {
   return join(homedir(), ".config", "herdr-gui");
 }
 
+// Mirrors the server's service env parser: leading whitespace, an optional
+// `export` prefix, whitespace around `=`, and optionally quoted values; the
+// last occurrence wins.
+function readServiceEnv(contents: string, name: string): string | undefined {
+  let value: string | undefined;
+  for (const line of contents.split(/\r?\n/)) {
+    const match = line.match(
+      new RegExp(`^\\s*(?:export\\s+)?${name}\\s*=\\s*(.*?)\\s*$`),
+    );
+    if (!match) continue;
+    const raw = match[1] ?? "";
+    value =
+      raw.length >= 2 &&
+      (raw.startsWith("'") || raw.startsWith('"')) &&
+      raw.at(-1) === raw[0]
+        ? raw.slice(1, -1)
+        : raw;
+  }
+  return value;
+}
+
 function computeUrl(): string {
   const dir = configDir();
   const envFile = join(dir, "herdr-gui.env");
   let host = "127.0.0.1";
   let port = "8787";
   if (existsSync(envFile)) {
-    for (const line of readFileSync(envFile, "utf8").split("\n")) {
-      const match = /^(HOST|PORT)=(.*)$/.exec(line.trim());
-      if (!match) continue;
-      if (match[1] === "HOST") host = match[2].trim();
-      if (match[1] === "PORT") port = match[2].trim();
-    }
+    const contents = readFileSync(envFile, "utf8");
+    host = readServiceEnv(contents, "HOST") ?? host;
+    port = readServiceEnv(contents, "PORT") ?? port;
   }
   const anyHost = host === "0.0.0.0" || host === "::";
   const browserHost = anyHost ? "localhost" : host;
@@ -184,12 +204,21 @@ function panel(): Promise<number> {
   const stdin = process.stdin;
   return new Promise((resolve) => {
     let message = "";
+    let done = false;
     const cleanup = (code: number) => {
+      if (done) return;
+      done = true;
       process.stdout.write("\x1b[?25h\x1b[0m\n");
       stdin.setRawMode(false);
       stdin.pause();
       resolve(code);
     };
+    // The host can end the session by closing stdin or signaling the
+    // process; leave the terminal restored in every exit path.
+    stdin.on("end", () => cleanup(0));
+    stdin.on("close", () => cleanup(0));
+    process.on("SIGTERM", () => cleanup(0));
+    process.on("SIGINT", () => cleanup(0));
     stdin.setRawMode(true);
     stdin.resume();
     stdin.on("data", (chunk: Buffer) => {

--- a/scripts/studio-plugin.ts
+++ b/scripts/studio-plugin.ts
@@ -4,9 +4,10 @@
 // are a frozen contract because managed installs call the action set cached
 // at install time.
 //
-// Verbs: build, start, restart, status, url, version, uninstall.
+// Verbs: build, start, restart, status, url, version, uninstall, panel.
 // `build` needs Bun on PATH; every other verb delegates to the compiled
 // standalone binary and builds it first when missing (plugin link mode).
+// `panel` is the interactive popup TUI behind the manifest [[panes]] entry.
 
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
@@ -40,24 +41,48 @@ function run(argv: string[]): number {
   return result.status ?? 1;
 }
 
+function capture(argv: string[]): { code: number; out: string; err: string } {
+  const result = spawnSync(argv[0], argv.slice(1), {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  });
+  if (result.error) return { code: 1, out: "", err: result.error.message };
+  return {
+    code: result.status ?? 1,
+    out: result.stdout ?? "",
+    err: result.stderr ?? "",
+  };
+}
+
 function build(): number {
   const install = run(["bun", "install"]);
   if (install !== 0) return install;
   return run(["bun", "run", "build"]);
 }
 
-function service(...args: string[]): number {
-  let binary = binaryPath();
-  if (!binary) {
-    console.error("studio-plugin: herdr-gui binary missing, building it first");
-    if (build() !== 0) return 1;
-    binary = binaryPath();
-    if (!binary) {
-      console.error("studio-plugin: build finished but no binary was produced");
-      return 1;
-    }
+function ensureBinary(): string | null {
+  const existing = binaryPath();
+  if (existing) return existing;
+  console.error("studio-plugin: herdr-gui binary missing, building it first");
+  if (build() !== 0) return null;
+  const built = binaryPath();
+  if (!built) {
+    console.error("studio-plugin: build finished but no binary was produced");
   }
+  return built;
+}
+
+function service(...args: string[]): number {
+  const binary = ensureBinary();
+  if (!binary) return 1;
   return run([binary, "service", ...args]);
+}
+
+function packageVersion(): string {
+  const packageJson = JSON.parse(
+    readFileSync(join(REPO_ROOT, "package.json"), "utf8"),
+  ) as { version?: string };
+  return packageJson.version ?? "unknown";
 }
 
 function configDir(): string {
@@ -70,7 +95,7 @@ function configDir(): string {
   return join(homedir(), ".config", "herdr-gui");
 }
 
-function printUrl(): number {
+function computeUrl(): string {
   const dir = configDir();
   const envFile = join(dir, "herdr-gui.env");
   let host = "127.0.0.1";
@@ -82,10 +107,6 @@ function printUrl(): number {
       if (match[1] === "HOST") host = match[2].trim();
       if (match[1] === "PORT") port = match[2].trim();
     }
-  } else {
-    console.error(
-      `studio-plugin: no service environment at ${envFile}, showing defaults`,
-    );
   }
   const anyHost = host === "0.0.0.0" || host === "::";
   const browserHost = anyHost ? "localhost" : host;
@@ -99,21 +120,109 @@ function printUrl(): number {
     const token = readFileSync(tokenPath, "utf8").trim();
     if (token) url = `${url}/?token=${token}`;
   }
-  console.log(url);
+  return url;
+}
+
+function printUrl(): number {
+  const envFile = join(configDir(), "herdr-gui.env");
+  if (!existsSync(envFile)) {
+    console.error(
+      `studio-plugin: no service environment at ${envFile}, showing defaults`,
+    );
+  }
+  console.log(computeUrl());
   return 0;
+}
+
+function versionText(): string {
+  const binary = binaryPath();
+  if (binary) {
+    const result = capture([binary, "--version"]);
+    if (result.code === 0) return result.out.trim();
+  }
+  return `${packageVersion()} (binary not built)`;
 }
 
 function version(): number {
-  const binary = binaryPath();
-  if (binary) return run([binary, "--version"]);
-  const packageJson = JSON.parse(
-    readFileSync(join(REPO_ROOT, "package.json"), "utf8"),
-  ) as { version?: string };
-  console.log(`${packageJson.version ?? "unknown"} (binary not built)`);
+  console.log(versionText());
   return 0;
 }
 
-function main(): number {
+function statusText(): string {
+  const binary = binaryPath();
+  if (!binary) return "binary not built";
+  const result = capture([binary, "service", "status"]);
+  if (result.code !== 0) return "not installed";
+  const firstLine = result.out.trim().split("\n")[0]?.trim();
+  return firstLine || "installed";
+}
+
+function renderPanel(message: string) {
+  const lines = [
+    "Herdr Studio",
+    "",
+    `Status:  ${statusText()}`,
+    `URL:     ${computeUrl()}`,
+    `Version: ${versionText()}`,
+    "",
+    "[s] start  [r] restart  [u] uninstall  [q] close",
+  ];
+  if (message) lines.push("", message);
+  process.stdout.write(`\x1b[?25l\x1b[2J\x1b[H${lines.join("\r\n")}\r\n`);
+}
+
+function panel(): Promise<number> {
+  if (!process.stdin.isTTY) {
+    console.log(`Status:  ${statusText()}`);
+    console.log(`URL:     ${computeUrl()}`);
+    console.log(`Version: ${versionText()}`);
+    return Promise.resolve(0);
+  }
+  const stdin = process.stdin;
+  return new Promise((resolve) => {
+    let message = "";
+    const cleanup = (code: number) => {
+      process.stdout.write("\x1b[?25h\x1b[0m\n");
+      stdin.setRawMode(false);
+      stdin.pause();
+      resolve(code);
+    };
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.on("data", (chunk: Buffer) => {
+      const key = chunk.toString("utf8");
+      if (key === "q" || key === "\x03") {
+        cleanup(0);
+        return;
+      }
+      const args =
+        key === "s"
+          ? ["install", "--force"]
+          : key === "r"
+            ? ["restart"]
+            : key === "u"
+              ? ["uninstall"]
+              : null;
+      if (!args) return;
+      const binary = ensureBinary();
+      if (!binary) {
+        message = "build failed";
+        renderPanel(message);
+        return;
+      }
+      message = "working...";
+      renderPanel(message);
+      const result = capture([binary, "service", ...args]);
+      const detail = (result.err || result.out).trim().split("\n").pop() ?? "";
+      message =
+        result.code === 0 ? "done" : `failed (exit ${result.code}): ${detail}`;
+      renderPanel(message);
+    });
+    renderPanel(message);
+  });
+}
+
+async function main(): Promise<number> {
   switch (process.argv[2]) {
     case "build":
       return build();
@@ -129,12 +238,14 @@ function main(): number {
       return version();
     case "uninstall":
       return service("uninstall");
+    case "panel":
+      return panel();
     default:
       console.error(
-        "usage: studio-plugin.ts <build|start|restart|status|url|version|uninstall>",
+        "usage: studio-plugin.ts <build|start|restart|status|url|version|uninstall|panel>",
       );
       return process.argv[2] ? 1 : 0;
   }
 }
 
-process.exit(main());
+process.exit(await main());

--- a/scripts/studio-plugin.ts
+++ b/scripts/studio-plugin.ts
@@ -1,0 +1,140 @@
+#!/usr/bin/env bun
+// Thin Herdr plugin shim for Herdr Studio. Herdr invokes the verbs below
+// through herdr-plugin.toml actions; the verb names and their argv mapping
+// are a frozen contract because managed installs call the action set cached
+// at install time.
+//
+// Verbs: build, start, restart, status, url, version, uninstall.
+// `build` needs Bun on PATH; every other verb delegates to the compiled
+// standalone binary and builds it first when missing (plugin link mode).
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const BINARY_CANDIDATES =
+  process.platform === "win32" ? ["herdr-gui.exe", "herdr-gui"] : ["herdr-gui"];
+
+function binaryPath(): string | null {
+  for (const name of BINARY_CANDIDATES) {
+    const path = join(REPO_ROOT, "server", name);
+    if (existsSync(path)) return path;
+  }
+  return null;
+}
+
+function run(argv: string[]): number {
+  const result = spawnSync(argv[0], argv.slice(1), {
+    cwd: REPO_ROOT,
+    stdio: "inherit",
+  });
+  if (result.error) {
+    console.error(
+      `studio-plugin: cannot run ${argv[0]}: ${result.error.message}`,
+    );
+    return 1;
+  }
+  return result.status ?? 1;
+}
+
+function build(): number {
+  const install = run(["bun", "install"]);
+  if (install !== 0) return install;
+  return run(["bun", "run", "build"]);
+}
+
+function service(...args: string[]): number {
+  let binary = binaryPath();
+  if (!binary) {
+    console.error("studio-plugin: herdr-gui binary missing, building it first");
+    if (build() !== 0) return 1;
+    binary = binaryPath();
+    if (!binary) {
+      console.error("studio-plugin: build finished but no binary was produced");
+      return 1;
+    }
+  }
+  return run([binary, "service", ...args]);
+}
+
+function configDir(): string {
+  if (process.platform === "win32") {
+    return join(
+      process.env.APPDATA ?? join(homedir(), "AppData", "Roaming"),
+      "herdr-gui",
+    );
+  }
+  return join(homedir(), ".config", "herdr-gui");
+}
+
+function printUrl(): number {
+  const dir = configDir();
+  const envFile = join(dir, "herdr-gui.env");
+  let host = "127.0.0.1";
+  let port = "8787";
+  if (existsSync(envFile)) {
+    for (const line of readFileSync(envFile, "utf8").split("\n")) {
+      const match = /^(HOST|PORT)=(.*)$/.exec(line.trim());
+      if (!match) continue;
+      if (match[1] === "HOST") host = match[2].trim();
+      if (match[1] === "PORT") port = match[2].trim();
+    }
+  } else {
+    console.error(
+      `studio-plugin: no service environment at ${envFile}, showing defaults`,
+    );
+  }
+  const anyHost = host === "0.0.0.0" || host === "::";
+  const browserHost = anyHost ? "localhost" : host;
+  const formatted = browserHost.includes(":")
+    ? `[${browserHost}]`
+    : browserHost;
+  let url = `http://${formatted}:${port}`;
+  // Non-loopback binds log in with the generated token; loopback is open.
+  const tokenPath = join(dir, "auth-token");
+  if (existsSync(tokenPath)) {
+    const token = readFileSync(tokenPath, "utf8").trim();
+    if (token) url = `${url}/?token=${token}`;
+  }
+  console.log(url);
+  return 0;
+}
+
+function version(): number {
+  const binary = binaryPath();
+  if (binary) return run([binary, "--version"]);
+  const packageJson = JSON.parse(
+    readFileSync(join(REPO_ROOT, "package.json"), "utf8"),
+  ) as { version?: string };
+  console.log(`${packageJson.version ?? "unknown"} (binary not built)`);
+  return 0;
+}
+
+function main(): number {
+  switch (process.argv[2]) {
+    case "build":
+      return build();
+    case "start":
+      return service("install", "--force");
+    case "restart":
+      return service("restart");
+    case "status":
+      return service("status");
+    case "url":
+      return printUrl();
+    case "version":
+      return version();
+    case "uninstall":
+      return service("uninstall");
+    default:
+      console.error(
+        "usage: studio-plugin.ts <build|start|restart|status|url|version|uninstall>",
+      );
+      return process.argv[2] ? 1 : 0;
+  }
+}
+
+process.exit(main());

--- a/scripts/studio-plugin.ts
+++ b/scripts/studio-plugin.ts
@@ -29,9 +29,9 @@ function binaryPath(): string | null {
   return null;
 }
 
-function run(argv: string[]): number {
+function run(argv: string[], cwd = REPO_ROOT): number {
   const result = spawnSync(argv[0], argv.slice(1), {
-    cwd: REPO_ROOT,
+    cwd,
     stdio: "inherit",
   });
   if (result.error) {
@@ -57,8 +57,12 @@ function capture(argv: string[]): { code: number; out: string; err: string } {
 }
 
 function build(): number {
-  const install = run(["bun", "install"]);
-  if (install !== 0) return install;
+  // This repo is not a Bun workspace: web/ and server/ carry their own
+  // dependencies, so a clean checkout needs an install in each location.
+  for (const dir of [".", "web", "server"]) {
+    const code = run(["bun", "install"], join(REPO_ROOT, dir));
+    if (code !== 0) return code;
+  }
   return run(["bun", "run", "build"]);
 }
 
@@ -100,7 +104,10 @@ function configDir(): string {
 // Mirrors the server's service env parser: leading whitespace, an optional
 // `export` prefix, whitespace around `=`, and optionally quoted values; the
 // last occurrence wins.
-function readServiceEnv(contents: string, name: string): string | undefined {
+export function readServiceEnv(
+  contents: string,
+  name: string,
+): string | undefined {
   let value: string | undefined;
   for (const line of contents.split(/\r?\n/)) {
     const match = line.match(
@@ -118,8 +125,7 @@ function readServiceEnv(contents: string, name: string): string | undefined {
   return value;
 }
 
-function computeUrl(): string {
-  const dir = configDir();
+export function computeUrl(dir = configDir()): string {
   const envFile = join(dir, "herdr-gui.env");
   let host = "127.0.0.1";
   let port = "8787";
@@ -280,4 +286,6 @@ async function main(): Promise<number> {
   }
 }
 
-process.exit(await main());
+if (import.meta.main) {
+  process.exit(await main());
+}

--- a/scripts/studio-plugin.ts
+++ b/scripts/studio-plugin.ts
@@ -114,11 +114,14 @@ function computeUrl(): string {
     ? `[${browserHost}]`
     : browserHost;
   let url = `http://${formatted}:${port}`;
-  // Non-loopback binds log in with the generated token; loopback is open.
+  // Only non-loopback binds require the generated login token (the server
+  // skips auth on loopback); the token file can also be absent or stale.
+  const loopback =
+    host === "127.0.0.1" || host === "localhost" || host === "::1";
   const tokenPath = join(dir, "auth-token");
-  if (existsSync(tokenPath)) {
+  if (!loopback && existsSync(tokenPath)) {
     const token = readFileSync(tokenPath, "utf8").trim();
-    if (token) url = `${url}/?token=${token}`;
+    if (token) url = `${url}/?token=${encodeURIComponent(token)}`;
   }
   return url;
 }


### PR DESCRIPTION
## Summary

- Add `herdr-plugin.toml` so Herdr Studio is installable via `herdr plugin install powerfooI/herdr-studio` and discoverable in the Herdr plugin marketplace (thin-launcher pattern, same as collie)
- `scripts/studio-plugin.ts` shim: `build` (Bun) plus `start`/`restart`/`status`/`url`/`version`/`uninstall` actions delegating to the compiled binary's service CLI (systemd, launchd, Windows Task Scheduler); the verb set is a frozen contract
- Interactive `panel` popup pane inside the Herdr TUI: service status, login URL, version, and single-key start/restart/uninstall — pane commands own their terminal, so unlike async plugin actions the output is visible directly
- `prepare-release` now bumps the manifest version alongside the three package.json versions
- Platforms: linux, macos, windows; `min_herdr_version = "0.7.2"` (terminal observe/control + snapshot surface)

## Verification

- `bun run format` / `lint` / `typecheck` / `test` — 862 tests pass
- `herdr plugin link` + `plugin action list`: manifest registers, all actions present
- Full lifecycle tested locally on :8791 (start → HTTP 200 with token login → restart → uninstall, no residue; original :8787 instance untouched)
- `herdr plugin pane open --plugin herdr.studio --entrypoint panel` returns ok and the panel renders in the TUI
- `build` verb produces a working standalone binary