### PR TITLE
Stage the plugin manifest in Prepare Release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -57,7 +57,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$branch"
-          git add package.json web/package.json server/package.json CHANGELOG.md
+          git add package.json web/package.json server/package.json herdr-plugin.toml CHANGELOG.md
           git commit -m "Release $VERSION"
           gh auth setup-git
           git push origin "$branch"


### PR DESCRIPTION
## Summary

- `prepare-release.ts` has synced `herdr-plugin.toml` as the fourth version file since #90, but the workflow's `git add` never staged it — release PRs would ship with the plugin manifest version stuck at the previous release
- Adds `herdr-plugin.toml` to the staged files; no other workflow changes

## Verification

- `git add` line now matches exactly the files written by `scripts/prepare-release.ts` (`RELEASE_FILES`: 3 package.json + herdr-plugin.toml + CHANGELOG.md rotation)