### PR TITLE
Fix duplicated IME text when switching input sources mid-composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixed
+
+- Stop duplicating IME text committed while switching input sources with
+  candidates visible (e.g. leaving a Chinese IME mid-composition).
+
 ## 0.5.2 - 2026-09-06
 
 ### Added

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -57,11 +57,13 @@ import { terminalFocusBlockedByOverlay } from "../terminalFocus";
 import { uploadTerminalImage } from "../terminalImageUpload";
 import {
   isTerminalImeCommittedInputType,
+  TerminalImeCommitGuard,
   TerminalImeFallbackTracker,
   TerminalImeKeyEventTracker,
   TerminalImeTextareaFallbackTracker,
   terminalImeEventTime,
   terminalImeFallbackText,
+  terminalImeTextareaDelta,
 } from "../terminalIme";
 import {
   macCommandEditingSequence,
@@ -824,6 +826,7 @@ export function TerminalView({
     const imeFallback = new TerminalImeFallbackTracker();
     const imeKeyEvent = new TerminalImeKeyEventTracker();
     const imeTextareaFallback = new TerminalImeTextareaFallbackTracker();
+    const imeCommitGuard = new TerminalImeCommitGuard();
     const readTerminalTextareaSnapshot = (): TerminalPasteTextareaSnapshot => {
       const textarea = term.textarea;
       const value = textarea?.value ?? "";
@@ -837,6 +840,7 @@ export function TerminalView({
     let imeTextareaTimer: number | null = null;
     let terminalCompositionActive = false;
     let compositionSettleTimer: number | null = null;
+    let compositionStartTextareaValue = "";
     let nativePasteFallbackTimer: number | null = null;
     let pasteTextareaClearTimer: number | null = null;
     let pasteTextareaBeforeInput: TerminalPasteTextareaSnapshot | null = null;
@@ -847,6 +851,9 @@ export function TerminalView({
       const unsuppressedData = imeTextareaFallback.recordXtermData(data);
       if (!unsuppressedData) return;
       const dataAt = performance.now();
+      if (!imeCommitGuard.filterXtermData(unsuppressedData, dataAt)) {
+        return;
+      }
       const shouldSend = imeFallback.recordXtermData(unsuppressedData, dataAt);
       if (!shouldSend) return;
       const terminalId = desiredTerminalRef.current;
@@ -1012,6 +1019,7 @@ export function TerminalView({
       eventTime: number,
       observedAt: number,
     ) => {
+      if (imeCommitGuard.consumeSuppressedDuplicate(text, observedAt)) return;
       const shouldSend = imeFallback.recordInput(text, eventTime, observedAt);
       if (!shouldSend) return;
       sendText(text);
@@ -1265,10 +1273,21 @@ export function TerminalView({
       pasteTextareaBeforeInput = null;
       pastePaneIdBeforeInput = null;
       lastTerminalTextareaSnapshot = readTerminalTextareaSnapshot();
+      compositionStartTextareaValue = lastTerminalTextareaSnapshot.value;
       cancelImeTextareaFallback();
     };
     const onTerminalCompositionEnd = () => {
       lastTerminalTextareaSnapshot = readTerminalTextareaSnapshot();
+      // Only arm the guard when the composition actually committed text. A
+      // canceled composition leaves no delta, so a stray emission right
+      // after Escape can never be captured as a commit.
+      imeCommitGuard.endComposition(
+        performance.now(),
+        terminalImeTextareaDelta(
+          compositionStartTextareaValue,
+          lastTerminalTextareaSnapshot.value,
+        ),
+      );
       cancelImeTextareaFallback();
       cancelCompositionSettle();
       // This listener runs after xterm's compositionend listener. Keep fallback
@@ -1702,6 +1721,7 @@ export function TerminalView({
         capture: true,
       });
       imeFallback.dispose();
+      imeCommitGuard.dispose();
       linkProvider.dispose();
       const terminalId = attachedRef.current ?? desiredTerminalRef.current;
       if (

--- a/web/src/terminalIme.test.ts
+++ b/web/src/terminalIme.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   isTerminalImeCommittedInputType,
+  TerminalImeCommitGuard,
   terminalImeEventTime,
   terminalImeFallbackText,
   TerminalImeFallbackTracker,
@@ -306,5 +307,97 @@ describe("terminal IME punctuation fallback tracking", () => {
     input("！", 130, "missing");
 
     expect(sent.join("")).toBe("，。？！");
+  });
+});
+
+describe("terminal IME commit duplication guard", () => {
+  test("suppresses exactly one identical re-emission of the commit", () => {
+    const guard = new TerminalImeCommitGuard();
+    guard.endComposition(100, "ni hao");
+    expect(guard.filterXtermData("ni hao", 101)).toBe(true);
+    expect(guard.filterXtermData("ni hao", 130)).toBe(false);
+    expect(guard.filterXtermData("ni hao", 140)).toBe(true);
+  });
+
+  test("never arms when a canceled composition leaves no delta", () => {
+    const guard = new TerminalImeCommitGuard();
+    guard.endComposition(100, null);
+    expect(guard.filterXtermData("x", 110)).toBe(true);
+    expect(guard.filterXtermData("x", 120)).toBe(true);
+  });
+
+  test("never arms when a canceled composition emits nothing", () => {
+    const guard = new TerminalImeCommitGuard();
+    guard.endComposition(100, "x");
+    expect(guard.filterXtermData("x", 200)).toBe(true);
+    expect(guard.filterXtermData("x", 220)).toBe(true);
+  });
+
+  test("lets a legitimately repeated commit re-arm through compositionend", () => {
+    const guard = new TerminalImeCommitGuard();
+    guard.endComposition(100, "ni hao");
+    expect(guard.filterXtermData("ni hao", 101)).toBe(true);
+    guard.endComposition(200, "ni hao");
+    expect(guard.filterXtermData("ni hao", 201)).toBe(true);
+    expect(guard.filterXtermData("ni hao", 230)).toBe(false);
+  });
+
+  test("does not consume on different text or after the duplicate window", () => {
+    const guard = new TerminalImeCommitGuard();
+    guard.endComposition(100, "ni hao");
+    expect(guard.filterXtermData("ni hao", 101)).toBe(true);
+    expect(guard.filterXtermData("ni", 120)).toBe(true);
+    expect(guard.filterXtermData("ni hao", 450)).toBe(true);
+    expect(guard.filterXtermData("ni hao", 460)).toBe(true);
+  });
+
+  test("still suppresses identical text after a different emission inside the window", () => {
+    const guard = new TerminalImeCommitGuard();
+    guard.endComposition(100, "ni hao");
+    expect(guard.filterXtermData("ni hao", 101)).toBe(true);
+    expect(guard.filterXtermData("other", 120)).toBe(true);
+    expect(guard.filterXtermData("ni hao", 150)).toBe(false);
+  });
+
+  test("treats window edges as still inside the window", () => {
+    const guard = new TerminalImeCommitGuard();
+    guard.endComposition(100, "ni hao");
+    expect(guard.filterXtermData("ni hao", 150)).toBe(true);
+    expect(guard.filterXtermData("ni hao", 450)).toBe(false);
+  });
+
+  test("ignores emissions outside the capture window before arming", () => {
+    const guard = new TerminalImeCommitGuard();
+    guard.endComposition(100, "late");
+    expect(guard.filterXtermData("late", 200)).toBe(true);
+    expect(guard.filterXtermData("late", 210)).toBe(true);
+  });
+
+  test("tombstones a suppressed duplicate for the recovery funnels", () => {
+    const guard = new TerminalImeCommitGuard();
+    guard.endComposition(100, "ni hao");
+    expect(guard.filterXtermData("ni hao", 101)).toBe(true);
+    expect(guard.filterXtermData("ni hao", 130)).toBe(false);
+    expect(guard.consumeSuppressedDuplicate("ni", 140)).toBe(false);
+    expect(guard.consumeSuppressedDuplicate("ni hao", 140)).toBe(true);
+    expect(guard.consumeSuppressedDuplicate("ni hao", 150)).toBe(false);
+  });
+
+  test("lets the tombstone expire", () => {
+    const guard = new TerminalImeCommitGuard();
+    guard.endComposition(100, "ni hao");
+    guard.filterXtermData("ni hao", 101);
+    guard.filterXtermData("ni hao", 130);
+    expect(guard.consumeSuppressedDuplicate("ni hao", 500)).toBe(false);
+  });
+
+  test("dispose clears any armed duplicate suppression", () => {
+    const guard = new TerminalImeCommitGuard();
+    guard.endComposition(100, "ni hao");
+    expect(guard.filterXtermData("ni hao", 101)).toBe(true);
+    guard.filterXtermData("ni hao", 110);
+    guard.dispose();
+    expect(guard.filterXtermData("ni hao", 120)).toBe(true);
+    expect(guard.consumeSuppressedDuplicate("ni hao", 120)).toBe(false);
   });
 });

--- a/web/src/terminalIme.ts
+++ b/web/src/terminalIme.ts
@@ -3,6 +3,8 @@ const EAST_ASIAN_PUNCTUATION_RE =
 const RECENT_OUTPUT_LEAD_MS = 16;
 const RECENT_OUTPUT_MAX_AGE_MS = 80;
 const PENDING_XTERM_OUTPUT_MAX_AGE_MS = 24;
+const COMMIT_CAPTURE_WINDOW_MS = 50;
+const COMMIT_DUPLICATE_WINDOW_MS = 300;
 
 type ImeInputEvent = Pick<InputEvent, "data" | "inputType" | "isComposing">;
 
@@ -259,5 +261,96 @@ export class TerminalImeFallbackTracker {
         this.pendingXtermOutput.delete(id);
       }
     }
+  }
+}
+
+/**
+ * Drops the duplicate of an IME commit that arrives as a side effect of
+ * switching input sources with candidates visible (e.g. pressing
+ * Shift/CapsLock to leave a Chinese IME). macOS confirms such commits
+ * asynchronously, so xterm emits the committed text once from its
+ * compositionend finalization and then again from its own input fast path
+ * when the OS re-delivers the text without a key event.
+ *
+ * The guard learns the committed text from xterm's first emission after each
+ * compositionend (normally the composition finalization), then drops exactly
+ * one identical re-emission inside a short window and records a tombstone so
+ * the app-side recovery funnels do not re-send that same text when the OS
+ * re-delivery arrives without a beforeinput event. A canceled composition
+ * (Escape) leaves no textarea delta and never arms the guard, and each
+ * compositionend re-arms the capture so legitimately repeated commits always
+ * pass. The guard is timer-free; windows expire lazily on the next check.
+ *
+ * Known limits, all benign by design: a same-text emission inside the
+ * window is indistinguishable from the OS duplicate (e.g. a term.paste
+ * fallback repeating the just-committed text); xterm-internal double
+ * finalization from a non-229 keydown mid-composition is out of scope; and
+ * a finalize emission delayed past the capture window simply leaves the
+ * guard unarmed, i.e. the pre-fix behavior.
+ */
+export class TerminalImeCommitGuard {
+  private captureUntil = 0;
+  private committedText: string | null = null;
+  private duplicateUntil = 0;
+  private suppressedDuplicate: { text: string; until: number } | null = null;
+
+  /**
+   * Reopens the capture window when a composition session ends having
+   * committed text. A canceled composition leaves no delta and never arms
+   * the guard, so a stray emission right after Escape cannot be captured.
+   */
+  endComposition(at: number, committedDelta: string | null): void {
+    this.captureUntil = committedDelta ? at + COMMIT_CAPTURE_WINDOW_MS : 0;
+    this.committedText = null;
+    this.duplicateUntil = 0;
+  }
+
+  /**
+   * Filters one xterm data emission. Returns false when the emission is the
+   * duplicate of the captured commit and must not reach the terminal.
+   */
+  filterXtermData(data: string, at: number): boolean {
+    if (this.committedText === null) {
+      if (at > this.captureUntil) return true;
+      this.captureUntil = 0;
+      this.committedText = data;
+      this.duplicateUntil = at + COMMIT_DUPLICATE_WINDOW_MS;
+      return true;
+    }
+    if (at > this.duplicateUntil) {
+      this.committedText = null;
+      this.duplicateUntil = 0;
+      return true;
+    }
+    if (data !== this.committedText) return true;
+    this.committedText = null;
+    this.duplicateUntil = 0;
+    this.suppressedDuplicate = {
+      text: data,
+      until: at + COMMIT_DUPLICATE_WINDOW_MS,
+    };
+    return false;
+  }
+
+  /**
+   * Consumes the tombstone of a previously suppressed duplicate when an
+   * app-side recovery funnel tries to send the same text again. Without a
+   * beforeinput event the textarea fallback still produces the duplicated
+   * commit text, and this check is the only thing that stops it.
+   */
+  consumeSuppressedDuplicate(text: string, at: number): boolean {
+    const suppressed = this.suppressedDuplicate;
+    if (!suppressed || at > suppressed.until || suppressed.text !== text) {
+      return false;
+    }
+    this.suppressedDuplicate = null;
+    return true;
+  }
+
+  dispose(): void {
+    this.captureUntil = 0;
+    this.committedText = null;
+    this.duplicateUntil = 0;
+    this.suppressedDuplicate = null;
   }
 }


### PR DESCRIPTION
## Problem

On macOS, committing IME text by switching input sources while candidates are still visible (e.g. pressing Shift/CapsLock to leave a Chinese IME instead of picking a candidate) delivers the text to the terminal twice: typing `nihao` and switching to English produced `ni haoni hao`.

## Root cause

macOS confirms these commits asynchronously, so the same text reaches xterm through two channels:

1. `compositionend` → xterm's `CompositionHelper._finalizeComposition(true)` reads the helper textarea after a 0ms timer and emits the committed text.
2. The OS re-delivers the text without any key event; xterm's own `input`-event fast path (`_inputEvent`, `insertText` with no keydown seen) emits it a second time.

The existing dedup trackers only cover app-originated fallback sends (and only within 16/24ms one-directional windows), so the second xterm-internal emission always reached the terminal. Normal candidate selection commits as `insertFromComposition` and never hits the fast path, which is why only input-source switching duplicates.

## Fix

Add `TerminalImeCommitGuard` (`web/src/terminalIme.ts`), a timer-free filter on the xterm data funnel:

- Each `compositionend` that actually committed text reopens a short capture window; xterm's first emission inside it (the composition finalization) is learned as the committed text.
- Exactly one identical re-emission inside a 300ms window is dropped, and a tombstone is recorded so the app-side recovery funnels (`sendMissingImeText`) do not re-send the same text when the OS re-delivery arrives without a `beforeinput` event (Safari-style ordering).
- A canceled composition (Escape) leaves no textarea delta, so it never arms the guard; every `compositionend` re-arms the capture so legitimately repeated commits always pass.

The filter sits after `imeTextareaFallback.recordXtermData` and before `imeFallback.recordXtermData`, so suppressed emissions still participate in the textarea-fallback accounting but never pollute the punctuation dedup windows.

## Testing

- `bun test src/terminalIme.test.ts`: 34 pass (11 new guard cases: single-suppression, consume-once, re-arm on repeated commits, canceled composition with/without delta, window edges, different-text interleaving, tombstone behavior/expiry, dispose).
- Full suite: 964 pass / 0 fail; `tsc --noEmit`, ESLint and Biome clean.

## Notes

- Cross-reviewed by independent agents; findings addressed in this branch (recovery-funnel tombstone, arm-only-on-real-commit).
- Both this PR and the Inspector focus PR add a `CHANGELOG.md` entry under `## Unreleased`; the second one to merge needs a trivial rebase.
- Final timing behavior on real macOS IMEs should be spot-checked on device.