### PR TITLE
Copy recent terminal lines with wrapped rows joined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- Copy the last 200 terminal lines from the pane toolbar with soft-wrapped
+  rows joined back into logical lines.
+
 ## 0.5.2 - 2026-09-06
 
 ### Added

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -52,6 +52,8 @@ Closed panes are removed from the history automatically.
   path into the terminal. This also works through `--ssh-host`.
 - Relay OSC 52 clipboard writes from local or remote terminal applications to
   the initiating browser.
+- Copy the last 200 terminal lines from the pane toolbar with soft-wrapped
+  rows joined back into logical lines.
 - `Cmd/Ctrl`-click HTTP(S) links to open them safely in a new tab.
 - `Cmd/Ctrl`-click workspace-relative or absolute file paths in terminal output
   to preview text, Markdown, or images without leaving the terminal.

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -1969,13 +1969,22 @@ export function TerminalView({
   const copyRecentUnwrapped = async () => {
     const targetPaneId = paneIdRef.current;
     if (!targetPaneId) return;
+    let text: string | null = null;
     try {
       const request = terminalCopyRecentRequest(targetPaneId);
       const result = await connectionClient.call(
         request.method,
         request.params,
       );
-      const text = terminalCopyRecentText(result);
+      text = terminalCopyRecentText(result);
+      if (text === null) {
+        store.notify({
+          kind: "error",
+          message: "Copy recent lines failed",
+          detail: "Unexpected response from Herdr.",
+        });
+        return;
+      }
       if (!text) {
         store.notify({
           kind: "info",
@@ -1989,12 +1998,17 @@ export function TerminalView({
         kind: "success",
         message: `Copied the last ${TERMINAL_COPY_RECENT_LINES} lines`,
         detail: "Wrapped lines were joined on the server.",
+        autoDismissMs: 5000,
       });
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       store.notify({
         kind: "error",
         message: "Copy recent lines failed",
-        detail: error instanceof Error ? error.message : String(error),
+        detail: text
+          ? `${message}. Use Copy to approve this clipboard write.`
+          : message,
+        ...(text ? { actionLabel: "Copy", actionClipboardText: text } : {}),
       });
     }
   };

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -6,7 +6,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { UnicodeGraphemesAddon } from "@xterm/addon-unicode-graphemes";
 import type { IBufferLine, ILink } from "@xterm/xterm";
 import { Terminal } from "@xterm/xterm";
-import { Columns2, Keyboard, Maximize2, Rows2, X } from "lucide-react";
+import { Columns2, Copy, Keyboard, Maximize2, Rows2, X } from "lucide-react";
 import {
   type CSSProperties,
   useCallback,
@@ -31,9 +31,15 @@ import {
 import { paneCanClose } from "../paneJump";
 import { shallowEqual, store, useStoreSelector } from "../store";
 import {
+  copyTextFromUserGesture,
   createTerminalClipboardProvider,
   decodeTerminalClipboard,
 } from "../terminalClipboard";
+import {
+  TERMINAL_COPY_RECENT_LINES,
+  terminalCopyRecentRequest,
+  terminalCopyRecentText,
+} from "../terminalCopyRecent";
 import {
   clearTerminalComposerDrafts,
   terminalComposerCloseWarning,
@@ -1960,6 +1966,38 @@ export function TerminalView({
   };
   const uploadComposerImage = (file: File) =>
     uploadTerminalImage(connectionClient, file);
+  const copyRecentUnwrapped = async () => {
+    const targetPaneId = paneIdRef.current;
+    if (!targetPaneId) return;
+    try {
+      const request = terminalCopyRecentRequest(targetPaneId);
+      const result = await connectionClient.call(
+        request.method,
+        request.params,
+      );
+      const text = terminalCopyRecentText(result);
+      if (!text) {
+        store.notify({
+          kind: "info",
+          message: "Nothing to copy",
+          detail: "The terminal has no recent output.",
+        });
+        return;
+      }
+      await copyTextFromUserGesture(text);
+      store.notify({
+        kind: "success",
+        message: `Copied the last ${TERMINAL_COPY_RECENT_LINES} lines`,
+        detail: "Wrapped lines were joined on the server.",
+      });
+    } catch (error) {
+      store.notify({
+        kind: "error",
+        message: "Copy recent lines failed",
+        detail: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
   const notifyComposerError = (message: string) => {
     store.notify({
       kind: "error",
@@ -2130,6 +2168,16 @@ export function TerminalView({
           />
         ) : null}
         <div className="terminal-pane-toolbar" aria-label="Pane actions">
+          <button
+            type="button"
+            className="terminal-pane-action"
+            title={`Copy the last ${TERMINAL_COPY_RECENT_LINES} lines (wrapped lines joined)`}
+            aria-label={`Copy the last ${TERMINAL_COPY_RECENT_LINES} lines (wrapped lines joined)`}
+            onPointerDown={preventPaneActionFocus}
+            onClick={() => void copyRecentUnwrapped()}
+          >
+            <Copy size={14} />
+          </button>
           <button
             type="button"
             className="terminal-pane-action"

--- a/web/src/terminalCopyRecent.test.ts
+++ b/web/src/terminalCopyRecent.test.ts
@@ -7,10 +7,10 @@ import {
 
 describe("terminalCopyRecentRequest", () => {
   test("reads recent unwrapped text for the pane", () => {
-    expect(terminalCopyRecentRequest("ws1.p1")).toEqual({
+    expect(terminalCopyRecentRequest("w1:p1")).toEqual({
       method: "pane.read",
       params: {
-        pane_id: "ws1.p1",
+        pane_id: "w1:p1",
         source: "recent_unwrapped",
         format: "text",
         lines: TERMINAL_COPY_RECENT_LINES,
@@ -19,7 +19,7 @@ describe("terminalCopyRecentRequest", () => {
   });
 
   test("accepts an explicit line count", () => {
-    expect(terminalCopyRecentRequest("ws1.p1", 50).params.lines).toBe(50);
+    expect(terminalCopyRecentRequest("w1:p1", 50).params.lines).toBe(50);
   });
 });
 
@@ -28,7 +28,7 @@ describe("terminalCopyRecentText", () => {
     const result = {
       type: "pane_read",
       read: {
-        pane_id: "ws1.p1",
+        pane_id: "w1:p1",
         workspace_id: "ws1",
         tab_id: "t1",
         source: "recent_unwrapped",

--- a/web/src/terminalCopyRecent.test.ts
+++ b/web/src/terminalCopyRecent.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import {
+  TERMINAL_COPY_RECENT_LINES,
+  terminalCopyRecentRequest,
+  terminalCopyRecentText,
+} from "./terminalCopyRecent";
+
+describe("terminalCopyRecentRequest", () => {
+  test("reads recent unwrapped text for the pane", () => {
+    expect(terminalCopyRecentRequest("ws1.p1")).toEqual({
+      method: "pane.read",
+      params: {
+        pane_id: "ws1.p1",
+        source: "recent_unwrapped",
+        format: "text",
+        lines: TERMINAL_COPY_RECENT_LINES,
+      },
+    });
+  });
+
+  test("accepts an explicit line count", () => {
+    expect(terminalCopyRecentRequest("ws1.p1", 50).params.lines).toBe(50);
+  });
+});
+
+describe("terminalCopyRecentText", () => {
+  test("returns the text from a pane_read envelope", () => {
+    const result = {
+      type: "pane_read",
+      read: {
+        pane_id: "ws1.p1",
+        workspace_id: "ws1",
+        tab_id: "t1",
+        source: "recent_unwrapped",
+        format: "text",
+        text: "joined\nlines\n",
+        revision: 0,
+        truncated: false,
+      },
+    };
+    expect(terminalCopyRecentText(result)).toBe("joined\nlines\n");
+  });
+
+  test("accepts an empty terminal payload", () => {
+    expect(
+      terminalCopyRecentText({ type: "pane_read", read: { text: "" } }),
+    ).toBe("");
+  });
+
+  test("rejects malformed responses", () => {
+    expect(terminalCopyRecentText(null)).toBeNull();
+    expect(terminalCopyRecentText(undefined)).toBeNull();
+    expect(terminalCopyRecentText("pane_read")).toBeNull();
+    expect(terminalCopyRecentText([])).toBeNull();
+    expect(terminalCopyRecentText({ type: "pane_list", panes: [] })).toBeNull();
+    expect(terminalCopyRecentText({ type: "pane_read" })).toBeNull();
+    expect(
+      terminalCopyRecentText({ type: "pane_read", read: null }),
+    ).toBeNull();
+    expect(terminalCopyRecentText({ type: "pane_read", read: [] })).toBeNull();
+    expect(
+      terminalCopyRecentText({ type: "pane_read", read: { text: 42 } }),
+    ).toBeNull();
+  });
+});

--- a/web/src/terminalCopyRecent.ts
+++ b/web/src/terminalCopyRecent.ts
@@ -1,0 +1,36 @@
+// "Copy recent lines" reads server-side terminal text through Herdr's
+// `pane.read` control API. The `recent_unwrapped` source joins soft-wrapped
+// rows back into logical lines, which the browser terminal cannot do on its
+// own: Herdr's server-rendered ANSI frames paint rows at absolute positions,
+// so xterm never marks any line as wrapped and selection copies keep every
+// visual row boundary as a newline.
+
+export const TERMINAL_COPY_RECENT_LINES = 200;
+
+export function terminalCopyRecentRequest(
+  paneId: string,
+  lines: number = TERMINAL_COPY_RECENT_LINES,
+) {
+  return {
+    method: "pane.read" as const,
+    params: {
+      pane_id: paneId,
+      source: "recent_unwrapped" as const,
+      format: "text" as const,
+      lines,
+    },
+  };
+}
+
+/** Extracts the text payload from a `pane.read` response envelope. */
+export function terminalCopyRecentText(result: unknown): string | null {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return null;
+  }
+  const envelope = result as Record<string, unknown>;
+  if (envelope.type !== "pane_read") return null;
+  const read = envelope.read;
+  if (!read || typeof read !== "object" || Array.isArray(read)) return null;
+  const text = (read as Record<string, unknown>).text;
+  return typeof text === "string" ? text : null;
+}


### PR DESCRIPTION
## Problem

Text copied out of a Herdr Studio terminal contains a newline at every visual row boundary. A long line that soft-wraps at the terminal's current width comes back as multiple hard lines, so every copy needs manual cleanup before it can be reused (pasted into an editor, a diff, a shell, …).

## Root cause

This is structural to the rendering architecture, not a copy-handler bug:

1. Herdr renders terminals server-side and streams **server-rendered ANSI frames** (see `docs/ARCHITECTURE.md`). Its blit encoder paints each screen row with absolute cursor positioning (`CUP`), row by row — the byte stream carries no soft-wrap relationship between rows.
2. xterm.js only sets a line's `isWrapped` flag when *its own* auto-wrap fires while printing the next character. Rows painted via `CUP` never trigger that path, so in a Herdr Studio terminal every visual row is a hard line as far as xterm is concerned.
3. xterm's `getSelection()` joins visual rows into logical lines **only** when `isWrapped` is set. With the flag always empty, every row boundary becomes `\n`. The existing `trimCopiedLinePadding` in `TerminalView.tsx` only strips trailing whitespace and cannot reconstruct joins.

The wrap information does exist on the Herdr side (its terminal model tracks soft-wrapped rows); it is only lost at the ANSI frame boundary. Making *selection* copies wrap-aware end-to-end therefore requires a Herdr-side protocol addition (frame wrap metadata or a selection-read RPC) and is intentionally **out of scope for this PR** — it should land as a Herdr change with matching browser support, with this client-side behavior as the fallback.

## What this PR does

Adds a **"Copy last 200 lines (wrapped lines joined)"** action to the floating pane toolbar, built entirely on APIs Herdr already exposes today (`pane.read` with `source: "recent_unwrapped"`, available since protocol 14; verified against Herdr 0.8.2). The bridge forwards unknown methods transparently (`server/src/index.ts`), so no bridge change is needed. The button copies server-side text in which soft-wrapped rows are joined back into logical lines — no manual cleanup needed for the common "copy recent output" case.

Details:

- `web/src/terminalCopyRecent.ts` (new, pure): builds the `pane.read` request and validates/extracts the `{"type": "pane_read", read: { text, … } }` response envelope. The line count is a named constant (`TERMINAL_COPY_RECENT_LINES = 200`; Herdr caps at 1000).
- `web/src/components/TerminalView.tsx`: a `Copy` button in the pane toolbar. On click it issues the RPC, then writes through the existing `copyTextFromUserGesture` helper (synchronous `execCommand` fallback preserves transient user activation on insecure HTTP origins; Clipboard API otherwise). Feedback uses the existing `store.notify` toasts: success auto-dismisses after 5 s (repo convention for quick confirmations), an empty terminal yields a "Nothing to copy" info notice, a malformed response envelope is reported as an error (not as "nothing to copy"), and a failed clipboard write keeps the text on the standard `Copy` retry action (`actionClipboardText`) so a click can approve the write when transient user activation has expired.
- The tooltip is explicit about the semantics: this copies the **last N lines** (Herdr reads from the live screen bottom), not the mouse selection — column ranges and scrolled-viewport fidelity remain selection-copy limitations documented above.
- `FEATURES.md` bullet and `CHANGELOG.md` Unreleased entry.

## Verification

- `web/src/terminalCopyRecent.test.ts` (new): request shape, explicit line counts, and parser behavior for valid, empty, and malformed envelopes.
- `bun run precommit` (Biome format check, ESLint, root+web+server `tsc --noEmit`, 957 unit tests) — pass.
- `bun run build:web` — pass (asset budget 118/160 files, 9.5/12 MiB).
- Manual check before merge: pane toolbar → copy button copies recent output with long lines joined; empty terminal → info notice; works over `--ssh-host` connections (same RPC path as image paste).

## Follow-ups (not in this PR)

- Herdr protocol: carry per-row wrap-continuation metadata in terminal-attach frames (or expose a selection-read RPC with viewport coordinates and a content revision), so the browser can make exact mouse selections wrap-aware while staying fully synchronous in the `copy` event handler. Once available, `onCopy` can prefer that path and keep this action as a complementary "copy recent lines" entry.
