### PR TITLE
Theme the terminal loading overlay and delay it during pastes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixed
+
+- Follow the terminal theme for the terminal loading overlay and delay its
+  appearance during pastes, so pasting no longer flashes a dark layer over a
+  light terminal.
+
 ## 0.5.2 - 2026-09-06
 
 ### Added

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -72,6 +72,7 @@ import {
   sanitizeTerminalHttpUrl,
 } from "../terminalLinks";
 import {
+  createTerminalPasteRunner,
   type TerminalPasteTextareaSnapshot,
   terminalPasteInputText,
   terminalPasteRequest,
@@ -135,9 +136,6 @@ const RESET_FOREGROUND = "\x1b[39m";
 const ANSI_SEQUENCE_RE =
   /\x1b\][\s\S]*?(?:\x07|\x1b\\)|\x1b\[[0-?]*[ -/]*[@-~]|\x1b[@-Z\\-_]/g;
 const CLIPBOARD_READ_TIMEOUT_MS = 2000;
-// Spinner-delay pattern: a paste that settles within this window never
-// surfaces the loading overlay, so quick pastes do not flash it at all.
-const PASTE_LOADING_DELAY_MS = 200;
 const TERMINAL_EVICTION_WINDOW_MS = 60_000;
 const TERMINAL_EVICTION_MAX_RETRIES = 3;
 
@@ -1041,44 +1039,11 @@ export function TerminalView({
       window.clearTimeout(pasteTextareaClearTimer);
       pasteTextareaClearTimer = null;
     };
-    let pasteOperationCount = 0;
-    let pasteLoadingTimer: number | null = null;
-    const cancelPasteLoadingTimer = () => {
-      if (pasteLoadingTimer === null) return;
-      window.clearTimeout(pasteLoadingTimer);
-      pasteLoadingTimer = null;
-    };
-    const runPasteOperation = async <T,>(operation: () => Promise<T>) => {
-      if (!connectionClient.isCurrent()) {
-        throw new Error("connection changed during paste");
-      }
-      pasteOperationCount += 1;
-      // One timer per busy period: the overlay only appears when a paste
-      // (or a batch of concurrent pastes) outlasts the delay.
-      if (pasteOperationCount === 1) {
-        pasteLoadingTimer = window.setTimeout(() => {
-          pasteLoadingTimer = null;
-          if (connectionClient.isCurrent()) {
-            setPasteLoading(true);
-          }
-        }, PASTE_LOADING_DELAY_MS);
-      }
-      try {
-        const result = await operation();
-        if (!connectionClient.isCurrent()) {
-          throw new Error("connection changed during paste");
-        }
-        return result;
-      } finally {
-        pasteOperationCount -= 1;
-        if (pasteOperationCount === 0) {
-          cancelPasteLoadingTimer();
-          if (connectionClient.isCurrent()) {
-            setPasteLoading(false);
-          }
-        }
-      }
-    };
+    const { run: runPasteOperation, dispose: disposePasteOperations } =
+      createTerminalPasteRunner(
+        () => connectionClient.isCurrent(),
+        setPasteLoading,
+      );
     const pasteImage = async (blob: Blob, destinationPaneId: string | null) => {
       const file =
         blob instanceof File
@@ -1675,10 +1640,7 @@ export function TerminalView({
       cancelCompositionSettle();
       cancelNativePasteFallback();
       cancelPasteTextareaClear();
-      cancelPasteLoadingTimer();
-      // The paste finally-blocks skip their reset once the connection is no
-      // longer current; never strand a visible overlay across the re-run.
-      setPasteLoading(false);
+      disposePasteOperations();
       term.textarea?.removeEventListener("keydown", onTerminalKeyDown, {
         capture: true,
       });

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -1676,6 +1676,9 @@ export function TerminalView({
       cancelNativePasteFallback();
       cancelPasteTextareaClear();
       cancelPasteLoadingTimer();
+      // The paste finally-blocks skip their reset once the connection is no
+      // longer current; never strand a visible overlay across the re-run.
+      setPasteLoading(false);
       term.textarea?.removeEventListener("keydown", onTerminalKeyDown, {
         capture: true,
       });

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -135,6 +135,9 @@ const RESET_FOREGROUND = "\x1b[39m";
 const ANSI_SEQUENCE_RE =
   /\x1b\][\s\S]*?(?:\x07|\x1b\\)|\x1b\[[0-?]*[ -/]*[@-~]|\x1b[@-Z\\-_]/g;
 const CLIPBOARD_READ_TIMEOUT_MS = 2000;
+// Spinner-delay pattern: a paste that settles within this window never
+// surfaces the loading overlay, so quick pastes do not flash it at all.
+const PASTE_LOADING_DELAY_MS = 200;
 const TERMINAL_EVICTION_WINDOW_MS = 60_000;
 const TERMINAL_EVICTION_MAX_RETRIES = 3;
 
@@ -1044,7 +1047,15 @@ export function TerminalView({
         throw new Error("connection changed during paste");
       }
       pasteOperationCount += 1;
-      setPasteLoading(true);
+      let loadingTimer: number | null = null;
+      if (pasteOperationCount === 1) {
+        loadingTimer = window.setTimeout(() => {
+          loadingTimer = null;
+          if (pasteOperationCount > 0 && connectionClient.isCurrent()) {
+            setPasteLoading(true);
+          }
+        }, PASTE_LOADING_DELAY_MS);
+      }
       try {
         const result = await operation();
         if (!connectionClient.isCurrent()) {
@@ -1052,6 +1063,9 @@ export function TerminalView({
         }
         return result;
       } finally {
+        if (loadingTimer !== null) {
+          window.clearTimeout(loadingTimer);
+        }
         pasteOperationCount -= 1;
         if (pasteOperationCount === 0 && connectionClient.isCurrent()) {
           setPasteLoading(false);

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -1042,16 +1042,23 @@ export function TerminalView({
       pasteTextareaClearTimer = null;
     };
     let pasteOperationCount = 0;
+    let pasteLoadingTimer: number | null = null;
+    const cancelPasteLoadingTimer = () => {
+      if (pasteLoadingTimer === null) return;
+      window.clearTimeout(pasteLoadingTimer);
+      pasteLoadingTimer = null;
+    };
     const runPasteOperation = async <T,>(operation: () => Promise<T>) => {
       if (!connectionClient.isCurrent()) {
         throw new Error("connection changed during paste");
       }
       pasteOperationCount += 1;
-      let loadingTimer: number | null = null;
+      // One timer per busy period: the overlay only appears when a paste
+      // (or a batch of concurrent pastes) outlasts the delay.
       if (pasteOperationCount === 1) {
-        loadingTimer = window.setTimeout(() => {
-          loadingTimer = null;
-          if (pasteOperationCount > 0 && connectionClient.isCurrent()) {
+        pasteLoadingTimer = window.setTimeout(() => {
+          pasteLoadingTimer = null;
+          if (connectionClient.isCurrent()) {
             setPasteLoading(true);
           }
         }, PASTE_LOADING_DELAY_MS);
@@ -1063,12 +1070,12 @@ export function TerminalView({
         }
         return result;
       } finally {
-        if (loadingTimer !== null) {
-          window.clearTimeout(loadingTimer);
-        }
         pasteOperationCount -= 1;
-        if (pasteOperationCount === 0 && connectionClient.isCurrent()) {
-          setPasteLoading(false);
+        if (pasteOperationCount === 0) {
+          cancelPasteLoadingTimer();
+          if (connectionClient.isCurrent()) {
+            setPasteLoading(false);
+          }
         }
       }
     };
@@ -1668,6 +1675,7 @@ export function TerminalView({
       cancelCompositionSettle();
       cancelNativePasteFallback();
       cancelPasteTextareaClear();
+      cancelPasteLoadingTimer();
       term.textarea?.removeEventListener("keydown", onTerminalKeyDown, {
         capture: true,
       });

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8120,8 +8120,10 @@ textarea:focus {
   justify-content: center;
   gap: 8px;
   border-radius: 9px;
-  background: rgba(11, 13, 18, 0.78);
-  color: #c9cdd6;
+  /* Follow the terminal theme: the hard-coded dark values matched the dark
+     palette but flashed black over the light terminal on every paste. */
+  background: color-mix(in srgb, var(--terminal-bg) 78%, transparent);
+  color: var(--terminal-fg);
   font:
     13px / 1 ui-monospace,
     SFMono-Regular,

--- a/web/src/terminalPaste.test.ts
+++ b/web/src/terminalPaste.test.ts
@@ -1,10 +1,183 @@
-import { describe, expect, test } from "bun:test";
 import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  mock,
+  test,
+} from "bun:test";
+import {
+  createTerminalPasteRunner,
   prepareTerminalPasteText,
   terminalPasteInputText,
   terminalPasteRequest,
   type TerminalPasteTextareaSnapshot,
 } from "./terminalPaste";
+
+function deferred() {
+  let resolve!: (value: string) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<string>((yes, no) => {
+    resolve = yes;
+    reject = no;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("terminal paste loading", () => {
+  let current: boolean;
+  const setLoading = mock((loading: boolean) => loading);
+  let runner: ReturnType<typeof createTerminalPasteRunner>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    current = true;
+    setLoading.mockClear();
+    runner = createTerminalPasteRunner(() => current, setLoading);
+  });
+  afterEach(() => {
+    runner.dispose();
+    jest.useRealTimers();
+  });
+
+  test("a paste finishing before 200ms never shows the overlay", async () => {
+    const operation = deferred();
+    const result = runner.run(() => operation.promise);
+    jest.advanceTimersByTime(199);
+    expect(setLoading).not.toHaveBeenCalled();
+    operation.resolve("pasted");
+    expect(await result).toBe("pasted");
+    expect(jest.getTimerCount()).toBe(0);
+    jest.advanceTimersByTime(1000);
+    expect(setLoading.mock.calls).toEqual([[false]]);
+  });
+
+  test("shows at 200ms and hides when a slow paste finishes", async () => {
+    const operation = deferred();
+    const result = runner.run(() => operation.promise);
+    jest.advanceTimersByTime(199);
+    expect(setLoading).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(1);
+    expect(setLoading.mock.calls).toEqual([[true]]);
+    operation.resolve("pasted");
+    await result;
+    expect(setLoading.mock.calls).toEqual([[true], [false]]);
+  });
+
+  test("overlapping pastes share the delay and wait for the last completion", async () => {
+    const first = deferred();
+    const second = deferred();
+    const a = runner.run(() => first.promise);
+    jest.advanceTimersByTime(150);
+    const b = runner.run(() => second.promise);
+    expect(jest.getTimerCount()).toBe(1);
+    first.resolve("first");
+    await a;
+    expect(setLoading).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(50);
+    expect(setLoading.mock.calls).toEqual([[true]]);
+    second.resolve("second");
+    await b;
+    expect(setLoading.mock.calls).toEqual([[true], [false]]);
+  });
+
+  test("a new busy period gets a fresh delay", async () => {
+    await runner.run(() => Promise.resolve("first"));
+    setLoading.mockClear();
+    const operation = deferred();
+    const result = runner.run(() => operation.promise);
+    jest.advanceTimersByTime(199);
+    expect(setLoading).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(1);
+    expect(setLoading.mock.calls).toEqual([[true]]);
+    operation.resolve("second");
+    await result;
+  });
+
+  test("a synchronous throw cancels the timer and preserves the error", async () => {
+    const error = new Error("clipboard unavailable");
+    await expect(
+      runner.run(() => {
+        throw error;
+      }),
+    ).rejects.toBe(error);
+    jest.advanceTimersByTime(1000);
+    expect(setLoading.mock.calls).toEqual([[false]]);
+  });
+
+  test("an async rejection hides the overlay and preserves the error", async () => {
+    const operation = deferred();
+    const result = runner.run(() => operation.promise);
+    jest.advanceTimersByTime(200);
+    const error = new Error("upload failed");
+    operation.reject(error);
+    await expect(result).rejects.toBe(error);
+    expect(setLoading.mock.calls).toEqual([[true], [false]]);
+  });
+
+  test("a stale connection cannot start a paste", async () => {
+    current = false;
+    const operation = mock(() => Promise.resolve("unused"));
+    await expect(runner.run(operation)).rejects.toThrow(
+      "connection changed during paste",
+    );
+    expect(operation).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(200);
+    expect(setLoading).not.toHaveBeenCalled();
+  });
+
+  test("a connection switch before the delay prevents a stale overlay", async () => {
+    const operation = deferred();
+    const result = runner.run(() => operation.promise);
+    current = false;
+    jest.advanceTimersByTime(200);
+    operation.resolve("stale");
+    await expect(result).rejects.toThrow("connection changed during paste");
+    expect(setLoading).not.toHaveBeenCalled();
+  });
+
+  test("teardown cancels a pending timer and prevents late updates", async () => {
+    const operation = deferred();
+    const result = runner.run(() => operation.promise);
+    runner.dispose();
+    expect(jest.getTimerCount()).toBe(0);
+    jest.advanceTimersByTime(200);
+    operation.resolve("stale");
+    await expect(result).rejects.toThrow("connection changed during paste");
+    expect(setLoading.mock.calls).toEqual([[false]]);
+  });
+
+  test("teardown resets a visible overlay even after the connection expires", async () => {
+    const operation = deferred();
+    const result = runner.run(() => operation.promise);
+    jest.advanceTimersByTime(200);
+    current = false;
+    runner.dispose();
+    expect(setLoading.mock.calls).toEqual([[true], [false]]);
+    operation.resolve("stale");
+    await expect(result).rejects.toThrow("connection changed during paste");
+    expect(setLoading.mock.calls).toEqual([[true], [false]]);
+  });
+
+  test("an old effect's completion cannot hide a new effect's overlay", async () => {
+    const oldOperation = deferred();
+    const oldResult = runner.run(() => oldOperation.promise);
+    jest.advanceTimersByTime(200);
+    runner.dispose();
+    runner = createTerminalPasteRunner(() => current, setLoading);
+    const newOperation = deferred();
+    const newResult = runner.run(() => newOperation.promise);
+    jest.advanceTimersByTime(200);
+    setLoading.mockClear();
+    oldOperation.resolve("old");
+    await expect(oldResult).rejects.toThrow("connection changed during paste");
+    expect(setLoading).not.toHaveBeenCalled();
+    newOperation.resolve("new");
+    await newResult;
+    expect(setLoading.mock.calls).toEqual([[false]]);
+  });
+});
 
 function snapshot(
   value: string,

--- a/web/src/terminalPaste.test.ts
+++ b/web/src/terminalPaste.test.ts
@@ -119,11 +119,19 @@ describe("terminal paste loading", () => {
   test("a stale connection cannot start a paste", async () => {
     current = false;
     const operation = mock(() => Promise.resolve("unused"));
-    await expect(runner.run(operation)).rejects.toThrow(
-      "connection changed during paste",
-    );
+    await expect(runner.run(operation)).rejects.toThrow("paste cancelled");
     expect(operation).not.toHaveBeenCalled();
     jest.advanceTimersByTime(200);
+    expect(setLoading).not.toHaveBeenCalled();
+  });
+
+  test("a disposed runner cannot start a paste on a current connection", async () => {
+    runner.dispose();
+    setLoading.mockClear();
+    const operation = mock(() => Promise.resolve("unused"));
+    await expect(runner.run(operation)).rejects.toThrow("paste cancelled");
+    expect(operation).not.toHaveBeenCalled();
+    expect(jest.getTimerCount()).toBe(0);
     expect(setLoading).not.toHaveBeenCalled();
   });
 
@@ -133,7 +141,7 @@ describe("terminal paste loading", () => {
     current = false;
     jest.advanceTimersByTime(200);
     operation.resolve("stale");
-    await expect(result).rejects.toThrow("connection changed during paste");
+    await expect(result).rejects.toThrow("paste cancelled");
     expect(setLoading).not.toHaveBeenCalled();
   });
 
@@ -144,7 +152,7 @@ describe("terminal paste loading", () => {
     expect(jest.getTimerCount()).toBe(0);
     jest.advanceTimersByTime(200);
     operation.resolve("stale");
-    await expect(result).rejects.toThrow("connection changed during paste");
+    await expect(result).rejects.toThrow("paste cancelled");
     expect(setLoading.mock.calls).toEqual([[false]]);
   });
 
@@ -156,7 +164,7 @@ describe("terminal paste loading", () => {
     runner.dispose();
     expect(setLoading.mock.calls).toEqual([[true], [false]]);
     operation.resolve("stale");
-    await expect(result).rejects.toThrow("connection changed during paste");
+    await expect(result).rejects.toThrow("paste cancelled");
     expect(setLoading.mock.calls).toEqual([[true], [false]]);
   });
 
@@ -171,7 +179,7 @@ describe("terminal paste loading", () => {
     jest.advanceTimersByTime(200);
     setLoading.mockClear();
     oldOperation.resolve("old");
-    await expect(oldResult).rejects.toThrow("connection changed during paste");
+    await expect(oldResult).rejects.toThrow("paste cancelled");
     expect(setLoading).not.toHaveBeenCalled();
     newOperation.resolve("new");
     await newResult;

--- a/web/src/terminalPaste.ts
+++ b/web/src/terminalPaste.ts
@@ -18,7 +18,7 @@ export function createTerminalPasteRunner(
   return {
     async run<T>(operation: () => Promise<T>): Promise<T> {
       if (disposed || !isCurrent()) {
-        throw new Error("connection changed during paste");
+        throw new Error("paste cancelled");
       }
       pending += 1;
       // Concurrent pastes share the first operation's delay, not a new one.
@@ -31,7 +31,7 @@ export function createTerminalPasteRunner(
       try {
         const result = await operation();
         if (disposed || !isCurrent()) {
-          throw new Error("connection changed during paste");
+          throw new Error("paste cancelled");
         }
         return result;
       } finally {

--- a/web/src/terminalPaste.ts
+++ b/web/src/terminalPaste.ts
@@ -1,3 +1,57 @@
+// Quick pastes should finish before the loading overlay becomes visible.
+const PASTE_LOADING_DELAY_MS = 200;
+
+/** One runner per terminal effect; dispose it when that effect tears down. */
+export function createTerminalPasteRunner(
+  isCurrent: () => boolean,
+  setLoading: (loading: boolean) => void,
+) {
+  let pending = 0;
+  let disposed = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const cancelTimer = () => {
+    if (timer === null) return;
+    clearTimeout(timer);
+    timer = null;
+  };
+
+  return {
+    async run<T>(operation: () => Promise<T>): Promise<T> {
+      if (disposed || !isCurrent()) {
+        throw new Error("connection changed during paste");
+      }
+      pending += 1;
+      // Concurrent pastes share the first operation's delay, not a new one.
+      if (pending === 1) {
+        timer = setTimeout(() => {
+          timer = null;
+          if (!disposed && isCurrent()) setLoading(true);
+        }, PASTE_LOADING_DELAY_MS);
+      }
+      try {
+        const result = await operation();
+        if (disposed || !isCurrent()) {
+          throw new Error("connection changed during paste");
+        }
+        return result;
+      } finally {
+        pending -= 1;
+        if (pending === 0) {
+          cancelTimer();
+          if (!disposed && isCurrent()) setLoading(false);
+        }
+      }
+    },
+    dispose() {
+      disposed = true;
+      cancelTimer();
+      // Reset even after the connection expires; old completions must not
+      // hide a newer effect's loading overlay on the same connection.
+      setLoading(false);
+    },
+  };
+}
+
 type TerminalPasteInputEvent = Pick<InputEvent, "inputType" | "isComposing">;
 
 export type TerminalPasteTextareaSnapshot = {


### PR DESCRIPTION
## Problem

When using a light theme, **every paste into a terminal flashes a black layer over the whole terminal area** for a moment before the content re-appears. The same overlay is invisible in the dark theme, so the effect only shows up for light-theme users.

## Root cause

Two independent facts combine into the flash:

1. **Every paste path toggles a full-terminal loading overlay synchronously.** `runPasteOperation` in `web/src/components/TerminalView.tsx` calls `setPasteLoading(true)` on entry and resets it in `finally`. All paste entry points funnel through it — `Ctrl+V` (`pasteFromBrowserClipboard`), the document-level native `paste` handler (`onPaste`, also the Apple `Cmd+V` path), the WebKit `insertFromPaste` input-event path, and image pastes. The overlay (`pasteLoading || terminalLoading` renders `.terminal-loading`) covers the entire terminal (`position: absolute; inset: 1px`). Since the `pane.send_input` RPC crosses at least one macrotask, React always commits one paint with the overlay visible; whenever the round trip exceeds one frame (≈16 ms — longer over SSH, during `navigator.clipboard.read()` permission waits, or while uploading an image), the overlay is actually painted.
2. **The overlay colors are hard-coded dark values.** `.terminal-loading` used `background: rgba(11, 13, 18, 0.78)` and `color: #c9cdd6` — exactly the dark theme's `--terminal-bg: #0b0d12` and `--terminal-fg`. There was no `[data-theme="light"]` override, so over the light terminal background (`#f6f7f9`) the overlay reads as a black flash. (The same hard-coded values also affect the "Loading terminal", "Connection paused", attach-error, and `App` Suspense-fallback states, which share this class.)

## Changes

- `web/src/styles.css` — make `.terminal-loading` theme-aware: `background: color-mix(in srgb, var(--terminal-bg) 78%, transparent)` and `color: var(--terminal-fg)`. In the dark theme the computed values are identical to the previous hard-coded ones (zero visual change); in the light theme the overlay becomes a light translucent layer. One rule fixes every state that reuses the class.
- `web/src/components/TerminalView.tsx` — delay the paste-loading overlay with the standard spinner-delay pattern: `runPasteOperation` now arms one `PASTE_LOADING_DELAY_MS` (200 ms) timer per busy period (first concurrent operation starts it, the last one to finish cancels it) and only shows the overlay if a paste is still running when it fires. Pastes that settle within the window (the common local case) never surface the overlay at all, so there is nothing to flash. The timer is also canceled from the effect cleanup alongside the other paste timers, and guarded by `connectionClient.isCurrent()` like the existing counter logic. The attach/loading path (`terminalLoading`) is untouched and still shows immediately, so the terminal never sits visibly empty before the first frame.
- The effect cleanup now also resets `pasteLoading` (next to the new timer cancellation): the paste `finally` blocks skip their reset once the connection is no longer current, which could otherwise strand a visible "Pasting…" overlay across a connection switch. This path predates the PR but sits exactly on the state this PR manages.
- `CHANGELOG.md` — Unreleased entry.

## Verification

- `bun run precommit` (Biome format check, ESLint, root+web+server `tsc --noEmit`, 952 unit tests) — pass.
- `bun run build:web` — pass (asset budget 118/160 files, 9.5/12 MiB).
- Manual matrix to run before merge: light/dark themes × { Ctrl+V text paste (no flash, no overlay under ~200 ms), right-click/menu paste, image paste (overlay appears as light translucent layer), `Cmd+V` on Apple UA, "Connection paused" and attach-loading states, mobile breakpoint (`.terminal-loading` inset override intact) }.

## Notes

- Deliberately out of scope: the floating pane toolbar uses a similar hard-coded dark background; it is constant (not a paste-time flash) and left for a separate change.
