### PR TITLE
Improve workspace and agent management, terminal theming, and IME support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,10 @@
 - Make `Cmd+W` close only the active pane in split tabs.
 - Keep Diff scope labels on one line and mobile terminal shortcuts within view.
 - Preserve History focus and view mode during refresh; correct Grok timestamps.
-- Make terminal backgrounds and ANSI colors follow the light application theme,
-  and upgrade xterm so IME preedit stays inside the viewport and anchors to the
+- Make terminal default colors follow the application theme while preserving
+  explicit application colors, and keep terminal sizing free of a hidden
+  scrollbar gutter.
+- Upgrade xterm so IME preedit stays inside the viewport and anchors to the
   live cursor during TUI redraws.
 
 ## 0.5.1 - 2026-09-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add a website tutorial, History filters, and adjustable text size.
 - Drag across the Files annotation gutter to comment on multiple lines.
 - Drag workspaces in the sidebar to persistently reorder them.
+- Drag agent sessions onto workspaces to move them into a new tab.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add a website tutorial, History filters, and adjustable text size.
 - Drag across the Files annotation gutter to comment on multiple lines.
 - Drag workspaces in the sidebar to persistently reorder them.
-- Drag agent sessions onto workspaces to move them into a new tab.
+- Reorder agent sessions by dragging them within the separate Agents panel.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add a website tutorial, History filters, and adjustable text size.
 - Drag across the Files annotation gutter to comment on multiple lines.
+- Drag workspaces in the sidebar to persistently reorder them.
 
 ### Changed
 
@@ -17,6 +18,9 @@
 - Make `Cmd+W` close only the active pane in split tabs.
 - Keep Diff scope labels on one line and mobile terminal shortcuts within view.
 - Preserve History focus and view mode during refresh; correct Grok timestamps.
+- Make terminal backgrounds and ANSI colors follow the light application theme,
+  and upgrade xterm so IME preedit stays inside the viewport and anchors to the
+  live cursor during TUI redraws.
 
 ## 0.5.1 - 2026-09-03
 

--- a/server/src/connections/runtime.ts
+++ b/server/src/connections/runtime.ts
@@ -48,6 +48,8 @@ const DEFAULT_EVENTS = [
   "workspace.renamed",
   "workspace.closed",
   "workspace.focused",
+  "workspace.moved",
+  "workspace.reordered",
   "tab.created",
   "tab.closed",
   "tab.renamed",

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -34,7 +34,7 @@
         "@shikijs/core": "^4.4.3",
         "@shikijs/langs": "^4.4.3",
         "@xterm/addon-clipboard": "^0.2.0",
-        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-fit": "0.12.0-beta.301",
         "@xterm/addon-unicode-graphemes": "^0.4.0",
         "@xterm/xterm": "6.1.0-beta.304",
         "beautiful-mermaid": "^1.1.3",
@@ -401,7 +401,7 @@
 
     "@xterm/addon-clipboard": ["@xterm/addon-clipboard@0.2.0", "", { "dependencies": { "js-base64": "^3.7.5" } }, "sha512-Dl31BCtBhLaUEECUbEiVcCLvLBbaeGYdT7NofB8OJkGTD3MWgBsaLjXvfGAD4tQNHhm6mbKyYkR7XD8kiZsdNg=="],
 
-    "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
+    "@xterm/addon-fit": ["@xterm/addon-fit@0.12.0-beta.301", "", { "peerDependencies": { "@xterm/xterm": "^6.1.0-beta.304" } }, "sha512-MukRyJLAFQrW/++aM209jBZ8G9J/Ioe4SGS6c3ba87v+zYuX/I66JrDB7sVfykQ9t7DlT+c1MWl1jTlX2kyx1w=="],
 
     "@xterm/addon-unicode-graphemes": ["@xterm/addon-unicode-graphemes@0.4.0", "", {}, "sha512-9+/CqwbKcnlkJU4d3wIgO+wjsL8f6vyz+UwUWLu6nADQz8Gr8ONqGCJfdDjIdI+yYZLABQqQy47FzEM6AWELjw=="],
 

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -36,7 +36,7 @@
         "@xterm/addon-clipboard": "^0.2.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-unicode-graphemes": "^0.4.0",
-        "@xterm/xterm": "^6.0.0",
+        "@xterm/xterm": "6.1.0-beta.304",
         "beautiful-mermaid": "^1.1.3",
         "cmdk": "^1.1.1",
         "codemirror": "^6.0.2",
@@ -405,7 +405,7 @@
 
     "@xterm/addon-unicode-graphemes": ["@xterm/addon-unicode-graphemes@0.4.0", "", {}, "sha512-9+/CqwbKcnlkJU4d3wIgO+wjsL8f6vyz+UwUWLu6nADQz8Gr8ONqGCJfdDjIdI+yYZLABQqQy47FzEM6AWELjw=="],
 
-    "@xterm/xterm": ["@xterm/xterm@6.0.0", "", {}, "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg=="],
+    "@xterm/xterm": ["@xterm/xterm@6.1.0-beta.304", "", {}, "sha512-Wq9d4qFYslYQBIan+riXotdyurtREc6v+HWdAwV6Y2JSDI9eJ1dkWm/fzYb2rCGgGnM3baiYuSK4Z6OLNKLzDw=="],
 
     "abbrev": ["abbrev@1.1.1", "", {}, "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -41,7 +41,7 @@
     "@shikijs/core": "^4.4.3",
     "@shikijs/langs": "^4.4.3",
     "@xterm/addon-clipboard": "^0.2.0",
-    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-fit": "0.12.0-beta.301",
     "@xterm/addon-unicode-graphemes": "^0.4.0",
     "@xterm/xterm": "6.1.0-beta.304",
     "beautiful-mermaid": "^1.1.3",

--- a/web/package.json
+++ b/web/package.json
@@ -43,7 +43,7 @@
     "@xterm/addon-clipboard": "^0.2.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-unicode-graphemes": "^0.4.0",
-    "@xterm/xterm": "^6.0.0",
+    "@xterm/xterm": "6.1.0-beta.304",
     "beautiful-mermaid": "^1.1.3",
     "cmdk": "^1.1.1",
     "codemirror": "^6.0.2",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -148,6 +148,7 @@ const LazyTerminalView = lazy(() =>
 
 type TerminalViewProps = {
   paneId?: string;
+  resolvedTheme: ResolvedTheme;
   showMobileKeys?: boolean;
   mobileShortcuts?: MobileTerminalShortcutRows;
   mobileSideShortcuts?: MobileTerminalSideShortcuts;
@@ -764,6 +765,7 @@ function resizeTargetForSplit(
 // Render the active tab's Herdr pane layout; single-pane and zoomed tabs keep
 // the old full terminal view.
 function TerminalPaneLayout({
+  resolvedTheme,
   mobileShortcuts,
   mobileSideShortcuts,
   composerOpen,
@@ -772,6 +774,7 @@ function TerminalPaneLayout({
   onAgentHistoryOpenChange,
   onOpenWorkspaceFile,
 }: {
+  resolvedTheme: ResolvedTheme;
   mobileShortcuts: MobileTerminalShortcutRows;
   mobileSideShortcuts: MobileTerminalSideShortcuts;
   composerOpen: boolean;
@@ -820,6 +823,7 @@ function TerminalPaneLayout({
     return (
       <TerminalView
         key={mountKeyForPane(activePaneId)}
+        resolvedTheme={resolvedTheme}
         mobileShortcuts={mobileShortcuts}
         mobileSideShortcuts={mobileSideShortcuts}
         composerOpen={composerOpen}
@@ -874,6 +878,7 @@ function TerminalPaneLayout({
         <TerminalView
           key={mountKeyForPane(activePaneId)}
           paneId={activePaneId}
+          resolvedTheme={resolvedTheme}
           mobileShortcuts={mobileShortcuts}
           mobileSideShortcuts={mobileSideShortcuts}
           composerOpen={composerOpen}
@@ -977,6 +982,7 @@ function TerminalPaneLayout({
             <TerminalView
               key={mountKeyForPane(layoutPane.pane_id)}
               paneId={layoutPane.pane_id}
+              resolvedTheme={resolvedTheme}
               showMobileKeys={isActive}
               mobileShortcuts={mobileShortcuts}
               mobileSideShortcuts={mobileSideShortcuts}
@@ -1053,6 +1059,7 @@ export default function App() {
   const [systemTheme, setSystemTheme] = useState<ResolvedTheme>(() =>
     loadSystemTheme(),
   );
+  const resolvedTheme: ResolvedTheme = theme === "system" ? systemTheme : theme;
   const [accentColor, setAccentColor] = useState<AccentColor>(() =>
     loadAccentColor(),
   );
@@ -2259,7 +2266,6 @@ export default function App() {
     return () => media.removeEventListener("change", onChange);
   }, []);
   useLayoutEffect(() => {
-    const resolvedTheme = theme === "system" ? systemTheme : theme;
     document.documentElement.dataset.theme = resolvedTheme;
     document.documentElement.style.colorScheme = resolvedTheme;
     localStorage.setItem(THEME_KEY, theme);
@@ -2276,7 +2282,7 @@ export default function App() {
       );
     }
     localStorage.setItem(UI_SCALE_KEY, String(uiScale));
-  }, [accentColor, systemTheme, theme, uiScale]);
+  }, [accentColor, resolvedTheme, theme, uiScale]);
   useEffect(() => {
     localStorage.setItem(
       MOBILE_TERMINAL_SHORTCUTS_STORAGE_KEY,
@@ -2816,6 +2822,7 @@ export default function App() {
           >
             <div className="workspace-terminal-surface">
               <TerminalPaneLayout
+                resolvedTheme={resolvedTheme}
                 mobileShortcuts={mobileTerminalShortcuts}
                 mobileSideShortcuts={mobileTerminalSideShortcuts}
                 composerOpen={terminalComposerOpen}

--- a/web/src/agentOrder.test.ts
+++ b/web/src/agentOrder.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import {
+  moveAgentPane,
+  orderAgentPanes,
+  parseAgentOrder,
+  serializeAgentOrder,
+} from "./agentOrder";
+
+describe("agent panel ordering", () => {
+  test("parses only bounded unique pane ids", () => {
+    expect(
+      parseAgentOrder(
+        JSON.stringify(["p2", "p1", "p2", 42, "", "x".repeat(513)]),
+      ),
+    ).toEqual(["p2", "p1"]);
+    expect(parseAgentOrder("bad json")).toEqual([]);
+    expect(parseAgentOrder("{}" as string)).toEqual([]);
+    expect(JSON.parse(serializeAgentOrder(["p2", "p1"]))).toEqual(["p2", "p1"]);
+  });
+
+  test("applies stored order and appends new panes in source order", () => {
+    const panes = [{ pane_id: "p1" }, { pane_id: "p2" }, { pane_id: "p3" }];
+    expect(
+      orderAgentPanes(panes, ["closed", "p3", "p1"]).map(
+        (pane) => pane.pane_id,
+      ),
+    ).toEqual(["p3", "p1", "p2"]);
+  });
+
+  test("moves panes before and after a drop target", () => {
+    expect(moveAgentPane(["p1", "p2", "p3"], "p3", "p1", "before")).toEqual([
+      "p3",
+      "p1",
+      "p2",
+    ]);
+    expect(moveAgentPane(["p1", "p2", "p3"], "p1", "p2", "after")).toEqual([
+      "p2",
+      "p1",
+      "p3",
+    ]);
+    expect(moveAgentPane(["p1", "p2"], "missing", "p1", "after")).toEqual([
+      "p1",
+      "p2",
+    ]);
+  });
+});

--- a/web/src/agentOrder.ts
+++ b/web/src/agentOrder.ts
@@ -1,0 +1,71 @@
+export const AGENT_ORDER_STORAGE_KEY = "agentOrder.v1";
+
+const MAX_AGENT_ORDER_ENTRIES = 512;
+const MAX_PANE_ID_LENGTH = 512;
+
+export function parseAgentOrder(raw: string | null): string[] {
+  if (!raw) return [];
+  try {
+    const value = JSON.parse(raw);
+    if (!Array.isArray(value)) return [];
+    const seen = new Set<string>();
+    const paneIds: string[] = [];
+    for (const candidate of value) {
+      if (
+        typeof candidate !== "string" ||
+        candidate.length === 0 ||
+        candidate.length > MAX_PANE_ID_LENGTH ||
+        seen.has(candidate)
+      ) {
+        continue;
+      }
+      seen.add(candidate);
+      paneIds.push(candidate);
+      if (paneIds.length >= MAX_AGENT_ORDER_ENTRIES) break;
+    }
+    return paneIds;
+  } catch {
+    return [];
+  }
+}
+
+export function serializeAgentOrder(paneIds: readonly string[]): string {
+  return JSON.stringify(paneIds.slice(0, MAX_AGENT_ORDER_ENTRIES));
+}
+
+export function orderAgentPanes<T extends { pane_id: string }>(
+  panes: readonly T[],
+  preferredPaneIds: readonly string[],
+): T[] {
+  const panesById = new Map(panes.map((pane) => [pane.pane_id, pane]));
+  const ordered: T[] = [];
+  const seen = new Set<string>();
+  for (const paneId of preferredPaneIds) {
+    const pane = panesById.get(paneId);
+    if (!pane || seen.has(paneId)) continue;
+    ordered.push(pane);
+    seen.add(paneId);
+  }
+  for (const pane of panes) {
+    if (seen.has(pane.pane_id)) continue;
+    ordered.push(pane);
+    seen.add(pane.pane_id);
+  }
+  return ordered;
+}
+
+export function moveAgentPane(
+  paneIds: readonly string[],
+  draggedPaneId: string,
+  targetPaneId: string,
+  position: "before" | "after",
+): string[] {
+  if (draggedPaneId === targetPaneId) return [...paneIds];
+  if (!paneIds.includes(draggedPaneId) || !paneIds.includes(targetPaneId)) {
+    return [...paneIds];
+  }
+  const next = paneIds.filter((paneId) => paneId !== draggedPaneId);
+  const targetIndex = next.indexOf(targetPaneId);
+  next.splice(targetIndex + (position === "after" ? 1 : 0), 0, draggedPaneId);
+  return next;
+}

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -91,12 +91,7 @@ import {
 } from "../terminalResize";
 import { terminalPageScroll, terminalWheelScroll } from "../terminalScroll";
 import { TerminalSelectionDragGuard } from "../terminalSelectionGuard";
-import {
-  inferTerminalCanvasBackground,
-  type TerminalRgb,
-  terminalAnsiForTheme,
-  terminalThemeFor,
-} from "../terminalThemes";
+import { applyTerminalTheme, terminalThemeFor } from "../terminalThemes";
 import { paneHasAgentHistory } from "./agentSession";
 import { ConfirmDialog, MessageDialog } from "./ModalDialogs";
 import { TerminalComposer } from "./TerminalComposer";
@@ -135,23 +130,6 @@ function sendBytes(
 
 const FONT_FAMILY =
   'SFMono-Regular, Menlo, Monaco, "0xProto Nerd Font Mono", "JetBrainsMonoNL Nerd Font", "MesloLGS NF", "Hack Nerd Font", "FiraCode Nerd Font", Consolas, "Liberation Mono", "Courier New", "Noto Sans Mono CJK SC", "Source Han Mono SC", "Sarasa Mono SC", "Herdr Nerd Symbols", monospace';
-const TERMINAL_CANVAS_BACKGROUND_PROPERTY = "--terminal-canvas-background";
-
-function applyTerminalTheme(
-  term: Terminal,
-  resolvedTheme: ResolvedTheme,
-  canvasBackground: TerminalRgb | null = null,
-) {
-  const theme = terminalThemeFor(resolvedTheme, canvasBackground);
-  term.options.theme = theme;
-  if (theme.background) {
-    term.element?.style.setProperty(
-      TERMINAL_CANVAS_BACKGROUND_PROPERTY,
-      theme.background,
-    );
-  }
-}
-
 const LINK_BLUE = "\x1b[94m";
 const RESET_FOREGROUND = "\x1b[39m";
 const ANSI_SEQUENCE_RE =
@@ -519,14 +497,8 @@ export function TerminalView({
   // and without an instance change in the deps the attach effect would not
   // fire again, leaving the recreated terminal detached and blank.
   const [termInstance, setTermInstance] = useState<Terminal | null>(null);
-  // The init effect intentionally does not depend on the theme: it reads the
-  // ref at mount, while the theme effect below requests a fresh Herdr frame.
+  // Theme changes update xterm in place without recreating the terminal.
   const resolvedThemeRef = useRef(resolvedTheme);
-  const terminalCanvasBackgroundRef = useRef<{
-    terminalId: string;
-    color: TerminalRgb;
-  } | null>(null);
-  const themeRefreshTerminalRef = useRef<string | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const attachedRef = useRef<string | null>(null);
   const attachingRef = useRef<string | null>(null);
@@ -803,9 +775,7 @@ export function TerminalView({
           if (url) window.open(url, "_blank", "noopener,noreferrer");
         },
       },
-      // xterm treats exactly 0 as "use the 14px platform default". A positive
-      // sub-pixel value rounds its internal scrollbar gutter down to zero.
-      scrollbar: { width: 0.01 },
+      scrollbar: { showScrollbar: false },
       scrollback: 2000,
     });
     const fit = new FitAddon();
@@ -901,39 +871,11 @@ export function TerminalView({
       }
       const text = b64toText(t.bytes);
       if (text === null) return;
-      if (t.full) {
-        const canvasBackground = inferTerminalCanvasBackground(text);
-        if (canvasBackground) {
-          terminalCanvasBackgroundRef.current = {
-            terminalId: t.terminal_id,
-            color: canvasBackground,
-          };
-          applyTerminalTheme(term, resolvedThemeRef.current, canvasBackground);
-        }
-        if (themeRefreshTerminalRef.current === t.terminal_id) {
-          themeRefreshTerminalRef.current = null;
-          applyTerminalTheme(term, resolvedThemeRef.current, canvasBackground);
-          term.reset();
-          renderedTerminalRef.current = t.terminal_id;
-        }
-      }
-      const canvasBackground =
-        terminalCanvasBackgroundRef.current?.terminalId === t.terminal_id
-          ? terminalCanvasBackgroundRef.current.color
-          : null;
       attachWatchdogRef.current?.markFrame();
       attachTimeoutCountRef.current = 0;
       setTerminalLoading(false);
       setTerminalAttachError("");
-      term.write(
-        colorHttpLinks(
-          terminalAnsiForTheme(
-            text,
-            resolvedThemeRef.current,
-            canvasBackground,
-          ),
-        ),
-      );
+      term.write(colorHttpLinks(text));
       focusTerminalSoon();
     });
     const offClipboard = bridge.onTerminalClipboard((clipboard) => {
@@ -1855,12 +1797,6 @@ export function TerminalView({
     // retry, reconnect): the server repaints a full frame anyway, and keeping
     // the buffer avoids a blank flash plus losing local scrollback.
     if (renderedTerminalRef.current !== terminalId) {
-      themeRefreshTerminalRef.current = null;
-      const canvasBackground =
-        terminalCanvasBackgroundRef.current?.terminalId === terminalId
-          ? terminalCanvasBackgroundRef.current.color
-          : null;
-      applyTerminalTheme(term, resolvedThemeRef.current, canvasBackground);
       term.reset();
       renderedTerminalRef.current = terminalId;
     }
@@ -1956,49 +1892,10 @@ export function TerminalView({
     termInstance,
   ]);
 
-  // Herdr's rendered frame contains an explicit true-color background on
-  // every cell, so changing xterm's theme alone leaves the old dark canvas in
-  // place. Ask Herdr for a same-size full repaint and swap themes immediately
-  // before that frame is written.
   useEffect(() => {
     resolvedThemeRef.current = resolvedTheme;
-    const term = termInstance;
-    if (!term) return;
-    const terminalId = attachedRef.current;
-    if (!terminalId) {
-      applyTerminalTheme(term, resolvedTheme);
-      return;
-    }
-    const size = fitVisibleTerminal() ?? { cols: term.cols, rows: term.rows };
-    const relaySize = relayViewportFor(size);
-    themeRefreshTerminalRef.current = terminalId;
-    connectionClient
-      .call("terminal.resize", {
-        terminal_id: terminalId,
-        cols: size.cols,
-        rows: size.rows,
-        relay_active: relaySize !== null,
-        ...(relaySize
-          ? { relay_cols: relaySize.cols, relay_rows: relaySize.rows }
-          : {}),
-      })
-      .catch(() => {
-        if (themeRefreshTerminalRef.current !== terminalId) return;
-        themeRefreshTerminalRef.current = null;
-        const canvasBackground =
-          terminalCanvasBackgroundRef.current?.terminalId === terminalId
-            ? terminalCanvasBackgroundRef.current.color
-            : null;
-        applyTerminalTheme(term, resolvedTheme, canvasBackground);
-        term.refresh(0, term.rows - 1);
-      });
-  }, [
-    connectionClient,
-    fitVisibleTerminal,
-    relayViewportFor,
-    resolvedTheme,
-    termInstance,
-  ]);
+    if (termInstance) applyTerminalTheme(termInstance, resolvedTheme);
+  }, [resolvedTheme, termInstance]);
 
   // Mobile browsers freeze the page while hidden: the socket can die
   // silently, rendering pauses, and composited content may come back blank.

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -18,6 +18,7 @@ import {
 } from "react";
 import "@xterm/xterm/css/xterm.css";
 import { bridge, type ConnectionClient } from "../api";
+import type { ResolvedTheme } from "../appearance";
 import { mobileTerminalShortcutExecution } from "../mobileTerminalShortcutAction";
 import {
   defaultMobileTerminalShortcutRows,
@@ -90,6 +91,12 @@ import {
 } from "../terminalResize";
 import { terminalPageScroll, terminalWheelScroll } from "../terminalScroll";
 import { TerminalSelectionDragGuard } from "../terminalSelectionGuard";
+import {
+  inferTerminalCanvasBackground,
+  type TerminalRgb,
+  terminalAnsiForTheme,
+  terminalThemeFor,
+} from "../terminalThemes";
 import { paneHasAgentHistory } from "./agentSession";
 import { ConfirmDialog, MessageDialog } from "./ModalDialogs";
 import { TerminalComposer } from "./TerminalComposer";
@@ -128,6 +135,23 @@ function sendBytes(
 
 const FONT_FAMILY =
   'SFMono-Regular, Menlo, Monaco, "0xProto Nerd Font Mono", "JetBrainsMonoNL Nerd Font", "MesloLGS NF", "Hack Nerd Font", "FiraCode Nerd Font", Consolas, "Liberation Mono", "Courier New", "Noto Sans Mono CJK SC", "Source Han Mono SC", "Sarasa Mono SC", "Herdr Nerd Symbols", monospace';
+const TERMINAL_CANVAS_BACKGROUND_PROPERTY = "--terminal-canvas-background";
+
+function applyTerminalTheme(
+  term: Terminal,
+  resolvedTheme: ResolvedTheme,
+  canvasBackground: TerminalRgb | null = null,
+) {
+  const theme = terminalThemeFor(resolvedTheme, canvasBackground);
+  term.options.theme = theme;
+  if (theme.background) {
+    term.element?.style.setProperty(
+      TERMINAL_CANVAS_BACKGROUND_PROPERTY,
+      theme.background,
+    );
+  }
+}
+
 const LINK_BLUE = "\x1b[94m";
 const RESET_FOREGROUND = "\x1b[39m";
 const ANSI_SEQUENCE_RE =
@@ -399,6 +423,7 @@ export type TerminalWorkspaceFileRequest = {
 
 export function TerminalView({
   paneId,
+  resolvedTheme,
   showMobileKeys = true,
   mobileShortcuts = defaultMobileTerminalShortcutRows(),
   mobileSideShortcuts = defaultMobileTerminalSideShortcuts(),
@@ -409,6 +434,7 @@ export function TerminalView({
   onOpenWorkspaceFile,
 }: {
   paneId?: string;
+  resolvedTheme: ResolvedTheme;
   showMobileKeys?: boolean;
   mobileShortcuts?: MobileTerminalShortcutRows;
   mobileSideShortcuts?: MobileTerminalSideShortcuts;
@@ -493,6 +519,14 @@ export function TerminalView({
   // and without an instance change in the deps the attach effect would not
   // fire again, leaving the recreated terminal detached and blank.
   const [termInstance, setTermInstance] = useState<Terminal | null>(null);
+  // The init effect intentionally does not depend on the theme: it reads the
+  // ref at mount, while the theme effect below requests a fresh Herdr frame.
+  const resolvedThemeRef = useRef(resolvedTheme);
+  const terminalCanvasBackgroundRef = useRef<{
+    terminalId: string;
+    color: TerminalRgb;
+  } | null>(null);
+  const themeRefreshTerminalRef = useRef<string | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const attachedRef = useRef<string | null>(null);
   const attachingRef = useRef<string | null>(null);
@@ -759,13 +793,7 @@ export function TerminalView({
       disableStdin: composerOpenRef.current,
       fontFamily: FONT_FAMILY,
       ...terminalDensity(),
-      theme: {
-        background: "#0b0d12",
-        foreground: "#c9cdd6",
-        cursor: "#c9cdd6",
-        overviewRulerBorder: "rgba(0,0,0,0)",
-        selectionBackground: "rgba(110,168,255,0.3)",
-      },
+      theme: terminalThemeFor(resolvedThemeRef.current),
       allowProposedApi: true,
       linkHandler: {
         activate(event, text) {
@@ -777,7 +805,7 @@ export function TerminalView({
       },
       // xterm treats exactly 0 as "use the 14px platform default". A positive
       // sub-pixel value rounds its internal scrollbar gutter down to zero.
-      overviewRuler: { width: 0.01 },
+      scrollbar: { width: 0.01 },
       scrollback: 2000,
     });
     const fit = new FitAddon();
@@ -873,11 +901,39 @@ export function TerminalView({
       }
       const text = b64toText(t.bytes);
       if (text === null) return;
+      if (t.full) {
+        const canvasBackground = inferTerminalCanvasBackground(text);
+        if (canvasBackground) {
+          terminalCanvasBackgroundRef.current = {
+            terminalId: t.terminal_id,
+            color: canvasBackground,
+          };
+          applyTerminalTheme(term, resolvedThemeRef.current, canvasBackground);
+        }
+        if (themeRefreshTerminalRef.current === t.terminal_id) {
+          themeRefreshTerminalRef.current = null;
+          applyTerminalTheme(term, resolvedThemeRef.current, canvasBackground);
+          term.reset();
+          renderedTerminalRef.current = t.terminal_id;
+        }
+      }
+      const canvasBackground =
+        terminalCanvasBackgroundRef.current?.terminalId === t.terminal_id
+          ? terminalCanvasBackgroundRef.current.color
+          : null;
       attachWatchdogRef.current?.markFrame();
       attachTimeoutCountRef.current = 0;
       setTerminalLoading(false);
       setTerminalAttachError("");
-      term.write(colorHttpLinks(text));
+      term.write(
+        colorHttpLinks(
+          terminalAnsiForTheme(
+            text,
+            resolvedThemeRef.current,
+            canvasBackground,
+          ),
+        ),
+      );
       focusTerminalSoon();
     });
     const offClipboard = bridge.onTerminalClipboard((clipboard) => {
@@ -1015,7 +1071,8 @@ export function TerminalView({
       observedAt: number,
     ) => {
       const shouldSend = imeFallback.recordInput(text, eventTime, observedAt);
-      if (shouldSend) sendText(text);
+      if (!shouldSend) return;
+      sendText(text);
     };
     const cancelImeTextareaFallback = () => {
       if (imeTextareaTimer !== null) {
@@ -1798,6 +1855,12 @@ export function TerminalView({
     // retry, reconnect): the server repaints a full frame anyway, and keeping
     // the buffer avoids a blank flash plus losing local scrollback.
     if (renderedTerminalRef.current !== terminalId) {
+      themeRefreshTerminalRef.current = null;
+      const canvasBackground =
+        terminalCanvasBackgroundRef.current?.terminalId === terminalId
+          ? terminalCanvasBackgroundRef.current.color
+          : null;
+      applyTerminalTheme(term, resolvedThemeRef.current, canvasBackground);
       term.reset();
       renderedTerminalRef.current = terminalId;
     }
@@ -1890,6 +1953,50 @@ export function TerminalView({
     s.terminalAttachEpoch,
     attachRetry,
     connectionClient,
+    termInstance,
+  ]);
+
+  // Herdr's rendered frame contains an explicit true-color background on
+  // every cell, so changing xterm's theme alone leaves the old dark canvas in
+  // place. Ask Herdr for a same-size full repaint and swap themes immediately
+  // before that frame is written.
+  useEffect(() => {
+    resolvedThemeRef.current = resolvedTheme;
+    const term = termInstance;
+    if (!term) return;
+    const terminalId = attachedRef.current;
+    if (!terminalId) {
+      applyTerminalTheme(term, resolvedTheme);
+      return;
+    }
+    const size = fitVisibleTerminal() ?? { cols: term.cols, rows: term.rows };
+    const relaySize = relayViewportFor(size);
+    themeRefreshTerminalRef.current = terminalId;
+    connectionClient
+      .call("terminal.resize", {
+        terminal_id: terminalId,
+        cols: size.cols,
+        rows: size.rows,
+        relay_active: relaySize !== null,
+        ...(relaySize
+          ? { relay_cols: relaySize.cols, relay_rows: relaySize.rows }
+          : {}),
+      })
+      .catch(() => {
+        if (themeRefreshTerminalRef.current !== terminalId) return;
+        themeRefreshTerminalRef.current = null;
+        const canvasBackground =
+          terminalCanvasBackgroundRef.current?.terminalId === terminalId
+            ? terminalCanvasBackgroundRef.current.color
+            : null;
+        applyTerminalTheme(term, resolvedTheme, canvasBackground);
+        term.refresh(0, term.rows - 1);
+      });
+  }, [
+    connectionClient,
+    fitVisibleTerminal,
+    relayViewportFor,
+    resolvedTheme,
     termInstance,
   ]);
 

--- a/web/src/components/WorkspaceAgentRows.tsx
+++ b/web/src/components/WorkspaceAgentRows.tsx
@@ -59,7 +59,10 @@ export function AgentRow({
   onOpenMenu: (x: number, y: number) => void;
   drag?: {
     isDragging: boolean;
+    dropPosition: "before" | "after" | null;
     onDragStart: (event: React.DragEvent<HTMLDivElement>) => void;
+    onDragOver: (event: React.DragEvent<HTMLDivElement>) => void;
+    onDrop: (event: React.DragEvent<HTMLDivElement>) => void;
     onDragEnd: () => void;
   };
 }) {
@@ -88,7 +91,7 @@ export function AgentRow({
         selected ? "is-selected" : ""
       } ${pane.focused ? "is-focused" : ""} ${
         drag?.isDragging ? "is-dragging" : ""
-      }`}
+      } ${drag?.dropPosition ? `drop-${drag.dropPosition}` : ""}`}
       style={
         nested
           ? { marginLeft: TREE_DEPTH_INDENT + depth * TREE_DEPTH_INDENT }
@@ -97,6 +100,8 @@ export function AgentRow({
       role={nested ? "treeitem" : "button"}
       draggable={!!drag}
       onDragStart={drag?.onDragStart}
+      onDragOver={drag?.onDragOver}
+      onDrop={drag?.onDrop}
       onDragEnd={drag?.onDragEnd}
       tabIndex={nested ? (selected ? 0 : -1) : 0}
       aria-level={nested ? depth + 1 : undefined}

--- a/web/src/components/WorkspaceAgentRows.tsx
+++ b/web/src/components/WorkspaceAgentRows.tsx
@@ -47,6 +47,7 @@ export function AgentRow({
   workspaceLabel,
   onSelect,
   onOpenMenu,
+  drag,
 }: {
   pane: Pane;
   selected: boolean;
@@ -56,6 +57,11 @@ export function AgentRow({
   workspaceLabel?: string;
   onSelect?: (pane: Pane) => void;
   onOpenMenu: (x: number, y: number) => void;
+  drag?: {
+    isDragging: boolean;
+    onDragStart: (event: React.DragEvent<HTMLDivElement>) => void;
+    onDragEnd: () => void;
+  };
 }) {
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const longPressStart = useRef<{ x: number; y: number } | null>(null);
@@ -80,13 +86,18 @@ export function AgentRow({
     <div
       className={`agent-row ${nested ? "is-nested" : "is-standalone"} ${
         selected ? "is-selected" : ""
-      } ${pane.focused ? "is-focused" : ""}`}
+      } ${pane.focused ? "is-focused" : ""} ${
+        drag?.isDragging ? "is-dragging" : ""
+      }`}
       style={
         nested
           ? { marginLeft: TREE_DEPTH_INDENT + depth * TREE_DEPTH_INDENT }
           : undefined
       }
       role={nested ? "treeitem" : "button"}
+      draggable={!!drag}
+      onDragStart={drag?.onDragStart}
+      onDragEnd={drag?.onDragEnd}
       tabIndex={nested ? (selected ? 0 : -1) : 0}
       aria-level={nested ? depth + 1 : undefined}
       aria-selected={nested ? selected : undefined}

--- a/web/src/components/WorkspaceTree.tsx
+++ b/web/src/components/WorkspaceTree.tsx
@@ -204,6 +204,12 @@ export function WorkspaceTree({
     workspaceId: string;
     position: "before" | "after";
   } | null>(null);
+  const [draggedAgentPaneId, setDraggedAgentPaneId] = useState<string | null>(
+    null,
+  );
+  const [agentDropWorkspaceId, setAgentDropWorkspaceId] = useState<
+    string | null
+  >(null);
   const [agentLayout, setAgentLayout] = useState<WorkspaceAgentLayout>(() =>
     parseWorkspaceAgentLayout(
       localStorage.getItem(WORKSPACE_AGENT_LAYOUT_STORAGE_KEY),
@@ -260,6 +266,8 @@ export function WorkspaceTree({
     setPendingClosePane(null);
     setDraggedWorkspaceId(null);
     setWorkspaceDropTarget(null);
+    setDraggedAgentPaneId(null);
+    setAgentDropWorkspaceId(null);
   }, [connectionClient]);
   useEffect(() => {
     localStorage.setItem(WORKSPACE_AGENT_LAYOUT_STORAGE_KEY, agentLayout);
@@ -336,6 +344,10 @@ export function WorkspaceTree({
     setDraggedWorkspaceId(null);
     setWorkspaceDropTarget(null);
   };
+  const clearAgentDrag = () => {
+    setDraggedAgentPaneId(null);
+    setAgentDropWorkspaceId(null);
+  };
   const workspaceDropPosition = (e: React.DragEvent<HTMLDivElement>) => {
     const rect = e.currentTarget.getBoundingClientRect();
     return e.clientY < rect.top + rect.height / 2 ? "before" : "after";
@@ -344,6 +356,7 @@ export function WorkspaceTree({
     workspace: Workspace,
     e: React.DragEvent<HTMLDivElement>,
   ) => {
+    clearAgentDrag();
     setDraggedWorkspaceId(workspace.workspace_id);
     e.dataTransfer.effectAllowed = "move";
     e.dataTransfer.setData("text/plain", workspace.workspace_id);
@@ -387,6 +400,64 @@ export function WorkspaceTree({
       return;
     }
     void store.moveWorkspace(draggedId, insertIndex);
+  };
+  const onAgentDragStart = (pane: Pane, e: React.DragEvent<HTMLDivElement>) => {
+    clearWorkspaceDrag();
+    setDraggedAgentPaneId(pane.pane_id);
+    e.dataTransfer.effectAllowed = "move";
+    e.dataTransfer.setData("application/x-herdr-pane-id", pane.pane_id);
+    e.dataTransfer.setData("text/plain", pane.pane_id);
+  };
+  const onAgentDragOverWorkspace = (
+    workspace: Workspace,
+    e: React.DragEvent<HTMLDivElement>,
+  ) => {
+    if (!draggedAgentPaneId) return;
+    const pane = s.panes.find(
+      (candidate) => candidate.pane_id === draggedAgentPaneId,
+    );
+    if (!pane || pane.workspace_id === workspace.workspace_id) {
+      setAgentDropWorkspaceId(null);
+      return;
+    }
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    setAgentDropWorkspaceId((current) =>
+      current === workspace.workspace_id ? current : workspace.workspace_id,
+    );
+  };
+  const onAgentDragLeaveWorkspace = (
+    workspace: Workspace,
+    e: React.DragEvent<HTMLDivElement>,
+  ) => {
+    const nextTarget = e.relatedTarget;
+    if (nextTarget instanceof Node && e.currentTarget.contains(nextTarget)) {
+      return;
+    }
+    setAgentDropWorkspaceId((current) =>
+      current === workspace.workspace_id ? null : current,
+    );
+  };
+  const onAgentDropOnWorkspace = (
+    workspace: Workspace,
+    e: React.DragEvent<HTMLDivElement>,
+  ) => {
+    if (!draggedAgentPaneId) return;
+    e.preventDefault();
+    const paneId = draggedAgentPaneId;
+    const pane = s.panes.find((candidate) => candidate.pane_id === paneId);
+    clearAgentDrag();
+    if (!pane || pane.workspace_id === workspace.workspace_id) return;
+    void store.movePaneToWorkspace(paneId, workspace.workspace_id);
+  };
+  const agentDrag: AgentDragProps = {
+    draggedPaneId: draggedAgentPaneId,
+    dropWorkspaceId: agentDropWorkspaceId,
+    onDragStart: onAgentDragStart,
+    onDragOverWorkspace: onAgentDragOverWorkspace,
+    onDragLeaveWorkspace: onAgentDragLeaveWorkspace,
+    onDropOnWorkspace: onAgentDropOnWorkspace,
+    onDragEnd: clearAgentDrag,
   };
 
   if (s.workspaces.length === 0) {
@@ -491,6 +562,7 @@ export function WorkspaceTree({
                 onDrop: (e) => onWorkspaceDrop(w, e),
                 onDragEnd: clearWorkspaceDrag,
               }}
+              agentDrag={agentDrag}
             />
           ))}
         </div>
@@ -522,6 +594,11 @@ export function WorkspaceTree({
                     }
                     onSelect={onSelectAgent}
                     onOpenMenu={(x, y) => setAgentMenu({ pane, x, y })}
+                    drag={{
+                      isDragging: draggedAgentPaneId === pane.pane_id,
+                      onDragStart: (event) => onAgentDragStart(pane, event),
+                      onDragEnd: clearAgentDrag,
+                    }}
                   />
                 );
               })
@@ -604,6 +681,25 @@ type WorkspaceDragProps = {
   onDragEnd: () => void;
 };
 
+type AgentDragProps = {
+  draggedPaneId: string | null;
+  dropWorkspaceId: string | null;
+  onDragStart: (pane: Pane, e: React.DragEvent<HTMLDivElement>) => void;
+  onDragOverWorkspace: (
+    workspace: Workspace,
+    e: React.DragEvent<HTMLDivElement>,
+  ) => void;
+  onDragLeaveWorkspace: (
+    workspace: Workspace,
+    e: React.DragEvent<HTMLDivElement>,
+  ) => void;
+  onDropOnWorkspace: (
+    workspace: Workspace,
+    e: React.DragEvent<HTMLDivElement>,
+  ) => void;
+  onDragEnd: () => void;
+};
+
 function workspaceSubtreeContainsActiveItem(
   workspace: Workspace,
   childrenByParent: ReadonlyMap<string, Workspace[]>,
@@ -644,6 +740,7 @@ function WorkspaceRow({
   onAgentContextMenu,
   onContextMenu,
   workspaceDrag,
+  agentDrag,
 }: {
   w: Workspace;
   depth: number;
@@ -658,6 +755,7 @@ function WorkspaceRow({
   onAgentContextMenu: (pane: Pane, x: number, y: number) => void;
   onContextMenu: (w: Workspace, x: number, y: number) => void;
   workspaceDrag?: WorkspaceDragProps;
+  agentDrag: AgentDragProps;
 }) {
   const children = childrenByParent.get(w.workspace_id) ?? [];
   const agents = agentsByWorkspace.get(w.workspace_id) ?? [];
@@ -745,13 +843,20 @@ function WorkspaceRow({
           workspaceDrag?.dropPosition
             ? `drop-${workspaceDrag.dropPosition}`
             : ""
-        }`}
+        } ${agentDrag.dropWorkspaceId === w.workspace_id ? "agent-drop-target" : ""}`}
         style={{ paddingLeft: 6 + depth * TREE_DEPTH_INDENT }}
         role="treeitem"
         draggable={!!workspaceDrag}
         onDragStart={workspaceDrag?.onDragStart}
-        onDragOver={workspaceDrag?.onDragOver}
-        onDrop={workspaceDrag?.onDrop}
+        onDragOver={(event) => {
+          workspaceDrag?.onDragOver(event);
+          agentDrag.onDragOverWorkspace(w, event);
+        }}
+        onDragLeave={(event) => agentDrag.onDragLeaveWorkspace(w, event)}
+        onDrop={(event) => {
+          workspaceDrag?.onDrop(event);
+          agentDrag.onDropOnWorkspace(w, event);
+        }}
         onDragEnd={workspaceDrag?.onDragEnd}
         tabIndex={
           workspaceTreeItemIsTabStop({
@@ -896,6 +1001,11 @@ function WorkspaceRow({
               }
               onSelect={onSelectAgent}
               onOpenMenu={(x, y) => onAgentContextMenu(pane, x, y)}
+              drag={{
+                isDragging: agentDrag.draggedPaneId === pane.pane_id,
+                onDragStart: (event) => agentDrag.onDragStart(pane, event),
+                onDragEnd: agentDrag.onDragEnd,
+              }}
             />
           ))}
           {children.map((child) => (
@@ -913,6 +1023,7 @@ function WorkspaceRow({
               onSelectAgent={onSelectAgent}
               onAgentContextMenu={onAgentContextMenu}
               onContextMenu={onContextMenu}
+              agentDrag={agentDrag}
             />
           ))}
         </>

--- a/web/src/components/WorkspaceTree.tsx
+++ b/web/src/components/WorkspaceTree.tsx
@@ -33,6 +33,13 @@ import {
 import { pruneClosedWorkspacePreferenceKeys } from "../workspacePreferences";
 import { connectionStorageKey } from "../connectionStorage";
 import {
+  AGENT_ORDER_STORAGE_KEY,
+  moveAgentPane,
+  orderAgentPanes,
+  parseAgentOrder,
+  serializeAgentOrder,
+} from "../agentOrder";
+import {
   WORKSPACE_AGENT_LAYOUT_STORAGE_KEY,
   type WorkspaceAgentLayout,
   parseWorkspaceAgentLayout,
@@ -194,6 +201,10 @@ export function WorkspaceTree({
     shallowEqual,
   );
   const connectionClient = useConnectionClient();
+  const agentOrderStorageKey = connectionStorageKey(
+    s.activeConnectionId,
+    AGENT_ORDER_STORAGE_KEY,
+  );
   const [menu, setMenu] = useState<ContextMenuState | null>(null);
   const [agentMenu, setAgentMenu] = useState<AgentMenuState | null>(null);
   const [pendingClosePane, setPendingClosePane] = useState<Pane | null>(null);
@@ -207,9 +218,13 @@ export function WorkspaceTree({
   const [draggedAgentPaneId, setDraggedAgentPaneId] = useState<string | null>(
     null,
   );
-  const [agentDropWorkspaceId, setAgentDropWorkspaceId] = useState<
-    string | null
-  >(null);
+  const [agentDropTarget, setAgentDropTarget] = useState<{
+    paneId: string;
+    position: "before" | "after";
+  } | null>(null);
+  const [agentPaneOrder, setAgentPaneOrder] = useState<string[]>(() =>
+    parseAgentOrder(localStorage.getItem(agentOrderStorageKey)),
+  );
   const [agentLayout, setAgentLayout] = useState<WorkspaceAgentLayout>(() =>
     parseWorkspaceAgentLayout(
       localStorage.getItem(WORKSPACE_AGENT_LAYOUT_STORAGE_KEY),
@@ -245,7 +260,7 @@ export function WorkspaceTree({
     () => groupAgentPanesByWorkspace(s.panes),
     [s.panes],
   );
-  const agentPanes = useMemo(() => {
+  const defaultAgentPanes = useMemo(() => {
     const workspaceNumbers = new Map(
       s.workspaces.map((workspace) => [
         workspace.workspace_id,
@@ -259,6 +274,10 @@ export function WorkspaceTree({
       return workspaceOrder || left.pane_id.localeCompare(right.pane_id);
     });
   }, [s.panes, s.workspaces]);
+  const agentPanes = useMemo(
+    () => orderAgentPanes(defaultAgentPanes, agentPaneOrder),
+    [agentPaneOrder, defaultAgentPanes],
+  );
 
   useEffect(() => {
     setMenu(null);
@@ -267,11 +286,17 @@ export function WorkspaceTree({
     setDraggedWorkspaceId(null);
     setWorkspaceDropTarget(null);
     setDraggedAgentPaneId(null);
-    setAgentDropWorkspaceId(null);
+    setAgentDropTarget(null);
   }, [connectionClient]);
   useEffect(() => {
     localStorage.setItem(WORKSPACE_AGENT_LAYOUT_STORAGE_KEY, agentLayout);
   }, [agentLayout]);
+  useEffect(() => {
+    localStorage.setItem(
+      agentOrderStorageKey,
+      serializeAgentOrder(agentPaneOrder),
+    );
+  }, [agentOrderStorageKey, agentPaneOrder]);
   useEffect(() => {
     localStorage.setItem(
       pinsStorageKey,
@@ -312,11 +337,13 @@ export function WorkspaceTree({
         );
       } else if (event.key === WORKSPACE_AGENT_LAYOUT_STORAGE_KEY) {
         setAgentLayout(parseWorkspaceAgentLayout(event.newValue));
+      } else if (event.key === agentOrderStorageKey) {
+        setAgentPaneOrder(parseAgentOrder(event.newValue));
       }
     };
     window.addEventListener("storage", onStorage);
     return () => window.removeEventListener("storage", onStorage);
-  }, [collapsedGroupsStorageKey, pinsStorageKey]);
+  }, [agentOrderStorageKey, collapsedGroupsStorageKey, pinsStorageKey]);
 
   const updatePinnedWorkspace = (workspace: Workspace, pinned: boolean) => {
     setPinnedWorkspaceKeys((current) =>
@@ -346,7 +373,7 @@ export function WorkspaceTree({
   };
   const clearAgentDrag = () => {
     setDraggedAgentPaneId(null);
-    setAgentDropWorkspaceId(null);
+    setAgentDropTarget(null);
   };
   const workspaceDropPosition = (e: React.DragEvent<HTMLDivElement>) => {
     const rect = e.currentTarget.getBoundingClientRect();
@@ -405,59 +432,34 @@ export function WorkspaceTree({
     clearWorkspaceDrag();
     setDraggedAgentPaneId(pane.pane_id);
     e.dataTransfer.effectAllowed = "move";
-    e.dataTransfer.setData("application/x-herdr-pane-id", pane.pane_id);
     e.dataTransfer.setData("text/plain", pane.pane_id);
   };
-  const onAgentDragOverWorkspace = (
-    workspace: Workspace,
-    e: React.DragEvent<HTMLDivElement>,
-  ) => {
-    if (!draggedAgentPaneId) return;
-    const pane = s.panes.find(
-      (candidate) => candidate.pane_id === draggedAgentPaneId,
-    );
-    if (!pane || pane.workspace_id === workspace.workspace_id) {
-      setAgentDropWorkspaceId(null);
-      return;
-    }
+  const onAgentDragOver = (pane: Pane, e: React.DragEvent<HTMLDivElement>) => {
+    if (!draggedAgentPaneId || draggedAgentPaneId === pane.pane_id) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = "move";
-    setAgentDropWorkspaceId((current) =>
-      current === workspace.workspace_id ? current : workspace.workspace_id,
+    const position = workspaceDropPosition(e);
+    setAgentDropTarget((current) =>
+      current?.paneId === pane.pane_id && current.position === position
+        ? current
+        : { paneId: pane.pane_id, position },
     );
   };
-  const onAgentDragLeaveWorkspace = (
-    workspace: Workspace,
-    e: React.DragEvent<HTMLDivElement>,
-  ) => {
-    const nextTarget = e.relatedTarget;
-    if (nextTarget instanceof Node && e.currentTarget.contains(nextTarget)) {
-      return;
-    }
-    setAgentDropWorkspaceId((current) =>
-      current === workspace.workspace_id ? null : current,
-    );
-  };
-  const onAgentDropOnWorkspace = (
-    workspace: Workspace,
-    e: React.DragEvent<HTMLDivElement>,
-  ) => {
+  const onAgentDrop = (pane: Pane, e: React.DragEvent<HTMLDivElement>) => {
     if (!draggedAgentPaneId) return;
     e.preventDefault();
-    const paneId = draggedAgentPaneId;
-    const pane = s.panes.find((candidate) => candidate.pane_id === paneId);
+    const draggedPaneId = draggedAgentPaneId;
+    const position = workspaceDropPosition(e);
     clearAgentDrag();
-    if (!pane || pane.workspace_id === workspace.workspace_id) return;
-    void store.movePaneToWorkspace(paneId, workspace.workspace_id);
-  };
-  const agentDrag: AgentDragProps = {
-    draggedPaneId: draggedAgentPaneId,
-    dropWorkspaceId: agentDropWorkspaceId,
-    onDragStart: onAgentDragStart,
-    onDragOverWorkspace: onAgentDragOverWorkspace,
-    onDragLeaveWorkspace: onAgentDragLeaveWorkspace,
-    onDropOnWorkspace: onAgentDropOnWorkspace,
-    onDragEnd: clearAgentDrag,
+    if (draggedPaneId === pane.pane_id) return;
+    setAgentPaneOrder(
+      moveAgentPane(
+        agentPanes.map((candidate) => candidate.pane_id),
+        draggedPaneId,
+        pane.pane_id,
+        position,
+      ),
+    );
   };
 
   if (s.workspaces.length === 0) {
@@ -562,7 +564,6 @@ export function WorkspaceTree({
                 onDrop: (e) => onWorkspaceDrop(w, e),
                 onDragEnd: clearWorkspaceDrag,
               }}
-              agentDrag={agentDrag}
             />
           ))}
         </div>
@@ -596,7 +597,13 @@ export function WorkspaceTree({
                     onOpenMenu={(x, y) => setAgentMenu({ pane, x, y })}
                     drag={{
                       isDragging: draggedAgentPaneId === pane.pane_id,
+                      dropPosition:
+                        agentDropTarget?.paneId === pane.pane_id
+                          ? agentDropTarget.position
+                          : null,
                       onDragStart: (event) => onAgentDragStart(pane, event),
+                      onDragOver: (event) => onAgentDragOver(pane, event),
+                      onDrop: (event) => onAgentDrop(pane, event),
                       onDragEnd: clearAgentDrag,
                     }}
                   />
@@ -681,25 +688,6 @@ type WorkspaceDragProps = {
   onDragEnd: () => void;
 };
 
-type AgentDragProps = {
-  draggedPaneId: string | null;
-  dropWorkspaceId: string | null;
-  onDragStart: (pane: Pane, e: React.DragEvent<HTMLDivElement>) => void;
-  onDragOverWorkspace: (
-    workspace: Workspace,
-    e: React.DragEvent<HTMLDivElement>,
-  ) => void;
-  onDragLeaveWorkspace: (
-    workspace: Workspace,
-    e: React.DragEvent<HTMLDivElement>,
-  ) => void;
-  onDropOnWorkspace: (
-    workspace: Workspace,
-    e: React.DragEvent<HTMLDivElement>,
-  ) => void;
-  onDragEnd: () => void;
-};
-
 function workspaceSubtreeContainsActiveItem(
   workspace: Workspace,
   childrenByParent: ReadonlyMap<string, Workspace[]>,
@@ -740,7 +728,6 @@ function WorkspaceRow({
   onAgentContextMenu,
   onContextMenu,
   workspaceDrag,
-  agentDrag,
 }: {
   w: Workspace;
   depth: number;
@@ -755,7 +742,6 @@ function WorkspaceRow({
   onAgentContextMenu: (pane: Pane, x: number, y: number) => void;
   onContextMenu: (w: Workspace, x: number, y: number) => void;
   workspaceDrag?: WorkspaceDragProps;
-  agentDrag: AgentDragProps;
 }) {
   const children = childrenByParent.get(w.workspace_id) ?? [];
   const agents = agentsByWorkspace.get(w.workspace_id) ?? [];
@@ -843,20 +829,13 @@ function WorkspaceRow({
           workspaceDrag?.dropPosition
             ? `drop-${workspaceDrag.dropPosition}`
             : ""
-        } ${agentDrag.dropWorkspaceId === w.workspace_id ? "agent-drop-target" : ""}`}
+        }`}
         style={{ paddingLeft: 6 + depth * TREE_DEPTH_INDENT }}
         role="treeitem"
         draggable={!!workspaceDrag}
         onDragStart={workspaceDrag?.onDragStart}
-        onDragOver={(event) => {
-          workspaceDrag?.onDragOver(event);
-          agentDrag.onDragOverWorkspace(w, event);
-        }}
-        onDragLeave={(event) => agentDrag.onDragLeaveWorkspace(w, event)}
-        onDrop={(event) => {
-          workspaceDrag?.onDrop(event);
-          agentDrag.onDropOnWorkspace(w, event);
-        }}
+        onDragOver={workspaceDrag?.onDragOver}
+        onDrop={workspaceDrag?.onDrop}
         onDragEnd={workspaceDrag?.onDragEnd}
         tabIndex={
           workspaceTreeItemIsTabStop({
@@ -1001,11 +980,6 @@ function WorkspaceRow({
               }
               onSelect={onSelectAgent}
               onOpenMenu={(x, y) => onAgentContextMenu(pane, x, y)}
-              drag={{
-                isDragging: agentDrag.draggedPaneId === pane.pane_id,
-                onDragStart: (event) => agentDrag.onDragStart(pane, event),
-                onDragEnd: agentDrag.onDragEnd,
-              }}
             />
           ))}
           {children.map((child) => (
@@ -1023,7 +997,6 @@ function WorkspaceRow({
               onSelectAgent={onSelectAgent}
               onAgentContextMenu={onAgentContextMenu}
               onContextMenu={onContextMenu}
-              agentDrag={agentDrag}
             />
           ))}
         </>

--- a/web/src/components/WorkspaceTree.tsx
+++ b/web/src/components/WorkspaceTree.tsx
@@ -197,6 +197,13 @@ export function WorkspaceTree({
   const [menu, setMenu] = useState<ContextMenuState | null>(null);
   const [agentMenu, setAgentMenu] = useState<AgentMenuState | null>(null);
   const [pendingClosePane, setPendingClosePane] = useState<Pane | null>(null);
+  const [draggedWorkspaceId, setDraggedWorkspaceId] = useState<string | null>(
+    null,
+  );
+  const [workspaceDropTarget, setWorkspaceDropTarget] = useState<{
+    workspaceId: string;
+    position: "before" | "after";
+  } | null>(null);
   const [agentLayout, setAgentLayout] = useState<WorkspaceAgentLayout>(() =>
     parseWorkspaceAgentLayout(
       localStorage.getItem(WORKSPACE_AGENT_LAYOUT_STORAGE_KEY),
@@ -251,6 +258,8 @@ export function WorkspaceTree({
     setMenu(null);
     setAgentMenu(null);
     setPendingClosePane(null);
+    setDraggedWorkspaceId(null);
+    setWorkspaceDropTarget(null);
   }, [connectionClient]);
   useEffect(() => {
     localStorage.setItem(WORKSPACE_AGENT_LAYOUT_STORAGE_KEY, agentLayout);
@@ -321,6 +330,63 @@ export function WorkspaceTree({
     setCollapsedWorktreeGroupKeys((current) =>
       setWorktreeGroupCollapsed(current, workspace, collapsed),
     );
+  };
+
+  const clearWorkspaceDrag = () => {
+    setDraggedWorkspaceId(null);
+    setWorkspaceDropTarget(null);
+  };
+  const workspaceDropPosition = (e: React.DragEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    return e.clientY < rect.top + rect.height / 2 ? "before" : "after";
+  };
+  const onWorkspaceDragStart = (
+    workspace: Workspace,
+    e: React.DragEvent<HTMLDivElement>,
+  ) => {
+    setDraggedWorkspaceId(workspace.workspace_id);
+    e.dataTransfer.effectAllowed = "move";
+    e.dataTransfer.setData("text/plain", workspace.workspace_id);
+  };
+  const onWorkspaceDragOver = (
+    workspace: Workspace,
+    e: React.DragEvent<HTMLDivElement>,
+  ) => {
+    if (!draggedWorkspaceId || draggedWorkspaceId === workspace.workspace_id) {
+      return;
+    }
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    const position = workspaceDropPosition(e);
+    setWorkspaceDropTarget((current) =>
+      current?.workspaceId === workspace.workspace_id &&
+      current.position === position
+        ? current
+        : { workspaceId: workspace.workspace_id, position },
+    );
+  };
+  const onWorkspaceDrop = (
+    workspace: Workspace,
+    e: React.DragEvent<HTMLDivElement>,
+  ) => {
+    e.preventDefault();
+    const draggedId = draggedWorkspaceId;
+    const position = workspaceDropPosition(e);
+    clearWorkspaceDrag();
+    if (!draggedId || draggedId === workspace.workspace_id) return;
+    const orderedIds = [...s.workspaces]
+      .sort((a, b) => a.number - b.number)
+      .map((candidate) => candidate.workspace_id);
+    const from = orderedIds.indexOf(draggedId);
+    const to = orderedIds.indexOf(workspace.workspace_id);
+    if (from < 0 || to < 0) return;
+    // workspace.move inserts before the entry currently at insert_index, so
+    // an insertion point past the dragged row lands one slot earlier.
+    const insertIndex = position === "before" ? to : to + 1;
+    if (from < insertIndex ? insertIndex - 1 === from : insertIndex === from) {
+      return;
+    }
+    void store.moveWorkspace(draggedId, insertIndex);
   };
 
   if (s.workspaces.length === 0) {
@@ -414,6 +480,17 @@ export function WorkspaceTree({
               onSelectAgent={onSelectAgent}
               onAgentContextMenu={(pane, x, y) => setAgentMenu({ pane, x, y })}
               onContextMenu={(w, x, y) => setMenu({ workspace: w, x, y })}
+              workspaceDrag={{
+                isDragging: draggedWorkspaceId === w.workspace_id,
+                dropPosition:
+                  workspaceDropTarget?.workspaceId === w.workspace_id
+                    ? workspaceDropTarget.position
+                    : null,
+                onDragStart: (e) => onWorkspaceDragStart(w, e),
+                onDragOver: (e) => onWorkspaceDragOver(w, e),
+                onDrop: (e) => onWorkspaceDrop(w, e),
+                onDragEnd: clearWorkspaceDrag,
+              }}
             />
           ))}
         </div>
@@ -518,6 +595,15 @@ export function WorkspaceTree({
   );
 }
 
+type WorkspaceDragProps = {
+  isDragging: boolean;
+  dropPosition: "before" | "after" | null;
+  onDragStart: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDragOver: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDrop: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDragEnd: () => void;
+};
+
 function workspaceSubtreeContainsActiveItem(
   workspace: Workspace,
   childrenByParent: ReadonlyMap<string, Workspace[]>,
@@ -557,6 +643,7 @@ function WorkspaceRow({
   onSelectAgent,
   onAgentContextMenu,
   onContextMenu,
+  workspaceDrag,
 }: {
   w: Workspace;
   depth: number;
@@ -570,6 +657,7 @@ function WorkspaceRow({
   onSelectAgent?: (pane: Pane) => void;
   onAgentContextMenu: (pane: Pane, x: number, y: number) => void;
   onContextMenu: (w: Workspace, x: number, y: number) => void;
+  workspaceDrag?: WorkspaceDragProps;
 }) {
   const children = childrenByParent.get(w.workspace_id) ?? [];
   const agents = agentsByWorkspace.get(w.workspace_id) ?? [];
@@ -653,9 +741,18 @@ function WorkspaceRow({
           hasActiveAgent ? "has-active-agent" : ""
         } ${isChild ? "is-child" : ""} ${pinned ? "is-pinned" : ""} ${
           isPendingFocus ? "is-loading" : ""
+        } ${workspaceDrag?.isDragging ? "is-dragging" : ""} ${
+          workspaceDrag?.dropPosition
+            ? `drop-${workspaceDrag.dropPosition}`
+            : ""
         }`}
         style={{ paddingLeft: 6 + depth * TREE_DEPTH_INDENT }}
         role="treeitem"
+        draggable={!!workspaceDrag}
+        onDragStart={workspaceDrag?.onDragStart}
+        onDragOver={workspaceDrag?.onDragOver}
+        onDrop={workspaceDrag?.onDrop}
+        onDragEnd={workspaceDrag?.onDragEnd}
         tabIndex={
           workspaceTreeItemIsTabStop({
             workspaceFocused: w.focused,

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -2084,6 +2084,17 @@ export const store = {
     );
   },
 
+  moveWorkspace(workspaceId: string, insertIndex: number) {
+    return action(
+      (lease) =>
+        lease.client.call("workspace.move", {
+          workspace_id: workspaceId,
+          insert_index: insertIndex,
+        }),
+      { refresh: "immediate" },
+    );
+  },
+
   gitPullWorkspace(workspaceId: string) {
     return action(
       async (lease) => {

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -2095,6 +2095,28 @@ export const store = {
     );
   },
 
+  movePaneToWorkspace(paneId: string, workspaceId: string) {
+    return action(
+      (lease) =>
+        lease.client.call("pane.move", {
+          pane_id: paneId,
+          destination: {
+            type: "new_tab",
+            workspace_id: workspaceId,
+          },
+          focus: false,
+        }),
+      {
+        refresh: "immediate",
+        failureNotice: (error) => ({
+          kind: "error",
+          message: "Agent move failed",
+          detail: error.message,
+        }),
+      },
+    );
+  },
+
   gitPullWorkspace(workspaceId: string) {
     return action(
       async (lease) => {

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -2095,28 +2095,6 @@ export const store = {
     );
   },
 
-  movePaneToWorkspace(paneId: string, workspaceId: string) {
-    return action(
-      (lease) =>
-        lease.client.call("pane.move", {
-          pane_id: paneId,
-          destination: {
-            type: "new_tab",
-            workspace_id: workspaceId,
-          },
-          focus: false,
-        }),
-      {
-        refresh: "immediate",
-        failureNotice: (error) => ({
-          kind: "error",
-          message: "Agent move failed",
-          detail: error.message,
-        }),
-      },
-    );
-  },
-
   gitPullWorkspace(workspaceId: string) {
     return action(
       async (lease) => {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2616,11 +2616,6 @@ textarea:focus {
 .tree-row.is-dragging {
   opacity: 0.45;
 }
-.tree-row.agent-drop-target {
-  background: color-mix(in srgb, var(--accent-soft) 82%, var(--panel));
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
-}
 .tree-row.drop-before::after,
 .tree-row.drop-after::after {
   content: "";
@@ -2872,21 +2867,42 @@ textarea:focus {
   overflow: auto;
 }
 .agent-row {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 6px;
   padding: 4px 6px;
   border-radius: 7px;
-  cursor: grab;
+  cursor: pointer;
   user-select: none;
   -webkit-user-select: none;
   -webkit-touch-callout: none;
 }
-.agent-row:active {
+.agent-row.is-standalone {
+  cursor: grab;
+}
+.agent-row.is-standalone:active {
   cursor: grabbing;
 }
 .agent-row.is-dragging {
   opacity: 0.45;
+}
+.agent-row.drop-before::after,
+.agent-row.drop-after::after {
+  content: "";
+  position: absolute;
+  left: 4px;
+  right: 4px;
+  height: 2px;
+  border-radius: 1px;
+  background: var(--accent);
+  pointer-events: none;
+}
+.agent-row.drop-before::after {
+  top: -1px;
+}
+.agent-row.drop-after::after {
+  bottom: -1px;
 }
 .agent-row:hover {
   background: var(--panel-2);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2616,6 +2616,11 @@ textarea:focus {
 .tree-row.is-dragging {
   opacity: 0.45;
 }
+.tree-row.agent-drop-target {
+  background: color-mix(in srgb, var(--accent-soft) 82%, var(--panel));
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
 .tree-row.drop-before::after,
 .tree-row.drop-after::after {
   content: "";
@@ -2872,10 +2877,16 @@ textarea:focus {
   gap: 6px;
   padding: 4px 6px;
   border-radius: 7px;
-  cursor: pointer;
+  cursor: grab;
   user-select: none;
   -webkit-user-select: none;
   -webkit-touch-callout: none;
+}
+.agent-row:active {
+  cursor: grabbing;
+}
+.agent-row.is-dragging {
+  opacity: 0.45;
 }
 .agent-row:hover {
   background: var(--panel-2);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6,6 +6,7 @@
   --panel-2: #24283b;
   --input-bg: #11141b;
   --terminal-bg: #0b0d12;
+  --terminal-fg: #c9cdd6;
   --border: #2f3549;
   --border-soft: rgba(255, 255, 255, 0.07);
   --text: #d5dcff;
@@ -85,7 +86,8 @@
   --panel: #d8d9e0;
   --panel-2: #c4c8da;
   --input-bg: #f6f7f9;
-  --terminal-bg: #0b0d12;
+  --terminal-bg: #f6f7f9;
+  --terminal-fg: #2b3245;
   --border: #b6bbd1;
   --border-soft: rgba(31, 47, 102, 0.12);
   --text: #1f2f66;
@@ -2520,6 +2522,7 @@ textarea:focus {
   color: var(--text-strong);
 }
 .tree-row {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 6px;
@@ -2609,6 +2612,26 @@ textarea:focus {
 }
 .tree-row.is-pinned:not(.is-focused) {
   background: color-mix(in srgb, var(--panel-2) 62%, transparent);
+}
+.tree-row.is-dragging {
+  opacity: 0.45;
+}
+.tree-row.drop-before::after,
+.tree-row.drop-after::after {
+  content: "";
+  position: absolute;
+  left: 4px;
+  right: 4px;
+  height: 2px;
+  border-radius: 1px;
+  background: var(--accent);
+  pointer-events: none;
+}
+.tree-row.drop-before::after {
+  top: -1px;
+}
+.tree-row.drop-after::after {
+  bottom: -1px;
 }
 .row-spinner {
   width: 10px;
@@ -7282,10 +7305,18 @@ textarea:focus {
    */
   letter-spacing: 0 !important;
 }
-.terminal-view .xterm-viewport {
+.terminal-view .xterm:not(.allow-transparency) .xterm-viewport {
+  /* xterm.css hard-codes black here, which otherwise leaks through below the
+     final fractional-height row and around the terminal padding. Include
+     xterm's transparency state so this wins even when its CSS loads later. */
+  background-color: var(--terminal-canvas-background, var(--terminal-bg));
   overflow-y: auto;
   overscroll-behavior: contain;
   touch-action: none;
+}
+.terminal-view .xterm .composition-view {
+  background-color: var(--terminal-canvas-background, var(--terminal-bg));
+  color: var(--terminal-fg);
 }
 .terminal-pane-toolbar {
   position: absolute;

--- a/web/src/terminalFit.test.ts
+++ b/web/src/terminalFit.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test";
+import { FitAddon } from "@xterm/addon-fit";
+import { Terminal } from "@xterm/xterm";
+
+test("FitAddon does not reserve a gutter for xterm's hidden scrollbar", () => {
+  const term = new Terminal({
+    allowProposedApi: true,
+    scrollback: 2000,
+    scrollbar: { showScrollbar: false },
+  });
+  const parentElement = {};
+  const element = {
+    parentElement,
+    ownerDocument: {
+      defaultView: {
+        getComputedStyle(target: unknown) {
+          return {
+            getPropertyValue(property: string) {
+              if (target !== parentElement) return "0px";
+              return property === "width" ? "1005px" : "500px";
+            },
+          };
+        },
+      },
+    },
+  };
+  Object.assign(parentElement, { ownerDocument: element.ownerDocument });
+  // Supply measured DOM geometry; use the installed xterm and addon together.
+  Object.defineProperties(term, {
+    element: { value: element },
+    dimensions: { value: { css: { cell: { width: 10, height: 20 } } } },
+  });
+  const fit = new FitAddon();
+  try {
+    term.loadAddon(fit);
+    expect(fit.proposeDimensions()).toEqual({ cols: 100, rows: 25 });
+    fit.fit();
+    expect(term.cols).toBe(100);
+    expect(term.rows).toBe(25);
+    term.options.scrollbar = { showScrollbar: true, width: 14 };
+    expect(fit.proposeDimensions()).toEqual({ cols: 99, rows: 25 });
+  } finally {
+    term.dispose();
+  }
+});

--- a/web/src/terminalThemes.test.ts
+++ b/web/src/terminalThemes.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import {
+  inferTerminalCanvasBackground,
+  terminalAnsiForTheme,
+  terminalThemeFor,
+} from "./terminalThemes";
+
+describe("terminal theme ANSI adaptation", () => {
+  test("matches dark xterm chrome to the rendered canvas background", () => {
+    expect(terminalThemeFor("dark", [40, 44, 52]).background).toBe(
+      "rgb(40 44 52)",
+    );
+    expect(terminalThemeFor("light", [40, 44, 52]).background).toBe("#f6f7f9");
+  });
+
+  test("infers the dominant true-color background from blank full-frame cells", () => {
+    const frame = [
+      "\x1b[0;39;48;2;40;44;52m ",
+      "\x1b[0;39;48;2;40;44;52m ",
+      "\x1b[0;38;2;255;0;0;48;2;9;10;11mX",
+      "\x1b[0;39;48;2;9;10;11m ",
+    ].join("");
+
+    expect(inferTerminalCanvasBackground(frame)).toEqual([40, 44, 52]);
+  });
+
+  test("uses the xterm default background in light mode", () => {
+    const frame =
+      "\x1b[0;39;48;2;40;44;52mA" + "\x1b[1;38;2;255;0;0;48;2;9;10;11mB";
+
+    expect(terminalAnsiForTheme(frame, "light", [40, 44, 52])).toBe(
+      "\x1b[0;39;49mA\x1b[1;38;2;255;0;0;48;2;9;10;11mB",
+    );
+  });
+
+  test("preserves CLI-owned ANSI, indexed, and true-color foregrounds", () => {
+    const frame = [
+      "\x1b[31;48;2;40;44;52mred",
+      "\x1b[38;5;208;48;5;17mindexed",
+      "\x1b[38;2;1;2;3;48;2;4;5;6mtrue-color",
+    ].join("");
+
+    expect(terminalAnsiForTheme(frame, "light", [40, 44, 52])).toBe(
+      "\x1b[31;49mred" +
+        "\x1b[38;5;208;48;5;17mindexed" +
+        "\x1b[38;2;1;2;3;48;2;4;5;6mtrue-color",
+    );
+  });
+
+  test("leaves the core frame unchanged in dark mode", () => {
+    const frame = "\x1b[0;39;48;2;40;44;52mA";
+
+    expect(terminalAnsiForTheme(frame, "dark", [40, 44, 52])).toBe(frame);
+  });
+});

--- a/web/src/terminalThemes.test.ts
+++ b/web/src/terminalThemes.test.ts
@@ -1,55 +1,58 @@
 import { describe, expect, test } from "bun:test";
-import {
-  inferTerminalCanvasBackground,
-  terminalAnsiForTheme,
-  terminalThemeFor,
-} from "./terminalThemes";
+import { Terminal } from "@xterm/xterm";
+import { applyTerminalTheme, terminalThemeFor } from "./terminalThemes";
 
-describe("terminal theme ANSI adaptation", () => {
-  test("matches dark xterm chrome to the rendered canvas background", () => {
-    expect(terminalThemeFor("dark", [40, 44, 52]).background).toBe(
-      "rgb(40 44 52)",
-    );
-    expect(terminalThemeFor("light", [40, 44, 52]).background).toBe("#f6f7f9");
+describe("terminal themes", () => {
+  test("changes defaults and the ANSI palette without changing dark defaults", () => {
+    expect(terminalThemeFor("dark").background).toBe("#0b0d12");
+    expect(terminalThemeFor("dark").red).toBeUndefined();
+    expect(terminalThemeFor("light").background).toBe("#f6f7f9");
+    expect(terminalThemeFor("light").red).toBe("#cf222e");
   });
 
-  test("infers the dominant true-color background from blank full-frame cells", () => {
-    const frame = [
-      "\x1b[0;39;48;2;40;44;52m ",
-      "\x1b[0;39;48;2;40;44;52m ",
-      "\x1b[0;38;2;255;0;0;48;2;9;10;11mX",
-      "\x1b[0;39;48;2;9;10;11m ",
-    ].join("");
-
-    expect(inferTerminalCanvasBackground(frame)).toEqual([40, 44, 52]);
+  test("preserves explicit backgrounds when Herdr elides repeated SGR", async () => {
+    const term = new Terminal({ allowProposedApi: true, cols: 120, rows: 3 });
+    try {
+      const frame =
+        "\x1b[0;39;48;2;40;44;52mA" +
+        " ".repeat(100) +
+        "\x1b[0;38;2;255;255;255;48;2;80;0;0m X";
+      await new Promise<void>((resolve) => term.write(frame, resolve));
+      for (const theme of ["light", "dark"] as const) {
+        applyTerminalTheme(term, theme);
+        const line = term.buffer.active.getLine(0)!;
+        expect(line.getCell(100)?.getBgColor()).toBe(0x282c34);
+        expect(line.getCell(101)?.getBgColor()).toBe(0x500000);
+        expect(line.getCell(102)?.getChars()).toBe("X");
+        expect(term.options.theme?.background).toBe(
+          terminalThemeFor(theme).background,
+        );
+      }
+    } finally {
+      term.dispose();
+    }
   });
 
-  test("uses the xterm default background in light mode", () => {
-    const frame =
-      "\x1b[0;39;48;2;40;44;52mA" + "\x1b[1;38;2;255;0;0;48;2;9;10;11mB";
-
-    expect(terminalAnsiForTheme(frame, "light", [40, 44, 52])).toBe(
-      "\x1b[0;39;49mA\x1b[1;38;2;255;0;0;48;2;9;10;11mB",
-    );
-  });
-
-  test("preserves CLI-owned ANSI, indexed, and true-color foregrounds", () => {
-    const frame = [
-      "\x1b[31;48;2;40;44;52mred",
-      "\x1b[38;5;208;48;5;17mindexed",
-      "\x1b[38;2;1;2;3;48;2;4;5;6mtrue-color",
-    ].join("");
-
-    expect(terminalAnsiForTheme(frame, "light", [40, 44, 52])).toBe(
-      "\x1b[31;49mred" +
-        "\x1b[38;5;208;48;5;17mindexed" +
-        "\x1b[38;2;1;2;3;48;2;4;5;6mtrue-color",
-    );
-  });
-
-  test("leaves the core frame unchanged in dark mode", () => {
-    const frame = "\x1b[0;39;48;2;40;44;52mA";
-
-    expect(terminalAnsiForTheme(frame, "dark", [40, 44, 52])).toBe(frame);
+  test("leaves RGB components and indexed colors to xterm's parser", async () => {
+    const term = new Terminal({ allowProposedApi: true });
+    try {
+      for (const theme of ["light", "dark"] as const) {
+        applyTerminalTheme(term, theme);
+        await new Promise<void>((resolve) =>
+          term.write(
+            "\x1b[H\x1b[0;38;2;48;2;200;48;2;40;44;52mX" +
+              "\x1b[38;5;208;48;5;17mY",
+            resolve,
+          ),
+        );
+        const line = term.buffer.active.getLine(0)!;
+        expect(line.getCell(0)?.getFgColor()).toBe(0x3002c8);
+        expect(line.getCell(0)?.getBgColor()).toBe(0x282c34);
+        expect(line.getCell(1)?.getFgColor()).toBe(208);
+        expect(line.getCell(1)?.getBgColor()).toBe(17);
+      }
+    } finally {
+      term.dispose();
+    }
   });
 });

--- a/web/src/terminalThemes.ts
+++ b/web/src/terminalThemes.ts
@@ -1,0 +1,130 @@
+import type { ITheme } from "@xterm/xterm";
+import type { ResolvedTheme } from "./appearance";
+
+export type TerminalRgb = readonly [red: number, green: number, blue: number];
+
+// Dark keeps the historical palette exactly: only background, foreground,
+// cursor, and selection are overridden; ANSI colors stay at xterm defaults.
+const DARK_TERMINAL_THEME: ITheme = {
+  background: "#0b0d12",
+  foreground: "#c9cdd6",
+  cursor: "#c9cdd6",
+  overviewRulerBorder: "rgba(0,0,0,0)",
+  selectionBackground: "rgba(110,168,255,0.3)",
+};
+
+// Light mode needs the full 16-color ANSI palette: the dark-oriented default
+// palette (bright blues, greens, yellows) is unreadable on a light background.
+const LIGHT_TERMINAL_THEME: ITheme = {
+  background: "#f6f7f9",
+  foreground: "#2b3245",
+  cursor: "#2b3245",
+  overviewRulerBorder: "rgba(0,0,0,0)",
+  selectionBackground: "rgba(46,125,233,0.25)",
+  black: "#24292f",
+  red: "#cf222e",
+  green: "#116329",
+  yellow: "#7d4e00",
+  blue: "#0969da",
+  magenta: "#8250df",
+  cyan: "#1b7c83",
+  white: "#6e7781",
+  brightBlack: "#57606a",
+  brightRed: "#a40e26",
+  brightGreen: "#1a7f37",
+  brightYellow: "#9a6700",
+  brightBlue: "#0550ae",
+  brightMagenta: "#6639ba",
+  brightCyan: "#0a6b74",
+  brightWhite: "#8c959f",
+};
+
+function terminalRgbCss(rgb: TerminalRgb): string {
+  return `rgb(${rgb.join(" ")})`;
+}
+
+export function terminalThemeFor(
+  resolvedTheme: ResolvedTheme,
+  canvasBackground: TerminalRgb | null = null,
+): ITheme {
+  if (resolvedTheme === "light") return LIGHT_TERMINAL_THEME;
+  return canvasBackground
+    ? { ...DARK_TERMINAL_THEME, background: terminalRgbCss(canvasBackground) }
+    : DARK_TERMINAL_THEME;
+}
+
+const SGR_WITH_CELL_RE = /\x1b\[([0-9;:]*)m([^\x1b]?)/g;
+const SGR_RE = /\x1b\[([0-9;:]*)m/g;
+
+function trueColorBackground(params: string): TerminalRgb | null {
+  const values = params.split(";").map(Number);
+  for (let index = 0; index <= values.length - 5; index += 1) {
+    if (values[index] !== 48 || values[index + 1] !== 2) continue;
+    const red = values[index + 2];
+    const green = values[index + 3];
+    const blue = values[index + 4];
+    if (
+      Number.isInteger(red) &&
+      Number.isInteger(green) &&
+      Number.isInteger(blue) &&
+      red >= 0 &&
+      red <= 255 &&
+      green >= 0 &&
+      green <= 255 &&
+      blue >= 0 &&
+      blue <= 255
+    ) {
+      return [red, green, blue];
+    }
+  }
+  return null;
+}
+
+function rgbKey(rgb: TerminalRgb): string {
+  return rgb.join(",");
+}
+
+/**
+ * Herdr's TerminalAnsi renderer paints every cell with the resolved core theme
+ * background instead of emitting ANSI default-background (49). Infer that
+ * canvas color from blank cells in a full frame so a browser can substitute
+ * its own light background without recoloring application-owned backgrounds.
+ */
+export function inferTerminalCanvasBackground(
+  fullFrame: string,
+): TerminalRgb | null {
+  const counts = new Map<string, { count: number; rgb: TerminalRgb }>();
+  for (const match of fullFrame.matchAll(SGR_WITH_CELL_RE)) {
+    if (match[2] !== " ") continue;
+    const rgb = trueColorBackground(match[1] ?? "");
+    if (!rgb) continue;
+    const key = rgbKey(rgb);
+    const current = counts.get(key);
+    counts.set(key, { count: (current?.count ?? 0) + 1, rgb });
+  }
+  let best: { count: number; rgb: TerminalRgb } | null = null;
+  for (const candidate of counts.values()) {
+    if (!best || candidate.count > best.count) best = candidate;
+  }
+  return best?.rgb ?? null;
+}
+
+/** Replace only Herdr's inferred canvas background; true-color output stays intact. */
+export function terminalAnsiForTheme(
+  text: string,
+  resolvedTheme: ResolvedTheme,
+  canvasBackground: TerminalRgb | null,
+): string {
+  if (resolvedTheme !== "light" || !canvasBackground) return text;
+  const expected = rgbKey(canvasBackground);
+  return text.replace(SGR_RE, (sequence, params: string) => {
+    const values = params.split(";");
+    for (let index = 0; index <= values.length - 5; index += 1) {
+      if (values[index] !== "48" || values[index + 1] !== "2") continue;
+      if (values.slice(index + 2, index + 5).join(",") !== expected) continue;
+      values.splice(index, 5, "49");
+      return `\x1b[${values.join(";")}m`;
+    }
+    return sequence;
+  });
+}

--- a/web/src/terminalThemes.ts
+++ b/web/src/terminalThemes.ts
@@ -1,7 +1,5 @@
-import type { ITheme } from "@xterm/xterm";
+import type { ITheme, Terminal } from "@xterm/xterm";
 import type { ResolvedTheme } from "./appearance";
-
-export type TerminalRgb = readonly [red: number, green: number, blue: number];
 
 // Dark keeps the historical palette exactly: only background, foreground,
 // cursor, and selection are overridden; ANSI colors stay at xterm defaults.
@@ -39,92 +37,23 @@ const LIGHT_TERMINAL_THEME: ITheme = {
   brightWhite: "#8c959f",
 };
 
-function terminalRgbCss(rgb: TerminalRgb): string {
-  return `rgb(${rgb.join(" ")})`;
+export function terminalThemeFor(resolvedTheme: ResolvedTheme): ITheme {
+  return resolvedTheme === "light" ? LIGHT_TERMINAL_THEME : DARK_TERMINAL_THEME;
 }
 
-export function terminalThemeFor(
+export function applyTerminalTheme(
+  term: Terminal,
   resolvedTheme: ResolvedTheme,
-  canvasBackground: TerminalRgb | null = null,
-): ITheme {
-  if (resolvedTheme === "light") return LIGHT_TERMINAL_THEME;
-  return canvasBackground
-    ? { ...DARK_TERMINAL_THEME, background: terminalRgbCss(canvasBackground) }
-    : DARK_TERMINAL_THEME;
-}
-
-const SGR_WITH_CELL_RE = /\x1b\[([0-9;:]*)m([^\x1b]?)/g;
-const SGR_RE = /\x1b\[([0-9;:]*)m/g;
-
-function trueColorBackground(params: string): TerminalRgb | null {
-  const values = params.split(";").map(Number);
-  for (let index = 0; index <= values.length - 5; index += 1) {
-    if (values[index] !== 48 || values[index + 1] !== 2) continue;
-    const red = values[index + 2];
-    const green = values[index + 3];
-    const blue = values[index + 4];
-    if (
-      Number.isInteger(red) &&
-      Number.isInteger(green) &&
-      Number.isInteger(blue) &&
-      red >= 0 &&
-      red <= 255 &&
-      green >= 0 &&
-      green <= 255 &&
-      blue >= 0 &&
-      blue <= 255
-    ) {
-      return [red, green, blue];
-    }
+) {
+  // The ANSI stream does not distinguish Herdr's resolved default background
+  // from an application's explicit RGB background. Preserve both; only xterm
+  // defaults and its ANSI palette follow the app theme. No repaint/reset is needed.
+  const theme = terminalThemeFor(resolvedTheme);
+  term.options.theme = theme;
+  if (theme.background) {
+    term.element?.style.setProperty(
+      "--terminal-canvas-background",
+      theme.background,
+    );
   }
-  return null;
-}
-
-function rgbKey(rgb: TerminalRgb): string {
-  return rgb.join(",");
-}
-
-/**
- * Herdr's TerminalAnsi renderer paints every cell with the resolved core theme
- * background instead of emitting ANSI default-background (49). Infer that
- * canvas color from blank cells in a full frame so a browser can substitute
- * its own light background without recoloring application-owned backgrounds.
- */
-export function inferTerminalCanvasBackground(
-  fullFrame: string,
-): TerminalRgb | null {
-  const counts = new Map<string, { count: number; rgb: TerminalRgb }>();
-  for (const match of fullFrame.matchAll(SGR_WITH_CELL_RE)) {
-    if (match[2] !== " ") continue;
-    const rgb = trueColorBackground(match[1] ?? "");
-    if (!rgb) continue;
-    const key = rgbKey(rgb);
-    const current = counts.get(key);
-    counts.set(key, { count: (current?.count ?? 0) + 1, rgb });
-  }
-  let best: { count: number; rgb: TerminalRgb } | null = null;
-  for (const candidate of counts.values()) {
-    if (!best || candidate.count > best.count) best = candidate;
-  }
-  return best?.rgb ?? null;
-}
-
-/** Replace only Herdr's inferred canvas background; true-color output stays intact. */
-export function terminalAnsiForTheme(
-  text: string,
-  resolvedTheme: ResolvedTheme,
-  canvasBackground: TerminalRgb | null,
-): string {
-  if (resolvedTheme !== "light" || !canvasBackground) return text;
-  const expected = rgbKey(canvasBackground);
-  return text.replace(SGR_RE, (sequence, params: string) => {
-    const values = params.split(";");
-    for (let index = 0; index <= values.length - 5; index += 1) {
-      if (values[index] !== "48" || values[index + 1] !== "2") continue;
-      if (values.slice(index + 2, index + 5).join(",") !== expected) continue;
-      values.splice(index, 5, "49");
-      return `\x1b[${values.join(";")}m`;
-    }
-    return sequence;
-  });
 }


### PR DESCRIPTION
## Summary

- add drag-and-drop workspace ordering and persistent per-connection ordering within the separate Agents panel
- make terminal rendering follow the resolved app theme while preserving CLI-owned ANSI colors and matching xterm chrome to the rendered canvas background
- upgrade xterm to a pinned 6.1.0 beta for the upstream IME composition anchoring and overflow fixes; switch back to the stable channel when 6.1.0 is released

## Verification

- `bun run precommit` (953 passed, 1 live SSH test skipped)
- `bun run build:darwin-arm64`
- manually verified light and dark terminal backgrounds on the built app at DPR 1 and DPR 2
- manually verified Apple Chinese IME preedit anchoring after repeated full-width punctuation
- unit-tested stored agent ordering, new-agent insertion, and before/after drag moves