### PR TITLE
Count conversation entries in History and load tool payloads on demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,14 @@
   tool-heavy turns no longer evict user messages, and fetch tool call/output
   payloads on demand instead of transmitting them with every refresh. Tool
   entries are now hidden by default and can be shown with the tool filter.
+- Show each workspace's tab count as a subtle number in the workspace tree,
+  and move the compact Inspector's back button into the file preview header.
 
 ### Fixed
 
+- Follow tab switches in the History view: re-pin the shown session to the
+  newly active tab's agent (or the next available agent when the pinned pane
+  closes) instead of showing a stale or missing session.
 - Follow the terminal theme for the terminal loading overlay and delay its
   appearance during pastes, so pasting no longer flashes a dark layer over a
   light terminal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Changed
+
+- Count only conversation messages toward the 200-entry History window so
+  tool-heavy turns no longer evict user messages, and fetch tool call/output
+  payloads on demand instead of transmitting them with every refresh. Tool
+  entries are now hidden by default and can be shown with the tool filter.
+
 ### Fixed
 
 - Follow the terminal theme for the terminal loading overlay and delay its

--- a/server/src/agent/agent-sessions.ts
+++ b/server/src/agent/agent-sessions.ts
@@ -15,7 +15,7 @@ import {
   readSessionProjection,
   type SessionProjectionCache,
 } from "./session-projection-cache";
-import { HISTORY_WINDOW_LIMIT } from "./session-history";
+import { HISTORY_WINDOW_LIMIT, redactHistoryUpdate } from "./session-history";
 
 const MAX_MESSAGES_PER_AGENT = 200;
 
@@ -61,8 +61,32 @@ export function createAgentSessionHandlers(args: {
         ...resolved,
         file: projection.file,
         updated_at: new Date(projection.file.mtimeMs).toISOString(),
-        ...update,
+        ...redactHistoryUpdate(update),
       };
+    },
+    readEntry: async (params: Record<string, unknown>) => {
+      const resolved = await resolveAgentSession(
+        params,
+        args.herdrCall,
+        args.files,
+        resolverContext,
+      );
+      if (!resolved.file) {
+        cache.invalidate(resolved);
+        throw new Error(resolved.detail || "Agent session is unavailable");
+      }
+      const projection = await cache.get(resolved);
+      const entryId =
+        typeof params.entry_id === "string" ? params.entry_id : "";
+      const entry = projection.entries.find(
+        (candidate) => candidate.id === entryId,
+      );
+      if (!entry) {
+        throw new Error(
+          "That history entry is no longer available; refresh the history and try again",
+        );
+      }
+      return { entry_id: entry.id, text: entry.text };
     },
     readSummary: (params: Record<string, unknown>) =>
       readAgentSessionSummary(

--- a/server/src/agent/session-history-window.ts
+++ b/server/src/agent/session-history-window.ts
@@ -1,0 +1,20 @@
+// Shared by the server projection and the web history merger, so it must stay
+// free of Node or browser imports.
+type WindowedEntry = { role: string };
+
+// The window counts conversation entries only (user/assistant messages and
+// errors). Tool calls and tool results ride along with the conversation
+// entries that survive the cut, so tool-heavy turns cannot evict user
+// messages from the visible history.
+export function historyWindowEntries<T extends WindowedEntry>(
+  entries: readonly T[],
+  limit: number,
+): T[] {
+  let remaining = Math.max(1, Math.floor(limit));
+  let start = entries.length;
+  while (start > 0 && remaining > 0) {
+    start -= 1;
+    if (entries[start]?.role !== "tool") remaining -= 1;
+  }
+  return entries.slice(start);
+}

--- a/server/src/agent/session-history.test.ts
+++ b/server/src/agent/session-history.test.ts
@@ -1,5 +1,11 @@
 import { expect, test } from "bun:test";
-import { historyEntriesFromTrajectory, historyUpdate } from "./session-history";
+import {
+  HISTORY_WINDOW_LIMIT,
+  type HistoryEntry,
+  historyEntriesFromTrajectory,
+  historyUpdate,
+  redactHistoryUpdate,
+} from "./session-history";
 import { projectAgentTrajectory } from "./session-trajectory";
 
 const file = { path: "/tmp/history.jsonl", mtimeMs: 1000 };
@@ -255,6 +261,105 @@ test("external call IDs with commas are hashed before order comparison", () => {
     removed: [],
     order: reversed.map((entry) => entry.id),
   });
+});
+
+test("window counts conversation entries only; tool entries ride along", () => {
+  const records = [];
+  for (let index = 0; index < HISTORY_WINDOW_LIMIT + 5; index++) {
+    records.push({
+      type: "message",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: `turn ${index}` }],
+      },
+    });
+    records.push({
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: `call-${index}`,
+            name: "bash",
+            arguments: { command: `echo ${index}` },
+          },
+        ],
+      },
+    });
+  }
+  const entries = historyEntriesFromTrajectory(
+    file,
+    projectAgentTrajectory("pi", file, records),
+  );
+  const conversation = entries.filter((entry) => entry.role !== "tool");
+  expect(conversation).toHaveLength(HISTORY_WINDOW_LIMIT);
+  // The five oldest user turns are evicted; their tool calls drop with them.
+  expect(conversation[0].text).toBe("turn 5");
+  expect(entries.filter((entry) => entry.role === "tool")).toHaveLength(
+    HISTORY_WINDOW_LIMIT,
+  );
+  expect(entries[0].text).toBe("turn 5");
+  expect(entries[1].kind).toBe("tool_call");
+});
+
+test("redaction strips tool payloads but keeps metadata for on-demand fetches", () => {
+  const tool: HistoryEntry = {
+    id: "t:0",
+    role: "tool",
+    kind: "tool_result",
+    text: "bulk output",
+    sent_at: "2026-01-01T00:00:00Z",
+    tool_name: "bash",
+    is_error: false,
+  };
+  const user: HistoryEntry = {
+    id: "u:0",
+    role: "user",
+    kind: "message",
+    text: "keep me",
+    sent_at: "2026-01-01T00:00:00Z",
+  };
+  const snapshot = redactHistoryUpdate({
+    history_version: 2,
+    mode: "snapshot",
+    cursor: { epoch: "e", revision: 1 },
+    window_limit: HISTORY_WINDOW_LIMIT,
+    entries: [user, tool],
+  });
+  if (snapshot.mode !== "snapshot") throw new Error("Expected snapshot");
+  expect(snapshot.entries[0]).toEqual(user);
+  expect(snapshot.entries[1]).toMatchObject({
+    id: "t:0",
+    text: "",
+    text_bytes: "bulk output".length,
+    tool_name: "bash",
+  });
+  // Non-ASCII payloads report real UTF-8 bytes, not string length.
+  const nonAscii = redactHistoryUpdate({
+    history_version: 2,
+    mode: "snapshot",
+    cursor: { epoch: "e", revision: 1 },
+    window_limit: HISTORY_WINDOW_LIMIT,
+    entries: [{ ...tool, id: "t:1", text: "你好世界" }],
+  });
+  if (nonAscii.mode !== "snapshot") throw new Error("Expected snapshot");
+  expect(nonAscii.entries[0].text_bytes).toBe(
+    Buffer.byteLength("你好世界", "utf8"),
+  );
+  const delta = redactHistoryUpdate({
+    history_version: 2,
+    mode: "delta",
+    cursor: { epoch: "e", revision: 2 },
+    base_revision: 1,
+    window_limit: HISTORY_WINDOW_LIMIT,
+    upserts: [tool],
+    removed: [user.id],
+  });
+  if (delta.mode !== "delta") throw new Error("Expected delta");
+  expect(delta.upserts[0].text).toBe("");
+  expect(delta.upserts[0].text_bytes).toBe("bulk output".length);
+  expect(delta.removed).toEqual([user.id]);
 });
 
 test("content identities survive early step renumbering and disambiguate repeated messages", () => {

--- a/server/src/agent/session-history.ts
+++ b/server/src/agent/session-history.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import type { AtifTrajectory, SessionFile } from "./session-types";
 import { isConversationStep } from "./session-messages";
+import { historyWindowEntries } from "./session-history-window";
 
 export type HistoryEntry = {
   id: string;
@@ -11,6 +12,9 @@ export type HistoryEntry = {
   tool_name?: string;
   source_call_id?: string;
   is_error?: boolean;
+  // Set on redacted wire entries: UTF-8 byte length of the withheld text,
+  // fetchable via agent_history.entry when the user expands the card.
+  text_bytes?: number;
 };
 export type HistoryCursor = { epoch: string; revision: number };
 export type HistoryUpdate = {
@@ -99,7 +103,25 @@ export function historyEntriesFromTrajectory(
       });
     }
   }
-  return entries.slice(-HISTORY_WINDOW_LIMIT);
+  return historyWindowEntries(entries, HISTORY_WINDOW_LIMIT);
+}
+
+function redactHistoryEntry(entry: HistoryEntry): HistoryEntry {
+  if (entry.role !== "tool" || entry.text.length === 0) return entry;
+  return {
+    ...entry,
+    text: "",
+    text_bytes: Buffer.byteLength(entry.text, "utf8"),
+  };
+}
+
+// Tool payloads are bulky and rarely read, so the wire format carries only
+// their metadata. The projection cache keeps full text for on-demand fetches.
+export function redactHistoryUpdate(update: HistoryUpdate): HistoryUpdate {
+  if (update.mode === "snapshot") {
+    return { ...update, entries: update.entries.map(redactHistoryEntry) };
+  }
+  return { ...update, upserts: update.upserts.map(redactHistoryEntry) };
 }
 
 export function historyUpdate(

--- a/server/src/agent/session-projection-cache.test.ts
+++ b/server/src/agent/session-projection-cache.test.ts
@@ -252,12 +252,39 @@ describe("session projection cache and history revisions", () => {
     });
     f.set([call("a")]);
     const first = snapshot(await f.history());
+    // Wire entries carry tool metadata only; the payload is fetched on demand.
+    expect(first.entries[0].text).toBe("");
+    expect(first.entries[0].text_bytes).toBe(
+      JSON.stringify({ command: "a" }, null, 2).length,
+    );
     f.set([call("longer")]);
     const next = delta(await f.history(first.cursor));
     expect(next.upserts[0].id).toBe(first.entries[0].id);
-    expect(next.upserts[0].text).toContain("longer");
+    expect(next.upserts[0].text).toBe("");
+    expect(next.upserts[0].text_bytes).toBe(
+      JSON.stringify({ command: "longer" }, null, 2).length,
+    );
     expect(next.removed).toEqual([]);
     expect(next.order).toBeUndefined();
+    const fetched = await f.handlers.readEntry({
+      pane_id: "p",
+      entry_id: first.entries[0].id,
+    });
+    expect(fetched.text).toContain("longer");
+  });
+
+  test("readEntry rejects unknown or evicted history entries", async () => {
+    const f = fixture();
+    f.set([message("one")]);
+    await f.history();
+    await expect(
+      f.handlers.readEntry({ pane_id: "p", entry_id: "missing:0" }),
+    ).rejects.toThrow("no longer available");
+    const fetched = await f.handlers.readEntry({
+      pane_id: "p",
+      entry_id: (await snapshot(await f.history())).entries[0].id,
+    });
+    expect(fetched.text).toBe("one");
   });
 
   test("recent window removes oldest entries; full export is not windowed", async () => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -131,6 +131,7 @@ const rpcOutcomes = new Map<string, { status: "error"; detail?: string }>();
 const IMPORTANT_RPC_METHODS = new Set([
   "bridge.pause_others",
   "agent_history.get",
+  "agent_history.entry",
   "agent_session.get",
   "file.read",
   "git.diff_file",
@@ -757,6 +758,7 @@ async function handleRpc(ws: ServerWebSocket<unknown>, raw: string) {
   const {
     readHistory: readAgentMessageHistory,
     readSummary: readAgentSessionSummary,
+    readEntry: readAgentHistoryEntry,
   } = connection.agentSessions;
 
   if (method === "agent_history.get") {
@@ -765,6 +767,15 @@ async function handleRpc(ws: ServerWebSocket<unknown>, raw: string) {
       sendReply({ id, result }, "agent-history-get");
     } catch (e) {
       sendError("agent-history-get-error", e);
+    }
+    return;
+  }
+  if (method === "agent_history.entry") {
+    try {
+      const result = await readAgentHistoryEntry(params ?? {});
+      sendReply({ id, result }, "agent-history-entry");
+    } catch (e) {
+      sendError("agent-history-entry-error", e);
     }
     return;
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1919,6 +1919,42 @@ export default function App() {
     s.pendingFocusWorkspaceId,
     s.workspaces,
   ]);
+  // Follow tab switches while History is open: the view pins its session to
+  // originPaneId, which tab changes never update on their own. Pane focus
+  // changes within the same tab keep the current pin.
+  const inspectorHistoryTabRef = useRef<string | null>(null);
+  useLayoutEffect(() => {
+    const current = inspectorStateRef.current;
+    const workspace =
+      current?.open && current.view === "history"
+        ? resolveWorkspaceForScope(current.scope, s.workspaces)
+        : undefined;
+    const activeTabId = workspace?.active_tab_id ?? null;
+    const previousTabId = inspectorHistoryTabRef.current;
+    inspectorHistoryTabRef.current = activeTabId;
+    if (!current?.open || current.view !== "history" || !workspace) return;
+    if (s.pendingFocusWorkspaceId) return;
+    const originMissing =
+      !!current.originPaneId &&
+      !s.panes.some((pane) => pane.pane_id === current.originPaneId);
+    const tabSwitched =
+      previousTabId !== null &&
+      activeTabId !== null &&
+      previousTabId !== activeTabId;
+    if (!originMissing && !tabSwitched) return;
+    const workspacePanes = s.panes.filter(
+      (pane) => pane.workspace_id === workspace.workspace_id,
+    );
+    const activePaneId = activePaneIdForSnapshot(s);
+    const routedPane =
+      workspacePanes.find((pane) => pane.pane_id === activePaneId) ??
+      workspacePanes.find((pane) => pane.focused);
+    const historyPane = paneHasAgentHistory(routedPane)
+      ? routedPane
+      : workspacePanes.find(paneHasAgentHistory);
+    if (!historyPane || historyPane.pane_id === current.originPaneId) return;
+    commitInspectorState({ ...current, originPaneId: historyPane.pane_id });
+  }, [commitInspectorState, s]);
   useEffect(() => {
     if (paneJumpOpen && paneJumpOptions.length === 0) closePaneJump();
     if (paneJumpIndexRef.current >= paneJumpOptions.length) {

--- a/web/src/components/AgentHistoryCard.test.ts
+++ b/web/src/components/AgentHistoryCard.test.ts
@@ -10,6 +10,49 @@ function render(entry: HistoryEntry) {
   );
 }
 
+test("redacted tool entries offer an on-demand Load button and suppress copy", () => {
+  const stub: HistoryEntry = {
+    id: "2",
+    kind: "tool_result",
+    role: "tool",
+    tool_name: "bash",
+    text: "",
+    text_bytes: 2048,
+    sent_at: "2026-01-01T00:00:00Z",
+  };
+  const markup = renderToStaticMarkup(
+    createElement(AgentHistoryCard, {
+      entry: stub,
+      index: 3,
+      onExpand() {},
+      onLoadContent() {},
+    }),
+  );
+  expect(markup).toContain("Load output (2.0 KB)");
+  expect(markup).not.toContain("agent-history-copy");
+  expect(markup).not.toContain("agent-history-card-open");
+  const callStub = renderToStaticMarkup(
+    createElement(AgentHistoryCard, {
+      entry: { ...stub, kind: "tool_call", text_bytes: 100 },
+      index: 4,
+      onExpand() {},
+      onLoadContent() {},
+    }),
+  );
+  expect(callStub).toContain("Load arguments (100 B)");
+  const loading = renderToStaticMarkup(
+    createElement(AgentHistoryCard, {
+      entry: stub,
+      index: 3,
+      contentLoading: true,
+      onExpand() {},
+      onLoadContent() {},
+    }),
+  );
+  expect(loading).toContain("Loading…");
+  expect(loading).toContain("disabled");
+});
+
 test("tool cards label arguments, output/errors and call association with bounded safe previews", () => {
   const base: HistoryEntry = {
     id: "1",

--- a/web/src/components/AgentHistoryCard.tsx
+++ b/web/src/components/AgentHistoryCard.tsx
@@ -1,6 +1,7 @@
 import { memo, useEffect, useRef, useState } from "react";
 import { Copy } from "lucide-react";
 import { historyEntryLabel, type HistoryEntry } from "./agentHistory";
+import { formatBytes } from "./agentSession";
 import { UI_LOCALE } from "../uiLocale";
 
 export const HISTORY_PREVIEW_CHARS = 4000;
@@ -9,17 +10,26 @@ export const AgentHistoryCard = memo(function AgentHistoryCard({
   entry,
   index,
   highlighted = false,
+  contentLoading = false,
   onExpand,
+  onLoadContent,
 }: {
   entry: HistoryEntry;
   index: number;
   highlighted?: boolean;
+  contentLoading?: boolean;
   onExpand: (entry: HistoryEntry) => void;
+  onLoadContent?: (entry: HistoryEntry) => void;
 }) {
   const contentRef = useRef<HTMLPreElement>(null);
   const [clipped, setClipped] = useState(false);
   const preview = entry.text.slice(0, HISTORY_PREVIEW_CHARS);
   const truncated = clipped || preview.length < entry.text.length;
+  // Tool payloads are redacted on the wire; the user fetches them on demand.
+  const contentPending =
+    entry.role === "tool" &&
+    entry.text.length === 0 &&
+    (entry.text_bytes ?? 0) > 0;
   useEffect(() => {
     const content = contentRef.current;
     if (!content) return;
@@ -51,41 +61,57 @@ export const AgentHistoryCard = memo(function AgentHistoryCard({
               })}
         </time>
         <span />
-        <button
-          type="button"
-          className="agent-history-copy"
-          onClick={() => void navigator.clipboard?.writeText(entry.text)}
-          aria-label={`Copy entry ${index}`}
-          title="Copy"
-        >
-          <Copy size={13} />
-        </button>
+        {!contentPending ? (
+          <button
+            type="button"
+            className="agent-history-copy"
+            onClick={() => void navigator.clipboard?.writeText(entry.text)}
+            aria-label={`Copy entry ${index}`}
+            title="Copy"
+          >
+            <Copy size={13} />
+          </button>
+        ) : null}
       </div>
       {entry.source_call_id ? (
         <div className="agent-history-tool-id" title={entry.source_call_id}>
           Call ID: {entry.source_call_id}
         </div>
       ) : null}
-      <button
-        type="button"
-        className={`agent-history-card-open ${truncated ? "is-truncated" : ""}`}
-        onClick={() => onExpand(entry)}
-        aria-label={`View ${label} entry ${index}`}
-      >
-        {entry.kind === "tool_call" ? (
-          <div className="agent-history-tool-label">Arguments</div>
-        ) : entry.kind === "tool_result" ? (
-          <div className="agent-history-tool-label">
-            {entry.is_error ? "Error output" : "Output"}
-          </div>
-        ) : null}
-        <pre ref={contentRef}>{preview}</pre>
-        {truncated ? (
-          <span>
-            View full {entry.role === "tool" ? "tool details" : "message"}
-          </span>
-        ) : null}
-      </button>
+      {contentPending ? (
+        <button
+          type="button"
+          className="agent-history-tool-load"
+          disabled={contentLoading}
+          onClick={() => onLoadContent?.(entry)}
+          aria-label={`Load ${entry.kind === "tool_call" ? "arguments" : "output"} for entry ${index}`}
+        >
+          {contentLoading
+            ? "Loading…"
+            : `Load ${entry.kind === "tool_call" ? "arguments" : "output"} (${formatBytes(entry.text_bytes)})`}
+        </button>
+      ) : (
+        <button
+          type="button"
+          className={`agent-history-card-open ${truncated ? "is-truncated" : ""}`}
+          onClick={() => onExpand(entry)}
+          aria-label={`View ${label} entry ${index}`}
+        >
+          {entry.kind === "tool_call" ? (
+            <div className="agent-history-tool-label">Arguments</div>
+          ) : entry.kind === "tool_result" ? (
+            <div className="agent-history-tool-label">
+              {entry.is_error ? "Error output" : "Output"}
+            </div>
+          ) : null}
+          <pre ref={contentRef}>{preview}</pre>
+          {truncated ? (
+            <span>
+              View full {entry.role === "tool" ? "tool details" : "message"}
+            </span>
+          ) : null}
+        </button>
+      )}
     </article>
   );
 });

--- a/web/src/components/AgentHistoryDrawer.tsx
+++ b/web/src/components/AgentHistoryDrawer.tsx
@@ -281,7 +281,17 @@ export function AgentHistoryDrawer({
     workspaces.find((workspace) => workspace.workspace_id === pane.workspace_id)
       ?.label ?? pane.workspace_id;
   const [history, setHistory] = useState<AgentHistory | null>(null);
-  const [filters, setFilters] = useState<HistoryFilters>(ALL_HISTORY_FILTERS);
+  // Tool entries arrive redacted (metadata only) and are fetched on demand.
+  const [filters, setFilters] = useState<HistoryFilters>({
+    ...ALL_HISTORY_FILTERS,
+    tool: false,
+  });
+  const [toolEntryTexts, setToolEntryTexts] = useState<
+    ReadonlyMap<string, { text: string; bytes: number }>
+  >(() => new Map());
+  const [toolEntryLoading, setToolEntryLoading] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
   const [session, setSession] = useState<AgentSessionSummary | null>(null);
   const [drawerTab, setDrawerTab] = useState<"messages" | "details">(
     "messages",
@@ -309,6 +319,11 @@ export function AgentHistoryDrawer({
   const previewSeqRef = useRef(0);
   const historyRef = useRef<AgentHistory | null>(null);
   const inFlightRef = useRef<number | null>(null);
+  const paneIdRef = useRef(pane.pane_id);
+  paneIdRef.current = pane.pane_id;
+  // Entries whose content fetch failed; suppresses auto-refetch loops while
+  // keeping the card's manual Load button usable.
+  const toolEntryFailedRef = useRef<Set<string>>(new Set());
 
   const loadHistory = useCallback(() => {
     if (
@@ -347,6 +362,34 @@ export function AgentHistoryDrawer({
           );
           historyRef.current = merged;
           setHistory(merged);
+          if (merged) {
+            // Drop on-demand texts for entries that left the window or whose
+            // content changed under the same id (byte-length mismatch).
+            setToolEntryTexts((current) => {
+              if (current.size === 0) return current;
+              const kept = new Map<string, { text: string; bytes: number }>();
+              for (const message of merged.messages) {
+                const overlay = current.get(message.id);
+                if (
+                  overlay !== undefined &&
+                  (message.text_bytes === undefined ||
+                    overlay.bytes === message.text_bytes)
+                ) {
+                  kept.set(message.id, overlay);
+                }
+              }
+              return kept.size === current.size ? current : kept;
+            });
+            // Failure marks for entries that left the window are dead weight;
+            // drop them so the set cannot grow across refreshes. An entry
+            // reappearing later may retry the fetch once.
+            const windowedIds = new Set(
+              merged.messages.map((message) => message.id),
+            );
+            for (const id of toolEntryFailedRef.current) {
+              if (!windowedIds.has(id)) toolEntryFailedRef.current.delete(id);
+            }
+          }
           setExpandedMessage((entry) =>
             entry
               ? (merged?.messages.find((message) => message.id === entry.id) ??
@@ -401,6 +444,9 @@ export function AgentHistoryDrawer({
     setSession(null);
     setDrawerTab("messages");
     setExpandedMessage(null);
+    setToolEntryTexts(new Map());
+    setToolEntryLoading(new Set());
+    toolEntryFailedRef.current.clear();
     setPreviewPane(null);
     setPreviewSummary(null);
     setPreviewLoading(false);
@@ -414,6 +460,77 @@ export function AgentHistoryDrawer({
     pane.workspace_id,
     pane.tab_id,
   ]);
+
+  const loadToolEntry = useCallback(
+    (entry: AgentHistoryEntry) => {
+      if (!pane.agent || !connectionClient.isCurrent()) return;
+      const paneId = pane.pane_id;
+      setToolEntryLoading((current) => new Set(current).add(entry.id));
+      connectionClient
+        .call("agent_history.entry", {
+          pane_id: pane.pane_id,
+          workspace_id: pane.workspace_id,
+          tab_id: pane.tab_id,
+          agent: pane.agent,
+          entry_id: entry.id,
+        })
+        .then((result) => {
+          if (!connectionClient.isCurrent() || paneIdRef.current !== paneId)
+            return;
+          toolEntryFailedRef.current.delete(entry.id);
+          const text = (result as { text?: unknown }).text;
+          const value = typeof text === "string" ? text : "";
+          setToolEntryTexts((current) =>
+            new Map(current).set(entry.id, {
+              text: value,
+              bytes: new TextEncoder().encode(value).length,
+            }),
+          );
+        })
+        .catch((value) => {
+          if (!connectionClient.isCurrent() || paneIdRef.current !== paneId)
+            return;
+          toolEntryFailedRef.current.add(entry.id);
+          setError(value instanceof Error ? value.message : String(value));
+        })
+        .finally(() => {
+          setToolEntryLoading((current) => {
+            if (!current.has(entry.id)) return current;
+            const next = new Set(current);
+            next.delete(entry.id);
+            return next;
+          });
+        });
+    },
+    [
+      connectionClient,
+      pane.agent,
+      pane.pane_id,
+      pane.tab_id,
+      pane.workspace_id,
+    ],
+  );
+
+  // A refresh can swap the expanded entry for a redacted stub whose fetched
+  // text was pruned (e.g. tool arguments rewritten under the same call id).
+  // Refetch instead of showing a blank dialog; failed fetches are not
+  // retried automatically (the card's manual Load button still works).
+  useEffect(() => {
+    if (
+      !expandedMessage ||
+      expandedMessage.role !== "tool" ||
+      expandedMessage.text.length > 0 ||
+      (expandedMessage.text_bytes ?? 0) === 0 ||
+      toolEntryLoading.has(expandedMessage.id) ||
+      toolEntryFailedRef.current.has(expandedMessage.id)
+    ) {
+      return;
+    }
+    const overlay = toolEntryTexts.get(expandedMessage.id);
+    if (overlay !== undefined && overlay.bytes === expandedMessage.text_bytes)
+      return;
+    loadToolEntry(expandedMessage);
+  }, [expandedMessage, toolEntryTexts, toolEntryLoading, loadToolEntry]);
 
   useEffect(() => {
     if (!open) return;
@@ -493,9 +610,27 @@ export function AgentHistoryDrawer({
     [],
   );
 
+  const messages = useMemo(() => history?.messages ?? [], [history?.messages]);
+  // Substitute on-demand fetched tool payloads over their redacted stubs.
+  // Byte-length validation keeps overlays from going stale when a revision
+  // replaces an entry's content under the same id.
+  const hydrateEntry = useCallback(
+    (entry: AgentHistoryEntry): AgentHistoryEntry => {
+      const overlay = toolEntryTexts.get(entry.id);
+      return overlay !== undefined &&
+        (entry.text_bytes === undefined || overlay.bytes === entry.text_bytes)
+        ? { ...entry, text: overlay.text }
+        : entry;
+    },
+    [toolEntryTexts],
+  );
+  const hydratedMessages = useMemo(
+    () => (toolEntryTexts.size === 0 ? messages : messages.map(hydrateEntry)),
+    [messages, toolEntryTexts, hydrateEntry],
+  );
   const { visible: visibleMessages, counts } = useMemo(
-    () => selectHistoryEntries(history?.messages ?? [], filters),
-    [history?.messages, filters],
+    () => selectHistoryEntries(hydratedMessages, filters),
+    [hydratedMessages, filters],
   );
   const changeFilters = (next: HistoryFilters) => {
     setFilters(next);
@@ -665,7 +800,6 @@ export function AgentHistoryDrawer({
   }, []);
 
   const usage = tokenUsage(session);
-  const messages = history?.messages ?? [];
   const messageEntries = visibleMessages.map((message, index) => ({
     message,
     sequence: index + 1,
@@ -777,7 +911,7 @@ export function AgentHistoryDrawer({
                   type="button"
                   role="tab"
                   aria-selected={drawerTab === "messages"}
-                  title="Most recent 200 messages and tool entries"
+                  title="Most recent 200 messages with their tool entries"
                   className={drawerTab === "messages" ? "is-active" : ""}
                   onClick={() => setDrawerTab("messages")}
                 >
@@ -854,7 +988,9 @@ export function AgentHistoryDrawer({
                           index={sequence}
                           key={message.id}
                           highlighted={highlightedSequence === sequence}
+                          contentLoading={toolEntryLoading.has(message.id)}
                           onExpand={setExpandedMessage}
+                          onLoadContent={loadToolEntry}
                         />
                       ))}
                     </div>
@@ -953,7 +1089,7 @@ export function AgentHistoryDrawer({
         )}
       </aside>
       <AgentMessageDialog
-        message={expandedMessage}
+        message={expandedMessage ? hydrateEntry(expandedMessage) : null}
         onClose={closeExpandedMessage}
       />
       <AgentSessionPreviewDialog

--- a/web/src/components/AgentMessageDialog.tsx
+++ b/web/src/components/AgentMessageDialog.tsx
@@ -15,6 +15,7 @@ type AgentMessage = {
   is_error?: boolean;
   text: string;
   sent_at: string;
+  text_bytes?: number;
 };
 
 function formatMessageTime(sentAt: string) {
@@ -65,6 +66,9 @@ export function AgentMessageDialog({
 
   if (!message) return null;
   const isTool = message.role === "tool";
+  // Redacted tool entry whose on-demand content has not arrived (yet).
+  const contentPending =
+    isTool && message.text.length === 0 && (message.text_bytes ?? 0) > 0;
   const roleLabel = isTool
     ? `${message.kind === "tool_call" ? "Tool arguments" : message.is_error ? "Tool error" : "Tool output"}: ${message.tool_name ?? "tool"}`
     : message.role === "assistant"
@@ -114,19 +118,27 @@ export function AgentMessageDialog({
                 {viewMode === "rendered" ? "Raw" : "Rendered"}
               </button>
             ) : null}
-            <button
-              type="button"
-              className="agent-history-icon"
-              onClick={() => void navigator.clipboard?.writeText(message.text)}
-              aria-label="Copy message"
-              title="Copy"
-            >
-              <Copy size={15} />
-            </button>
+            {!contentPending ? (
+              <button
+                type="button"
+                className="agent-history-icon"
+                onClick={() =>
+                  void navigator.clipboard?.writeText(message.text)
+                }
+                aria-label="Copy message"
+                title="Copy"
+              >
+                <Copy size={15} />
+              </button>
+            ) : null}
             <CloseButton label="Close message" onClick={onClose} />
           </div>
         </div>
-        {!isTool && viewMode === "rendered" ? (
+        {contentPending ? (
+          <pre className="agent-message-modal-content">
+            Loading tool content…
+          </pre>
+        ) : !isTool && viewMode === "rendered" ? (
           <div className="agent-message-modal-content is-rendered">
             <MarkdownPreview
               text={message.text}

--- a/web/src/components/FilePreviewContent.tsx
+++ b/web/src/components/FilePreviewContent.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import type { EditorView as CodeMirrorEditorView } from "@codemirror/view";
+import { ChevronLeft } from "lucide-react";
 import { fileReviewLineLabel, MAX_QUOTE_LENGTH } from "../annotations";
 import {
   FileAnnotationDrag,
@@ -164,6 +165,7 @@ export function FilePreviewContent({
   changesContent,
   changesKey,
   annotations = [],
+  backAction,
   onOpenChanges,
   onCreateAnnotation,
   onReanchorAnnotations,
@@ -174,6 +176,7 @@ export function FilePreviewContent({
   error: string | null;
   changesContent?: ReactNode;
   changesKey?: string;
+  backAction?: { label: string; onClick: () => void };
   annotations?: readonly ReviewAnnotation[];
   onOpenChanges?: () => void;
   onCreateAnnotation?: (annotation: NewReviewAnnotation) => void;
@@ -397,6 +400,16 @@ export function FilePreviewContent({
     >
       <div className="file-preview-head">
         <div className="file-preview-title-row">
+          {backAction ? (
+            <button
+              type="button"
+              className="file-preview-back"
+              onClick={backAction.onClick}
+            >
+              <ChevronLeft size={13} aria-hidden="true" />
+              {backAction.label}
+            </button>
+          ) : null}
           <div className="file-preview-title" title={entry?.name}>
             {entry?.name ?? "Preview"}
           </div>

--- a/web/src/components/WorkspaceInspectorHost.tsx
+++ b/web/src/components/WorkspaceInspectorHost.tsx
@@ -696,7 +696,7 @@ export function WorkspaceInspectorHost({
         </div>
       ) : (
         <div className="workspace-inspector-body">
-          {hasDetail ? (
+          {hasDetail && state.view === "changes" ? (
             <button
               type="button"
               className="workspace-inspector-back"
@@ -709,7 +709,7 @@ export function WorkspaceInspectorHost({
               }}
             >
               <ChevronLeft size={15} />
-              {state.view === "files" ? "Files" : "Changed files"}
+              Changed files
             </button>
           ) : null}
 
@@ -760,6 +760,20 @@ export function WorkspaceInspectorHost({
                 preview={fileSelection.preview}
                 loading={fileSelection.loading}
                 error={fileSelection.error}
+                backAction={
+                  compact && drillInByView.files && fileSelection.entry
+                    ? {
+                        label: "Files",
+                        onClick: () => {
+                          setDrillInByView((current) => ({
+                            ...current,
+                            files: false,
+                          }));
+                          onBack();
+                        },
+                      }
+                    : undefined
+                }
                 annotations={annotations}
                 onCreateAnnotation={addAnnotation}
                 onReanchorAnnotations={reanchorFileAnnotations}

--- a/web/src/components/WorkspaceTree.tsx
+++ b/web/src/components/WorkspaceTree.tsx
@@ -196,6 +196,7 @@ export function WorkspaceTree({
       panes: state.panes,
       selectedPaneId: state.selectedPaneId,
       status: state.status,
+      tabs: state.tabs,
       workspaces: state.workspaces,
     }),
     shallowEqual,
@@ -260,6 +261,13 @@ export function WorkspaceTree({
     () => groupAgentPanesByWorkspace(s.panes),
     [s.panes],
   );
+  const tabCountsByWorkspace = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const tab of s.tabs) {
+      counts.set(tab.workspace_id, (counts.get(tab.workspace_id) ?? 0) + 1);
+    }
+    return counts;
+  }, [s.tabs]);
   const defaultAgentPanes = useMemo(() => {
     const workspaceNumbers = new Map(
       s.workspaces.map((workspace) => [
@@ -545,6 +553,7 @@ export function WorkspaceTree({
                   ? agentsByWorkspace
                   : EMPTY_AGENT_PANES_BY_WORKSPACE
               }
+              tabCountsByWorkspace={tabCountsByWorkspace}
               activePaneId={activePaneId}
               pinnedWorkspaceKeys={pinnedWorkspaceSet}
               collapsedWorktreeGroupKeys={collapsedWorktreeGroupSet}
@@ -719,6 +728,7 @@ function WorkspaceRow({
   depth,
   childrenByParent,
   agentsByWorkspace,
+  tabCountsByWorkspace,
   activePaneId,
   pinnedWorkspaceKeys,
   collapsedWorktreeGroupKeys,
@@ -733,6 +743,7 @@ function WorkspaceRow({
   depth: number;
   childrenByParent: Map<string, Workspace[]>;
   agentsByWorkspace: ReadonlyMap<string, Pane[]>;
+  tabCountsByWorkspace: ReadonlyMap<string, number>;
   activePaneId: string | null;
   pinnedWorkspaceKeys: ReadonlySet<string>;
   collapsedWorktreeGroupKeys: ReadonlySet<string>;
@@ -745,6 +756,7 @@ function WorkspaceRow({
 }) {
   const children = childrenByParent.get(w.workspace_id) ?? [];
   const agents = agentsByWorkspace.get(w.workspace_id) ?? [];
+  const tabCount = tabCountsByWorkspace.get(w.workspace_id) ?? 0;
   const s = useStoreSelector(
     (state) => ({
       pendingFocusWorkspaceId: state.pendingFocusWorkspaceId,
@@ -825,7 +837,9 @@ function WorkspaceRow({
           hasActiveAgent ? "has-active-agent" : ""
         } ${isChild ? "is-child" : ""} ${pinned ? "is-pinned" : ""} ${
           isPendingFocus ? "is-loading" : ""
-        } ${workspaceDrag?.isDragging ? "is-dragging" : ""} ${
+        } ${tabCount > 1 ? "has-tab-count" : ""} ${
+          workspaceDrag?.isDragging ? "is-dragging" : ""
+        } ${
           workspaceDrag?.dropPosition
             ? `drop-${workspaceDrag.dropPosition}`
             : ""
@@ -949,6 +963,15 @@ function WorkspaceRow({
           <span className="twisty" aria-hidden="true" />
         )}
         <strong className="ws-label">{workspaceDisplayName(w)}</strong>
+        {tabCount > 1 ? (
+          <span
+            className="workspace-tab-count"
+            title={`${tabCount} tabs`}
+            aria-label={`${tabCount} tabs`}
+          >
+            {tabCount}
+          </span>
+        ) : null}
         {pinned ? (
           <Pin
             className="workspace-pin"
@@ -989,6 +1012,7 @@ function WorkspaceRow({
               depth={depth + 1}
               childrenByParent={childrenByParent}
               agentsByWorkspace={agentsByWorkspace}
+              tabCountsByWorkspace={tabCountsByWorkspace}
               activePaneId={activePaneId}
               pinnedWorkspaceKeys={pinnedWorkspaceKeys}
               collapsedWorktreeGroupKeys={collapsedWorktreeGroupKeys}

--- a/web/src/components/agentHistory.test.ts
+++ b/web/src/components/agentHistory.test.ts
@@ -159,6 +159,30 @@ test("filtering leaves hidden entries synchronized across delta updates and remo
   expect(next.cursor).toEqual({ epoch: "a", revision: 2 });
 });
 
+test("window counts conversation entries only; tool entries ride along", () => {
+  const tool = (id: string): HistoryEntry => ({
+    ...entry(id),
+    role: "tool",
+    kind: "tool_call",
+    tool_name: "bash",
+    text: "",
+    text_bytes: 10,
+  });
+  const interleaved: HistoryEntry[] = [];
+  for (let index = 0; index < 205; index++) {
+    interleaved.push(entry(`u${index}`), tool(`t${index}`));
+  }
+  const merged = mergeAgentHistory(null, response(interleaved), null)!;
+  expect(merged.messages.filter((item) => item.role !== "tool")).toHaveLength(
+    200,
+  );
+  expect(merged.messages[0].id).toBe("u5");
+  expect(merged.messages[1].id).toBe("t5");
+  expect(merged.messages.filter((item) => item.role === "tool")).toHaveLength(
+    200,
+  );
+});
+
 test("bounds snapshots and rejects malformed delta ordering", () => {
   const first = mergeAgentHistory(
     null,

--- a/web/src/components/agentHistory.ts
+++ b/web/src/components/agentHistory.ts
@@ -3,6 +3,7 @@ import type {
   HistoryEntry,
   HistoryUpdate,
 } from "../../../server/src/agent/session-history";
+import { historyWindowEntries } from "../../../server/src/agent/session-history-window";
 export type { HistoryCursor, HistoryEntry, HistoryUpdate };
 
 export type AgentHistory = {
@@ -103,6 +104,7 @@ export function mergeAgentHistory(
   )
     return current;
   // Never retain transport deltas or full snapshots beside the visible list.
+  // The window counts conversation entries only; tool entries ride along.
   return {
     status: response.status,
     detail: response.detail,
@@ -114,7 +116,7 @@ export function mergeAgentHistory(
     updated_at: response.updated_at,
     path: response.path,
     cursor: response.cursor,
-    messages: messages.slice(-limit),
+    messages: historyWindowEntries(messages, limit),
   };
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2598,9 +2598,23 @@ textarea:focus {
 }
 .ws-label {
   flex: 1;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.tree-row.has-tab-count > .ws-label {
+  flex: 0 1 auto;
+}
+.workspace-tab-count {
+  flex: 1 0 auto;
+  color: color-mix(in srgb, var(--muted) 55%, transparent);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+.tree-row.is-focused > .workspace-tab-count {
+  color: color-mix(in srgb, var(--muted) 85%, transparent);
 }
 .tree-row.is-child strong {
   font-weight: 500;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5091,6 +5091,7 @@ textarea:focus {
   gap: 10px;
 }
 .file-preview-title {
+  flex: 1 1 auto;
   min-width: 0;
   overflow: hidden;
   color: var(--text-strong);
@@ -5104,6 +5105,23 @@ textarea:focus {
   display: inline-flex;
   align-items: center;
   gap: 6px;
+}
+.file-preview-back {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  height: 24px;
+  padding: 0 8px 0 5px;
+  border-radius: 7px;
+  background: var(--viewer-panel-bg);
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 700;
+}
+.file-preview-back:hover {
+  background: var(--accent-soft);
+  color: var(--text-strong);
 }
 .file-preview-mode-toggle,
 .file-preview-copy,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8005,6 +8005,26 @@ textarea:focus {
   border: none;
   border-radius: 0;
 }
+.agent-history-tool-load {
+  display: block;
+  width: 100%;
+  padding: 14px 10px;
+  border: 1px dashed var(--border);
+  border-radius: 7px;
+  background: transparent;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  text-align: center;
+}
+.agent-history-tool-load:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.agent-history-tool-load:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
 .agent-history-card-open.is-truncated::after {
   content: "";
   position: absolute;


### PR DESCRIPTION
## Summary

- **History window counts conversation entries only.** The 200-entry History window now counts user/assistant/error entries; tool calls and results ride along with the turns that survive the cut, so tool-heavy turns no longer evict user messages from the visible history.
- **Tool payloads load on demand.** History refreshes no longer transmit tool call arguments or output: wire entries carry metadata plus a size hint, and the full text is fetched per entry via a new `agent_history.entry` RPC when the user clicks Load. Tool entries are hidden by default and can be re-enabled with the tool filter. Expanded tool details automatically refetch if a refresh replaces the viewed entry, and the dialog shows a loading placeholder instead of going blank.
- **History follows tab switches.** The History view re-pins its session to the newly active tab's agent, or to the next available agent when the pinned pane closes, instead of showing a stale or missing session.
- **Workspace tab counts.** Workspace tree rows show a subtle tab count next to the name when a workspace has more than one tab.
- **Compact Inspector back button.** The back button moved from a standalone row into the file preview header, next to the file name.

## Verification

- `bun run format:check` — clean
- `bun run lint` — clean
- `cd server && bunx tsc --noEmit` — clean
- `cd web && bunx tsc --noEmit` — only the 3 xterm `scrollbar` type errors that already exist on `main`
- `bun run test` — 968 pass; the single failure (`terminalFit` hidden-scrollbar test) also fails on `main`

New coverage: conversation-counted window semantics (server + web merge), wire redaction stubs, `agent_history.entry` round-trip and eviction errors, redacted-card Load button states.
