### PR TITLE
Release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 - Add a Herdr plugin manifest and launcher so Herdr Studio can be installed
   and managed with `herdr plugin install powerfooI/herdr-studio`, with start,
   restart, status, URL, version, and uninstall actions on Linux, macOS, and
-  Windows.
+  Windows. The plugin downloads a checksum-verified prebuilt release binary,
+  so no source toolchain is needed.
 - Add an interactive Herdr Studio popup pane (`herdr.studio` plugin `panel`
   entrypoint) showing service status, the login URL, and start, restart, and
   uninstall keys.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.5.1 - 2026-09-03
+
 ### Added
 
 - Add pane keyboard shortcuts: `Cmd+Ctrl+Arrow` focuses the neighboring pane,

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "herdr.studio"
 name = "Herdr Studio"
-version = "0.5.0"
+version = "0.5.1"
 min_herdr_version = "0.7.2"
 description = "Browser and PWA client for Herdr: workspaces, tabs, panes, agent status, session inspection, diffs, and review annotations"
 platforms = ["linux", "macos", "windows"]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "herdr-studio",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Herdr Studio: a web client for Herdr (local socket bridge + React dashboard).",
   "license": "MIT",
   "author": "Arthur",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "herdr-studio-server",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "herdr-studio-web",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Release 0.5.1 — prepared with `bun run release:prepare 0.5.1`.

- Bumps the four version files (3 package.json + herdr-plugin.toml) to 0.5.1
- Finalizes CHANGELOG.md: pane keyboard shortcuts (#89), Herdr plugin manifest and launcher (#90), prebuilt plugin downloads (#91)

Merge this PR, then run the **Publish Release** workflow with `0.5.1`.