### PR TITLE
Add mobile bottom-sheet menu and interface text size control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+### Added
+
+- Add a Text size control (Menu > Appearance) that scales the whole interface
+  between 80% and 150%, making the app easier to read on mobile where browser
+  zoom shortcuts are unavailable.
+
+### Changed
+
+- Replace the desktop dropdown application menu with a mobile bottom sheet on
+  narrow screens: slide-up sheet with a grab handle, grid tile actions,
+  and full-width preference rows sized for touch. The desktop-only Keyboard
+  shortcuts item is hidden in the sheet.
+
+### Fixed
+
+- Fit the mobile terminal shortcut bar to the screen width: keys shrink with
+  label ellipsis instead of overflowing into horizontal scrolling.
+
 ## 0.5.1 - 2026-09-03
 
 ### Added

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -265,6 +265,8 @@ browser and do not change Herdr server configuration.
 - Enable browser task-completion notifications that return directly to the
   relevant pane.
 - Choose light/dark themes (or follow the system color scheme) and persistent accent colors.
+- Scale the interface from 80% to 150% via Menu → Appearance → Text size,
+  useful on mobile where browser zoom shortcuts are unavailable.
 - Install and manage a systemd or launchd user service from the CLI.
 - Check for Herdr Studio releases and perform a checksum-verified, one-click binary
   update when running a standalone binary under a supported supervisor.
@@ -277,7 +279,7 @@ see [SECURITY.md](./SECURITY.md) before exposing the service.
 
 ## Keyboard Shortcut Reference
 
-The in-app reference is available from **Menu → Keyboard shortcuts**.
+The in-app reference is available on desktop from **Menu → Keyboard shortcuts** (the mobile sheet omits it).
 
 ### Global
 

--- a/web/index.html
+++ b/web/index.html
@@ -42,7 +42,11 @@
         const storedUiScale = localStorage.getItem("uiScale");
         const uiScale = storedUiScale === null ? 100 : Number(storedUiScale);
         if (Number.isFinite(uiScale) && uiScale !== 100) {
-          const clampedUiScale = Math.min(150, Math.max(80, uiScale));
+          // Keep in sync with clampUiScale in web/src/appearance.ts.
+          const clampedUiScale = Math.min(
+            150,
+            Math.max(80, Math.round(uiScale / 5) * 5),
+          );
           document.documentElement.style.zoom = String(clampedUiScale / 100);
         }
       } catch {}

--- a/web/index.html
+++ b/web/index.html
@@ -37,6 +37,14 @@
               : "dark";
         document.documentElement.dataset.theme = resolvedTheme;
         document.documentElement.style.colorScheme = resolvedTheme;
+        // Apply the persisted interface scale too so the first paint matches
+        // the Text size preference.
+        const storedUiScale = localStorage.getItem("uiScale");
+        const uiScale = storedUiScale === null ? 100 : Number(storedUiScale);
+        if (Number.isFinite(uiScale) && uiScale !== 100) {
+          const clampedUiScale = Math.min(150, Math.max(80, uiScale));
+          document.documentElement.style.zoom = String(clampedUiScale / 100);
+        }
       } catch {}
     </script>
   </head>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -30,6 +30,8 @@ import {
   type AccentColor,
   normalizeAccentColor,
   normalizeThemePreference,
+  normalizeUiScale,
+  UI_SCALE_DEFAULT,
   type ResolvedTheme,
   resolveSystemTheme,
   SYSTEM_THEME_QUERY,
@@ -133,6 +135,7 @@ const MAX_SIDEBAR = 560;
 const DEFAULT_SIDEBAR = 284;
 const THEME_KEY = "theme";
 const ACCENT_COLOR_KEY = "accentColor";
+const UI_SCALE_KEY = "uiScale";
 const LazyTerminalView = lazy(() =>
   import("./components/TerminalView").then((module) => ({
     default: module.TerminalView,
@@ -235,6 +238,10 @@ function loadSystemTheme(): ResolvedTheme {
 
 function loadAccentColor(): AccentColor {
   return normalizeAccentColor(localStorage.getItem(ACCENT_COLOR_KEY));
+}
+
+function loadUiScale(): number {
+  return normalizeUiScale(localStorage.getItem(UI_SCALE_KEY));
 }
 
 function loadMobileTerminalShortcuts(): MobileTerminalShortcutRows {
@@ -364,9 +371,12 @@ function ViewportDebugOverlay() {
   );
 }
 
-function useVisualViewportCssVars() {
+function useVisualViewportCssVars(uiScale: number) {
   useEffect(() => {
     const root = document.documentElement;
+    // CSS zoom scales every computed px length, so emit viewport geometry in
+    // pre-zoom units to keep the rendered shell matching the real viewport.
+    const geometryScale = uiScale / 100;
     let pollTimer: number | undefined;
     let settleTimers: number[] = [];
 
@@ -382,7 +392,7 @@ function useVisualViewportCssVars() {
       root.classList.toggle("keyboard-open", keyboardOpen);
       root.style.setProperty(
         "--app-viewport-height",
-        `${Math.round(height)}px`,
+        `${Math.round(height / geometryScale)}px`,
       );
       // Keep the app surface at the full layout height, even while the
       // keyboard is open. iOS can over-report the keyboard occlusion (the
@@ -392,29 +402,29 @@ function useVisualViewportCssVars() {
       // with padding-bottom in the mobile styles.
       root.style.setProperty(
         "--app-height",
-        `calc(${Math.round(window.innerHeight)}px + env(safe-area-inset-bottom, 0px))`,
+        `calc(${Math.round(window.innerHeight / geometryScale)}px + env(safe-area-inset-bottom, 0px))`,
       );
       root.style.setProperty(
         "--app-viewport-offset-top",
-        `${Math.round(offsetTop)}px`,
+        `${Math.round(offsetTop / geometryScale)}px`,
       );
       root.style.setProperty(
         "--keyboard-inset-bottom",
-        `${Math.round(keyboardInset)}px`,
+        `${Math.round(keyboardInset / geometryScale)}px`,
       );
       // Both platforms need the visual viewport lift here; without it some
       // Android browsers place the composer behind the software keyboard.
       const contentInset = Math.max(0, keyboardInset - keyboardInsetTrim);
       root.style.setProperty(
         "--keyboard-inset-content",
-        `${Math.round(contentInset)}px`,
+        `${Math.round(contentInset / geometryScale)}px`,
       );
       root.style.setProperty(
         "--keyboard-inset-composer-gap",
         `${Math.round(
-          usesIosKeyboardViewportLift
+          (usesIosKeyboardViewportLift
             ? Math.max(0, keyboardInset - contentInset)
-            : 0,
+            : 0) / geometryScale,
         )}px`,
       );
       return keyboardOpen;
@@ -479,7 +489,7 @@ function useVisualViewportCssVars() {
       root.style.removeProperty("--keyboard-inset-content");
       root.style.removeProperty("--keyboard-inset-composer-gap");
     };
-  }, []);
+  }, [uiScale]);
 }
 
 function isEditableElement(target: EventTarget | null) {
@@ -1026,7 +1036,6 @@ export default function App() {
     shallowEqual,
   );
   const connectionClient = useConnectionClient();
-  useVisualViewportCssVars();
   const mobile = useMobileLayout();
   useEffect(() => {
     activateTerminalComposerDraftScope(
@@ -1043,6 +1052,8 @@ export default function App() {
   const [accentColor, setAccentColor] = useState<AccentColor>(() =>
     loadAccentColor(),
   );
+  const [uiScale, setUiScale] = useState<number>(() => loadUiScale());
+  useVisualViewportCssVars(uiScale);
   const [mobileTerminalShortcuts, setMobileTerminalShortcuts] =
     useState<MobileTerminalShortcutRows>(loadMobileTerminalShortcuts);
   const [mobileTerminalSideShortcuts, setMobileTerminalSideShortcuts] =
@@ -2244,7 +2255,18 @@ export default function App() {
     localStorage.setItem(THEME_KEY, theme);
     document.documentElement.dataset.accent = accentColor;
     localStorage.setItem(ACCENT_COLOR_KEY, accentColor);
-  }, [accentColor, systemTheme, theme]);
+    document.documentElement.style.zoom =
+      uiScale === UI_SCALE_DEFAULT ? "" : String(uiScale / 100);
+    if (uiScale === UI_SCALE_DEFAULT) {
+      document.documentElement.style.removeProperty("--ui-scale");
+    } else {
+      document.documentElement.style.setProperty(
+        "--ui-scale",
+        String(uiScale / 100),
+      );
+    }
+    localStorage.setItem(UI_SCALE_KEY, String(uiScale));
+  }, [accentColor, systemTheme, theme, uiScale]);
   useEffect(() => {
     localStorage.setItem(
       MOBILE_TERMINAL_SHORTCUTS_STORAGE_KEY,
@@ -2467,6 +2489,8 @@ export default function App() {
               mobileTerminalSideShortcuts={mobileTerminalSideShortcuts}
               onThemeChange={setTheme}
               onAccentColorChange={setAccentColor}
+              uiScale={uiScale}
+              onUiScaleChange={setUiScale}
               onMobileTerminalShortcutsChange={setMobileTerminalShortcuts}
               onMobileTerminalSideShortcutsChange={
                 setMobileTerminalSideShortcuts

--- a/web/src/appearance.test.ts
+++ b/web/src/appearance.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
+  clampUiScale,
   normalizeAccentColor,
   normalizeThemePreference,
+  normalizeUiScale,
   resolveSystemTheme,
+  UI_SCALE_DEFAULT,
+  UI_SCALE_MAX,
+  UI_SCALE_MIN,
 } from "./appearance";
 
 const matches = (value: boolean) => ({ matches: value });
@@ -36,5 +41,42 @@ describe("appearance preferences", () => {
   test("resolves the system theme from the color-scheme media query", () => {
     expect(resolveSystemTheme(matches(true))).toBe("light");
     expect(resolveSystemTheme(matches(false))).toBe("dark");
+  });
+});
+
+describe("clampUiScale", () => {
+  test("keeps in-range values on the step grid", () => {
+    expect(clampUiScale(100)).toBe(100);
+    expect(clampUiScale(125)).toBe(125);
+  });
+
+  test("rounds values to the nearest step", () => {
+    expect(clampUiScale(103)).toBe(105);
+    expect(clampUiScale(102)).toBe(100);
+  });
+
+  test("clamps to the supported range", () => {
+    expect(clampUiScale(10)).toBe(UI_SCALE_MIN);
+    expect(clampUiScale(500)).toBe(UI_SCALE_MAX);
+  });
+
+  test("falls back to the default for non-finite values", () => {
+    expect(clampUiScale(Number.NaN)).toBe(UI_SCALE_DEFAULT);
+    expect(clampUiScale(Number.POSITIVE_INFINITY)).toBe(UI_SCALE_DEFAULT);
+  });
+});
+
+describe("normalizeUiScale", () => {
+  test("defaults when nothing is stored", () => {
+    expect(normalizeUiScale(null)).toBe(UI_SCALE_DEFAULT);
+  });
+
+  test("defaults for unparsable stored values", () => {
+    expect(normalizeUiScale("large")).toBe(UI_SCALE_DEFAULT);
+  });
+
+  test("parses and clamps stored values", () => {
+    expect(normalizeUiScale("110")).toBe(110);
+    expect(normalizeUiScale("999")).toBe(UI_SCALE_MAX);
   });
 });

--- a/web/src/appearance.ts
+++ b/web/src/appearance.ts
@@ -40,3 +40,18 @@ export function resolveSystemTheme(
 }
 
 export const SYSTEM_THEME_QUERY = "(prefers-color-scheme: light)";
+
+export const UI_SCALE_DEFAULT = 100;
+export const UI_SCALE_MIN = 80;
+export const UI_SCALE_MAX = 150;
+export const UI_SCALE_STEP = 5;
+
+export function clampUiScale(value: number): number {
+  if (!Number.isFinite(value)) return UI_SCALE_DEFAULT;
+  const stepped = Math.round(value / UI_SCALE_STEP) * UI_SCALE_STEP;
+  return Math.min(UI_SCALE_MAX, Math.max(UI_SCALE_MIN, stepped));
+}
+
+export function normalizeUiScale(value: string | null): number {
+  return value === null ? UI_SCALE_DEFAULT : clampUiScale(Number(value));
+}

--- a/web/src/components/ConfigMenu.tsx
+++ b/web/src/components/ConfigMenu.tsx
@@ -1,14 +1,17 @@
 import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
 import {
+  ALargeSmall,
   Bell,
   ChevronDown,
   ChevronRight,
   Download,
   GitBranch,
   Keyboard,
+  Minus,
   Moon,
   Palette,
+  Plus,
   RefreshCw,
   ScrollText,
   Server,
@@ -18,7 +21,15 @@ import {
 } from "lucide-react";
 import packageJson from "../../package.json";
 import type { Theme } from "../App";
-import { ACCENT_OPTIONS, type AccentColor } from "../appearance";
+import {
+  ACCENT_OPTIONS,
+  type AccentColor,
+  clampUiScale,
+  UI_SCALE_DEFAULT,
+  UI_SCALE_MAX,
+  UI_SCALE_MIN,
+  UI_SCALE_STEP,
+} from "../appearance";
 import { connectionHttpPath } from "../connectionHttp";
 import { shallowEqual, store, useStoreSelector } from "../store";
 import { useConnectionClient } from "../useConnectionClient";
@@ -53,10 +64,12 @@ type HerdrInfo = {
 type ConfigMenuProps = {
   theme: Theme;
   accentColor: AccentColor;
+  uiScale: number;
   mobileTerminalShortcuts: MobileTerminalShortcutRows;
   mobileTerminalSideShortcuts: MobileTerminalSideShortcuts;
   onThemeChange: (theme: Theme) => void;
   onAccentColorChange: (accentColor: AccentColor) => void;
+  onUiScaleChange: (scale: number) => void;
   onMobileTerminalShortcutsChange: (rows: MobileTerminalShortcutRows) => void;
   onMobileTerminalSideShortcutsChange: (
     shortcuts: MobileTerminalSideShortcuts,
@@ -66,10 +79,12 @@ type ConfigMenuProps = {
 export function ConfigMenu({
   theme,
   accentColor,
+  uiScale,
   mobileTerminalShortcuts,
   mobileTerminalSideShortcuts,
   onThemeChange,
   onAccentColorChange,
+  onUiScaleChange,
   onMobileTerminalShortcutsChange,
   onMobileTerminalSideShortcutsChange,
 }: ConfigMenuProps) {
@@ -311,6 +326,51 @@ export function ConfigMenu({
                   ))}
                 </div>
               </div>
+              <div className="config-preference-row">
+                <span className="config-item-icon">
+                  <ALargeSmall size={15} />
+                </span>
+                <div className="config-item-copy">
+                  <strong>Text size</strong>
+                  <span>Scale the interface, handy on mobile</span>
+                </div>
+                <div
+                  className="config-scale-control"
+                  role="group"
+                  aria-label="Text size"
+                >
+                  <button
+                    type="button"
+                    aria-label="Decrease text size"
+                    disabled={uiScale <= UI_SCALE_MIN}
+                    onClick={() =>
+                      onUiScaleChange(clampUiScale(uiScale - UI_SCALE_STEP))
+                    }
+                  >
+                    <Minus size={14} />
+                  </button>
+                  <button
+                    type="button"
+                    className="config-scale-value"
+                    aria-label={`Reset text size, currently ${uiScale}%`}
+                    title="Reset to 100%"
+                    disabled={uiScale === UI_SCALE_DEFAULT}
+                    onClick={() => onUiScaleChange(UI_SCALE_DEFAULT)}
+                  >
+                    {uiScale}%
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="Increase text size"
+                    disabled={uiScale >= UI_SCALE_MAX}
+                    onClick={() =>
+                      onUiScaleChange(clampUiScale(uiScale + UI_SCALE_STEP))
+                    }
+                  >
+                    <Plus size={14} />
+                  </button>
+                </div>
+              </div>
             </div>
 
             <div className="config-section">
@@ -391,7 +451,7 @@ export function ConfigMenu({
               />
             </div>
 
-            <div className="config-section">
+            <div className="config-section config-section-tiles-3">
               <div className="config-title">Help & updates</div>
               <ConfigMenuItem
                 icon={<ScrollText size={15} />}
@@ -406,6 +466,7 @@ export function ConfigMenu({
                 icon={<Keyboard size={15} />}
                 label="Keyboard shortcuts"
                 description="View shortcut lookup"
+                className="config-menu-item-desktop-only"
                 onClick={() => {
                   setOpen(false);
                   setShortcutsOpen(true);
@@ -524,6 +585,7 @@ function ConfigMenuItem({
   onClick,
   disabled = false,
   primary = false,
+  className,
 }: {
   icon: ReactNode;
   label: string;
@@ -531,11 +593,12 @@ function ConfigMenuItem({
   onClick: () => void;
   disabled?: boolean;
   primary?: boolean;
+  className?: string;
 }) {
   return (
     <button
       type="button"
-      className={`config-menu-item ${primary ? "is-primary" : ""}`}
+      className={`config-menu-item${primary ? " is-primary" : ""}${className ? ` ${className}` : ""}`}
       onClick={onClick}
       disabled={disabled}
     >

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1195,6 +1195,40 @@ textarea:focus {
   background: var(--panel-2);
   color: var(--text-strong);
 }
+.config-scale-control {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  background: var(--input-bg);
+}
+.config-scale-control button {
+  min-width: 28px;
+  height: 26px;
+  padding: 0 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-color: transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+}
+.config-scale-control button:hover:not(:disabled) {
+  color: var(--text);
+}
+.config-scale-control button:disabled {
+  opacity: 0.45;
+}
+.config-scale-control .config-scale-value {
+  min-width: 42px;
+  color: var(--text-strong);
+  font-variant-numeric: tabular-nums;
+}
 .config-accent-control {
   display: flex;
   align-items: center;
@@ -1518,6 +1552,16 @@ textarea:focus {
     transform: rotate(360deg);
   }
 }
+@keyframes config-sheet-in {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
 @keyframes toast-in {
   from {
     opacity: 0;
@@ -1530,6 +1574,11 @@ textarea:focus {
 }
 @media (prefers-reduced-motion: reduce) {
   .toast {
+    animation: none;
+  }
+  /* Higher specificity than the mobile sheet rule so reduced motion wins
+     regardless of source order. */
+  .config-menu .config-dropdown {
     animation: none;
   }
   .toast,
@@ -8029,6 +8078,146 @@ textarea:focus {
   .mobile-shortcuts-actions button:first-child {
     grid-column: 1 / -1;
   }
+  /* Mobile application menu: a bottom sheet with tile actions instead of
+     the desktop dropdown list. */
+  .config-dropdown {
+    position: fixed;
+    top: auto;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    max-height: min(78dvh, 640px);
+    max-height: min(
+      calc(78dvh / var(--ui-scale, 1)),
+      calc(640px / var(--ui-scale, 1))
+    );
+    padding: 4px 10px calc(10px + env(safe-area-inset-bottom, 0px));
+    border: none;
+    border-top: 1px solid var(--shell-border);
+    border-radius: 14px 14px 0 0;
+    animation: config-sheet-in 160ms ease;
+  }
+  .config-dropdown::before {
+    content: "";
+    display: block;
+    width: 36px;
+    height: 4px;
+    margin: 2px auto 6px;
+    border-radius: 999px;
+    background: var(--border);
+  }
+  .config-summary {
+    align-items: center;
+    padding: 2px 4px 8px;
+  }
+  .config-section {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px;
+    padding: 8px 0;
+  }
+  .config-title,
+  .config-preference-row,
+  .config-runtime-row,
+  .config-details-toggle,
+  .config-details {
+    grid-column: 1 / -1;
+  }
+  .config-title {
+    margin: 0 2px;
+    font-size: 10px;
+  }
+  .config-preference-row,
+  .config-runtime-row,
+  .config-details-toggle {
+    grid-template-columns: 24px minmax(0, 1fr) auto;
+    gap: 8px;
+    min-height: 38px;
+    padding: 4px 6px;
+  }
+  .config-item-icon {
+    width: 24px;
+    height: 24px;
+    border-radius: 6px;
+  }
+  .config-item-copy {
+    gap: 0;
+  }
+  .config-item-copy span {
+    display: none;
+  }
+  .config-menu-item {
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 10px 6px;
+    border: 1px solid var(--border-soft);
+    border-radius: 10px;
+    background: var(--input-bg);
+  }
+  .config-menu-item > svg {
+    display: none;
+  }
+  .config-menu-item-desktop-only {
+    display: none;
+  }
+  .config-section-tiles-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .config-section-tiles-3 .config-menu-item .config-item-copy strong {
+    white-space: normal;
+  }
+  .config-menu-item:hover:not(:disabled) {
+    border-color: var(--border-soft);
+  }
+  .config-menu-item .config-item-icon {
+    width: 28px;
+    height: 28px;
+  }
+  .config-menu-item .config-item-copy {
+    width: 100%;
+    text-align: center;
+  }
+  .config-menu-item .config-item-copy strong {
+    font-size: 11px;
+  }
+  .config-theme-control button {
+    width: 30px;
+    height: 26px;
+  }
+  .config-accent-control button {
+    width: 18px;
+    height: 18px;
+  }
+  .config-accent-control button[data-accent="neutral"]::after {
+    top: 7px;
+    width: 12px;
+  }
+  .config-scale-control button {
+    min-width: 28px;
+    height: 26px;
+    padding: 0 5px;
+  }
+  .config-scale-control .config-scale-value {
+    min-width: 40px;
+  }
+  .settings-switch {
+    width: 36px;
+    height: 20px;
+  }
+  .settings-switch > span {
+    top: 2px;
+    left: 2px;
+    width: 14px;
+    height: 14px;
+  }
+  .settings-switch.is-on > span {
+    transform: translateX(16px);
+  }
   .worktree-lifecycle-modal {
     width: 100%;
     height: calc(
@@ -8982,18 +9171,19 @@ textarea:focus {
     width: 100%;
     min-width: 0;
     display: grid;
-    grid-template-columns: repeat(var(--mobile-shortcut-columns), 48px);
+    grid-template-columns: repeat(
+        var(--mobile-shortcut-columns),
+        minmax(0, 1fr)
+      );
     gap: 2px;
-    overflow-x: auto;
-    scrollbar-width: none;
-  }
-  .terminal-composer-shortcuts::-webkit-scrollbar {
-    display: none;
   }
   .terminal-composer-shortcut-row {
     grid-column: 1 / -1;
     display: grid;
-    grid-template-columns: repeat(var(--mobile-shortcut-columns), 48px);
+    grid-template-columns: repeat(
+        var(--mobile-shortcut-columns),
+        minmax(0, 1fr)
+      );
     gap: 2px;
   }
   .terminal-composer-shortcut-spacer,
@@ -9003,10 +9193,10 @@ textarea:focus {
     pointer-events: none;
   }
   .terminal-composer-shortcuts button {
-    width: 48px;
+    width: 100%;
+    max-width: 48px;
     min-width: 0;
     height: 28px;
-    flex: 0 0 48px;
     display: inline-flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
## Summary

- **Mobile bottom-sheet menu**: on narrow screens the application menu becomes a slide-up bottom sheet with a grab handle, tile action grid (three across in Help & updates), full-width preference rows, compact touch-sized controls, reduced-motion support, and safe-area padding. The desktop-only Keyboard shortcuts item is hidden in the sheet; the desktop dropdown is unchanged.
- **Text size control** (Menu → Appearance): scales the whole interface 80–150% in 5% steps, persisted in localStorage and applied before first paint. Mobile viewport geometry (app height, keyboard insets, sheet max-height) is emitted in pre-zoom units so the shell, software-keyboard lift, and sheet stay correct at any scale.
- **Terminal shortcut bar fit**: mobile composer shortcut keys shrink with label ellipsis to fit the screen width instead of scrolling horizontally.

CHANGELOG (`## Unreleased`) and FEATURES.md are updated accordingly.

## Verification

- `bun run precommit` — format, lint, typecheck, 882 tests pass / 0 fail
- `bun run build:web` — clean, asset budget 118/160 files

Screenshots from a physical phone would still be valuable for the sheet and the 80%/150% scale extremes.