### PR TITLE
Route Herdr 0.9.0 terminal streams through stable endpoint protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Changed
+
+- Route terminal streams on Herdr 0.9.0 through the stable endpoint
+  generation 1 protocol instead of the private direct-attach protocol: the
+  browser terminal now renders the pane cropped from the server-rendered tab
+  surface, input is classified into semantic key events, and scrollback goes
+  through `pane.scroll`. Set `HERDR_GUI_DISABLE_ENDPOINT=1` to fall back to
+  the legacy path. Known gaps on the endpoint path: mouse input is not yet
+  classified, and panes sharing a tab render at their layout size.
+
 ## 0.5.3 - 2026-09-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
   the legacy path. Known gaps on the endpoint path: mouse input is not yet
   classified, and panes sharing a tab render at their layout size.
 
+### Fixed
+
+- Clear stale terminal text on endpoint repaints, wait for the initial snapshot
+  before attaching, and reject pending endpoint requests when disconnected.
+
 ## 0.5.3 - 2026-09-08
 
 ### Changed

--- a/server/src/bridge/endpoint-client.test.ts
+++ b/server/src/bridge/endpoint-client.test.ts
@@ -1,0 +1,362 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as net from "node:net";
+import * as path from "node:path";
+import { tmpdir } from "node:os";
+import { BinReader, BinWriter, encodeFrame } from "./bincode";
+import { EndpointClient, type EndpointSurface } from "./endpoint-client";
+import type { CellData, FrameData } from "./thin-client";
+
+const servers: net.Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map(
+        (server) =>
+          new Promise<void>((resolve) => server.close(() => resolve())),
+      ),
+  );
+});
+
+const WELCOME = {
+  generation: 1,
+  server_version: "0.9.0",
+  snapshot_codec: "shell.snapshot.v1",
+  surface_codec: "shell.surface.v1",
+  input_codec: "shell.input.semantic.v1",
+  blob_codec: "shell.blob.v1",
+  methods: ["pane.focus"],
+  capabilities: ["surface_interest", "health_check"],
+};
+
+function cell(symbol: string, over: Partial<CellData> = {}): CellData {
+  return {
+    symbol,
+    fg: 0,
+    bg: 0,
+    modifier: 0,
+    skip: false,
+    hyperlink: null,
+    ...over,
+  };
+}
+
+function writeCell(w: BinWriter, c: CellData) {
+  w.string(c.symbol);
+  w.varint(c.fg);
+  w.varint(c.bg);
+  w.varint(c.modifier);
+  w.bool(c.skip);
+  w.option(c.hyperlink, (v) => w.varint(v));
+}
+
+function writeFrame(w: BinWriter, frame: FrameData) {
+  w.varint(frame.cells.length);
+  for (const c of frame.cells) writeCell(w, c);
+  w.varint(frame.width);
+  w.varint(frame.height);
+  w.option(frame.cursor, (cur) => {
+    w.varint(cur.x);
+    w.varint(cur.y);
+    w.bool(cur.visible);
+    w.u8(cur.shape);
+  });
+  w.varint(frame.hyperlinks.length);
+  for (const link of frame.hyperlinks) w.string(link);
+  w.bytes(Buffer.alloc(0)); // graphics
+}
+
+function writePane(w: BinWriter, paneId: string, focused = true) {
+  w.string(paneId);
+  w.varint(1); // content_revision
+  for (const rect of [
+    { x: 0, y: 0, width: 10, height: 5 },
+    { x: 0, y: 0, width: 10, height: 5 },
+  ]) {
+    w.varint(rect.x);
+    w.varint(rect.y);
+    w.varint(rect.width);
+    w.varint(rect.height);
+  }
+  w.bool(false); // scrollbar_rect
+  w.bool(false); // scroll metrics
+  w.bool(focused);
+  w.bool(false); // mouse_reporting
+  w.bool(false); // sgr_pixel_mouse
+  w.bool(false); // alternate_screen_active
+  w.varint(0); // pixel_width
+  w.varint(0); // pixel_height
+}
+
+function surfaceFrame(payload: {
+  surfaceRevision: number;
+  frame: FrameData;
+}): Buffer {
+  const w = new BinWriter();
+  w.variant(13); // PaneSurface
+  w.string("boot-1");
+  w.varint(1); // projection_revision
+  w.varint(payload.surfaceRevision);
+  writeFrame(w, payload.frame);
+  w.varint(1); // one pane
+  writePane(w, "w1:p1");
+  w.varint(0); // splits
+  w.bool(false); // popup
+  // SurfaceGraphicsScene tail: the client stops reading before it.
+  return w.toBuffer();
+}
+
+function patchFrame(payload: {
+  baseSurfaceRevision: number;
+  surfaceRevision: number;
+  rows: Array<{ x: number; y: number; cells: CellData[] }>;
+  cursor?: { x: number; y: number; visible: boolean; shape: number };
+}): Buffer {
+  const w = new BinWriter();
+  w.variant(19); // PaneSurfacePatch
+  w.string("boot-1");
+  w.varint(1);
+  w.varint(payload.baseSurfaceRevision);
+  w.varint(payload.surfaceRevision);
+  w.varint(payload.rows.length);
+  for (const row of payload.rows) {
+    w.varint(row.x);
+    w.varint(row.y);
+    w.varint(row.cells.length);
+    for (const c of row.cells) writeCell(w, c);
+  }
+  w.varint(1);
+  writePane(w, "w1:p1");
+  w.option(payload.cursor, (cur) => {
+    w.varint(cur.x);
+    w.varint(cur.y);
+    w.bool(cur.visible);
+    w.u8(cur.shape);
+  });
+  return w.toBuffer();
+}
+
+function controlFrame(kind: string, data: string): Buffer {
+  const w = new BinWriter();
+  w.variant(20);
+  w.string(kind);
+  w.string(data);
+  return w.toBuffer();
+}
+
+/**
+ * Fake endpoint server: expects endpoint.hello.v1 as the first message, then
+ * replies with the welcome and runs the given script.
+ */
+async function startEndpointServer(
+  onHello: (hello: any, socket: net.Socket) => void,
+  onMessage?: (variant: number, reader: BinReader, socket: net.Socket) => void,
+) {
+  const socketPath = path.join(
+    tmpdir(),
+    `herdr-gui-endpoint-${process.pid}-${crypto.randomUUID()}.sock`,
+  );
+  const server = net.createServer((socket) => {
+    let input = Buffer.alloc(0);
+    let greeted = false;
+    socket.on("data", (chunk) => {
+      input = Buffer.concat([
+        input,
+        Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk),
+      ]);
+      while (input.length >= 4) {
+        const length = input.readUInt32LE(0);
+        if (input.length < length + 4) return;
+        const reader = new BinReader(input.subarray(4, length + 4));
+        input = input.subarray(length + 4);
+        const variant = reader.variant();
+        if (!greeted) {
+          greeted = true;
+          expect(variant).toBe(20);
+          expect(reader.string()).toBe("endpoint.hello.v1");
+          const hello = JSON.parse(reader.string());
+          expect(reader.remaining).toBe(0);
+          socket.write(
+            encodeFrame(
+              controlFrame("endpoint.welcome.v1", JSON.stringify(WELCOME)),
+            ),
+          );
+          onHello(hello, socket);
+          continue;
+        }
+        onMessage?.(variant, reader, socket);
+      }
+    });
+  });
+  servers.push(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, resolve);
+  });
+  return socketPath;
+}
+
+describe("EndpointClient (endpoint generation 1)", () => {
+  test("sends a generation-1 hello with the required codecs", async () => {
+    const socketPath = await startEndpointServer(() => {});
+    const client = new EndpointClient(socketPath);
+    const welcome = new Promise<any>((resolve) =>
+      client.once("welcome", resolve),
+    );
+    await client.connect(100, 30);
+    const w = await welcome;
+    expect(w.serverVersion).toBe("0.9.0");
+    expect(w.capabilities).toEqual(["surface_interest", "health_check"]);
+    client.close();
+  });
+
+  test("composes full surfaces and applies patches on the matching base", async () => {
+    const base: FrameData = {
+      cells: Array.from({ length: 20 }, () => cell(" ")),
+      width: 10,
+      height: 2,
+      cursor: null,
+      hyperlinks: [],
+    };
+    const socketPath = await startEndpointServer((_hello, socket) => {
+      socket.write(
+        encodeFrame(surfaceFrame({ surfaceRevision: 1, frame: base })),
+      );
+      socket.write(
+        encodeFrame(
+          patchFrame({
+            baseSurfaceRevision: 1,
+            surfaceRevision: 2,
+            rows: [{ x: 2, y: 1, cells: [cell("h"), cell("i")] }],
+            cursor: { x: 4, y: 1, visible: true, shape: 1 },
+          }),
+        ),
+      );
+      // Stale patch: wrong base must be dropped.
+      socket.write(
+        encodeFrame(
+          patchFrame({
+            baseSurfaceRevision: 1,
+            surfaceRevision: 3,
+            rows: [{ x: 0, y: 0, cells: [cell("X")] }],
+          }),
+        ),
+      );
+    });
+    const client = new EndpointClient(socketPath);
+    const surfaces: EndpointSurface[] = [];
+    client.on("surface", (s) => surfaces.push(s));
+    await client.connect(10, 2);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    expect(surfaces.length).toBe(2);
+    expect(surfaces[0].surfaceRevision).toBe(1);
+    expect(surfaces[0].panes).toEqual([
+      {
+        paneId: "w1:p1",
+        rect: { x: 0, y: 0, width: 10, height: 5 },
+        innerRect: { x: 0, y: 0, width: 10, height: 5 },
+        scroll: null,
+        focused: true,
+      },
+    ]);
+    const patched = surfaces[1];
+    expect(patched.surfaceRevision).toBe(2);
+    expect(patched.frame.cells[12].symbol).toBe("h");
+    expect(patched.frame.cells[13].symbol).toBe("i");
+    expect(patched.frame.cells[0].symbol).toBe(" ");
+    // Earlier emitted frames stay immutable for retained consumers.
+    expect(surfaces[0].frame.cells[12].symbol).toBe(" ");
+    expect(patched.frame.cursor).toEqual({
+      x: 4,
+      y: 1,
+      visible: true,
+      shape: 1,
+    });
+    client.close();
+  });
+
+  test("encodes resize and answers health pings with a pong", async () => {
+    const seen: Array<{ variant: number; fields: unknown[] }> = [];
+    const socketPath = await startEndpointServer(
+      (_hello, socket) => {
+        socket.write(
+          encodeFrame(controlFrame("endpoint.health.ping.v1", "{}")),
+        );
+      },
+      (variant, reader, socket) => {
+        if (variant === 12) {
+          seen.push({
+            variant,
+            fields: [
+              reader.varint(),
+              reader.varint(),
+              reader.varint(),
+              reader.varint(),
+              reader.bool(),
+            ],
+          });
+        } else if (variant === 20) {
+          seen.push({ variant, fields: [reader.string(), reader.string()] });
+          socket.write(
+            encodeFrame(controlFrame("endpoint.health.pong.v1", "{}")),
+          );
+        }
+      },
+    );
+    const client = new EndpointClient(socketPath);
+    await client.connect(100, 30);
+    client.resize(80, 24);
+    client.ping();
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    expect(seen).toContainEqual({ variant: 12, fields: [0, 0, 80, 24, false] });
+    expect(seen).toContainEqual({
+      variant: 20,
+      fields: ["endpoint.health.ping.v1", "{}"],
+    });
+    // The client's pong reply to the server ping.
+    expect(seen).toContainEqual({
+      variant: 20,
+      fields: ["endpoint.health.pong.v1", "{}"],
+    });
+    client.close();
+  });
+
+  test("rejects when the welcome carries a handshake error", async () => {
+    const socketPath = path.join(
+      tmpdir(),
+      `herdr-gui-endpoint-err-${process.pid}-${crypto.randomUUID()}.sock`,
+    );
+    const server = net.createServer((socket) => {
+      socket.once("data", () => {
+        socket.write(
+          encodeFrame(
+            controlFrame(
+              "endpoint.welcome.v1",
+              JSON.stringify({
+                ...WELCOME,
+                methods: [],
+                capabilities: [],
+                error: {
+                  code: "unsupported_generation",
+                  message: "endpoint generation 2 is unsupported",
+                },
+              }),
+            ),
+          ),
+        );
+      });
+    });
+    servers.push(server);
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(socketPath, resolve);
+    });
+    const client = new EndpointClient(socketPath);
+    await expect(client.connect(100, 30)).rejects.toThrow(
+      "unsupported_generation",
+    );
+  });
+});

--- a/server/src/bridge/endpoint-client.test.ts
+++ b/server/src/bridge/endpoint-client.test.ts
@@ -7,8 +7,11 @@ import { EndpointClient, type EndpointSurface } from "./endpoint-client";
 import type { CellData, FrameData } from "./thin-client";
 
 const servers: net.Server[] = [];
+const sockets = new Set<net.Socket>();
 
 afterEach(async () => {
+  for (const socket of sockets) socket.destroy();
+  sockets.clear();
   await Promise.all(
     servers
       .splice(0)
@@ -152,12 +155,15 @@ function controlFrame(kind: string, data: string): Buffer {
 async function startEndpointServer(
   onHello: (hello: any, socket: net.Socket) => void,
   onMessage?: (variant: number, reader: BinReader, socket: net.Socket) => void,
+  sendSnapshot = true,
 ) {
   const socketPath = path.join(
     tmpdir(),
     `herdr-gui-endpoint-${process.pid}-${crypto.randomUUID()}.sock`,
   );
   const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
     let input = Buffer.alloc(0);
     let greeted = false;
     socket.on("data", (chunk) => {
@@ -182,6 +188,16 @@ async function startEndpointServer(
               controlFrame("endpoint.welcome.v1", JSON.stringify(WELCOME)),
             ),
           );
+          if (sendSnapshot) {
+            socket.write(
+              encodeFrame(
+                controlFrame(
+                  "shell.snapshot.v1",
+                  JSON.stringify({ boot_id: "boot-1", revision: 1 }),
+                ),
+              ),
+            );
+          }
           onHello(hello, socket);
           continue;
         }
@@ -210,6 +226,96 @@ describe("EndpointClient (endpoint generation 1)", () => {
     expect(w.capabilities).toEqual(["surface_interest", "health_check"]);
     client.close();
   });
+
+  test("waits for a valid snapshot after welcome before becoming ready", async () => {
+    let peer!: net.Socket;
+    const socketPath = await startEndpointServer(
+      (_hello, socket) => {
+        peer = socket;
+      },
+      undefined,
+      false,
+    );
+    const client = new EndpointClient(socketPath);
+    const welcome = new Promise<void>((resolve) =>
+      client.once("welcome", resolve),
+    );
+    let ready = false;
+    const connecting = client.connect(80, 24).then(() => {
+      ready = true;
+    });
+    try {
+      await welcome;
+      expect(ready).toBe(false);
+      const invalidSnapshot = new Promise<void>((resolve) =>
+        client.once("snapshot", resolve),
+      );
+      peer.write(
+        encodeFrame(controlFrame("shell.snapshot.v1", '{"boot_id":42}')),
+      );
+      await invalidSnapshot;
+      expect(ready).toBe(false);
+      peer.write(
+        encodeFrame(controlFrame("shell.snapshot.v1", '{"boot_id":"boot-1"}')),
+      );
+      await connecting;
+      expect(ready).toBe(true);
+    } finally {
+      client.close();
+    }
+  });
+
+  test("rejects startup when the peer closes before the snapshot", async () => {
+    const socketPath = await startEndpointServer(
+      (_hello, socket) => socket.end(),
+      undefined,
+      false,
+    );
+    const client = new EndpointClient(socketPath);
+    try {
+      await expect(client.connect(80, 24)).rejects.toThrow("closed");
+    } finally {
+      client.close();
+    }
+  });
+
+  test("times out if welcome is not followed by a snapshot", async () => {
+    const socketPath = await startEndpointServer(() => {}, undefined, false);
+    const client = new EndpointClient(socketPath);
+    try {
+      await expect(client.connect(80, 24)).rejects.toThrow(
+        "welcome and snapshot",
+      );
+      expect(client.isClosed).toBe(true);
+    } finally {
+      client.close();
+    }
+  }, 12_000);
+
+  test.each(["peer", "client"])(
+    "rejects pending and new requests when the %s closes",
+    async (closer) => {
+      const socketPath = await startEndpointServer(
+        () => {},
+        (variant, _reader, socket) => {
+          if (variant === 15 && closer === "peer") socket.end();
+        },
+      );
+      const client = new EndpointClient(socketPath);
+      try {
+        await client.connect(80, 24);
+        const pending = client.callEndpoint("pane.focus", { pane_id: "w1:p1" });
+        if (closer === "client") client.close();
+        await expect(pending).rejects.toThrow("closed");
+        expect(client.isClosed).toBe(true);
+        await expect(client.callEndpoint("pane.scroll", {})).rejects.toThrow(
+          "closed",
+        );
+      } finally {
+        client.close();
+      }
+    },
+  );
 
   test("composes full surfaces and applies patches on the matching base", async () => {
     const base: FrameData = {

--- a/server/src/bridge/endpoint-client.ts
+++ b/server/src/bridge/endpoint-client.ts
@@ -80,8 +80,8 @@ export interface EndpointSurface {
  * bincode-envelope `EndpointControl` with JSON payloads, plus the frozen
  * PaneSurface/PaneSurfacePatch codecs.
  *
- * After `connect` resolves (welcome received), the server pushes one
- * shell.snapshot.v1 and a stream of surfaces. Full surfaces replace the
+ * `connect` waits for both the welcome and the first valid shell.snapshot.v1
+ * so endpoint methods can use its boot ID. Full surfaces replace the
  * composed frame; patches are applied to it. Consumers only ever see a
  * complete `FrameData` per `surface` event.
  *
@@ -92,6 +92,7 @@ export class EndpointClient extends EventEmitter {
   private sock: net.Socket | null = null;
   private buf = Buffer.alloc(0);
   private closed = false;
+  private welcomed = false;
   private pendingWelcome:
     | {
         resolve: () => void;
@@ -132,7 +133,9 @@ export class EndpointClient extends EventEmitter {
       this.sock = sock;
       const timer = setTimeout(() => {
         this.rejectWelcome(
-          new Error("timed out waiting for Herdr endpoint welcome"),
+          new Error(
+            "timed out waiting for Herdr endpoint welcome and snapshot",
+          ),
         );
         this.close();
       }, HANDSHAKE_TIMEOUT_MS);
@@ -146,10 +149,7 @@ export class EndpointClient extends EventEmitter {
         this.emit("error", e);
       });
       sock.on("close", () => {
-        this.closed = true;
-        this.rejectWelcome(
-          new Error("endpoint connection closed during handshake"),
-        );
+        this.close();
         this.emit("close");
       });
     });
@@ -209,6 +209,9 @@ export class EndpointClient extends EventEmitter {
     method: string,
     params: Record<string, unknown>,
   ): Promise<unknown> {
+    if (this.closed) {
+      return Promise.reject(new Error("endpoint client closed"));
+    }
     if (!this.bootId) {
       return Promise.reject(new Error("endpoint snapshot has not arrived yet"));
     }
@@ -217,9 +220,9 @@ export class EndpointClient extends EventEmitter {
     w.variant(CM.ClientShellEndpointRequest);
     w.string(this.bootId);
     w.string(JSON.stringify({ id: requestId, method, params }));
-    this.write(w.toBuffer());
     return new Promise((resolve, reject) => {
       this.pendingRequests.set(requestId, { resolve, reject, chunks: [] });
+      this.write(w.toBuffer());
     });
   }
 
@@ -238,6 +241,7 @@ export class EndpointClient extends EventEmitter {
   }
 
   private resolveWelcome() {
+    if (!this.welcomed || !this.bootId) return;
     const pending = this.pendingWelcome;
     if (!pending) return;
     this.pendingWelcome = undefined;
@@ -358,6 +362,7 @@ export class EndpointClient extends EventEmitter {
         methods: parsed.methods ?? [],
         capabilities: parsed.capabilities ?? [],
       };
+      this.welcomed = true;
       this.emit("welcome", welcome);
       this.resolveWelcome();
       return;
@@ -366,12 +371,13 @@ export class EndpointClient extends EventEmitter {
       try {
         const raw = JSON.parse(data);
         const snapshot: EndpointSnapshot = {
-          bootId: raw.boot_id ?? "",
+          bootId: typeof raw.boot_id === "string" ? raw.boot_id : "",
           revision: raw.revision ?? 0,
           raw,
         };
         this.bootId = snapshot.bootId;
         this.emit("snapshot", snapshot);
+        this.resolveWelcome();
       } catch (e) {
         this.emit("error", e instanceof Error ? e : new Error(String(e)));
       }

--- a/server/src/bridge/endpoint-client.ts
+++ b/server/src/bridge/endpoint-client.ts
@@ -1,0 +1,481 @@
+import { EventEmitter } from "node:events";
+import * as net from "node:net";
+import { BinReader, BinWriter, encodeFrame } from "./bincode";
+import {
+  type CellData,
+  type CursorState,
+  type FrameData,
+  readCellData,
+  readFrameData,
+} from "./thin-client";
+
+import { type PaneInputEvent, encodePaneInput } from "./vt-input-classifier";
+
+const HANDSHAKE_TIMEOUT_MS = 8_000;
+
+// ClientMessage tags used by the stable endpoint contract. The variant order is
+// frozen for endpoint generation 1; compatible behavior arrives through
+// EndpointControl, not new variants.
+const CM = {
+  ClientShellResize: 12,
+  ClientShellPaneInput: 13,
+  ClientShellEndpointRequest: 15,
+  EndpointControl: 20,
+} as const;
+
+// ServerMessage tags (frozen for endpoint generation 1).
+const SM = {
+  Welcome: 0,
+  ClientShellSnapshot: 12,
+  PaneSurface: 13,
+  ClientShellError: 15,
+  ClientShellEndpointResponseChunk: 18,
+  PaneSurfacePatch: 19,
+  EndpointControl: 20,
+} as const;
+
+const ENDPOINT_GENERATION = 1;
+const HELLO_KIND = "endpoint.hello.v1";
+const WELCOME_KIND = "endpoint.welcome.v1";
+const SNAPSHOT_KIND = "shell.snapshot.v1";
+const HEALTH_PING_KIND = "endpoint.health.ping.v1";
+const HEALTH_PONG_KIND = "endpoint.health.pong.v1";
+
+export interface EndpointWelcome {
+  generation: number;
+  serverVersion: string;
+  methods: string[];
+  capabilities: string[];
+}
+
+export interface EndpointSnapshot {
+  bootId: string;
+  revision: number;
+  /** Parsed shell.snapshot.v1 JSON; additive fields are ignored. */
+  raw: Record<string, unknown>;
+}
+
+export interface PaneSurfacePaneMeta {
+  paneId: string;
+  rect: { x: number; y: number; width: number; height: number };
+  /** Content area inside decorations; crop targets this rect. */
+  innerRect: { x: number; y: number; width: number; height: number };
+  scroll: {
+    offsetFromBottom: number;
+    maxOffsetFromBottom: number;
+    viewportRows: number;
+  } | null;
+  focused: boolean;
+}
+
+export interface EndpointSurface {
+  frame: FrameData;
+  surfaceRevision: number;
+  panes: PaneSurfacePaneMeta[];
+}
+
+/**
+ * Client-owned shell connection to a Herdr >= 0.9.0 server over
+ * herdr-client.sock, speaking the stable endpoint generation 1 contract:
+ * bincode-envelope `EndpointControl` with JSON payloads, plus the frozen
+ * PaneSurface/PaneSurfacePatch codecs.
+ *
+ * After `connect` resolves (welcome received), the server pushes one
+ * shell.snapshot.v1 and a stream of surfaces. Full surfaces replace the
+ * composed frame; patches are applied to it. Consumers only ever see a
+ * complete `FrameData` per `surface` event.
+ *
+ * Input is intentionally not implemented here yet; see the bridge for the
+ * semantic-input classifier.
+ */
+export class EndpointClient extends EventEmitter {
+  private sock: net.Socket | null = null;
+  private buf = Buffer.alloc(0);
+  private closed = false;
+  private pendingWelcome:
+    | {
+        resolve: () => void;
+        reject: (error: Error) => void;
+        timer: ReturnType<typeof setTimeout>;
+      }
+    | undefined;
+  private surface: EndpointSurface | null = null;
+  private bootId = "";
+  private requestSeq = 0;
+  private pendingRequests = new Map<
+    string,
+    {
+      resolve: (result: unknown) => void;
+      reject: (error: Error) => void;
+      chunks: string[];
+    }
+  >();
+
+  constructor(private socketPath: string) {
+    super();
+  }
+
+  get isClosed() {
+    return this.closed;
+  }
+
+  /** Latest composed surface, for consumers that join mid-stream. */
+  get currentSurface(): EndpointSurface | null {
+    return this.surface;
+  }
+
+  async connect(cols: number, rows: number): Promise<void> {
+    if (this.sock) throw new Error("endpoint client is already connected");
+    if (this.closed) throw new Error("endpoint client is closed");
+    await new Promise<void>((resolve, reject) => {
+      const sock = net.createConnection({ path: this.socketPath });
+      this.sock = sock;
+      const timer = setTimeout(() => {
+        this.rejectWelcome(
+          new Error("timed out waiting for Herdr endpoint welcome"),
+        );
+        this.close();
+      }, HANDSHAKE_TIMEOUT_MS);
+      this.pendingWelcome = { resolve, reject, timer };
+      sock.once("connect", () => this.sendHello(cols, rows));
+      sock.on("data", (c) =>
+        this.onData(Buffer.isBuffer(c) ? c : Buffer.from(c)),
+      );
+      sock.on("error", (e) => {
+        this.rejectWelcome(e);
+        this.emit("error", e);
+      });
+      sock.on("close", () => {
+        this.closed = true;
+        this.rejectWelcome(
+          new Error("endpoint connection closed during handshake"),
+        );
+        this.emit("close");
+      });
+    });
+  }
+
+  private sendHello(cols: number, rows: number) {
+    const hello = {
+      generation: ENDPOINT_GENERATION,
+      cell_width_px: 0,
+      cell_height_px: 0,
+      surface_size: { cols, rows },
+      pixel_mouse: false,
+      direct_graphics: false,
+      endpoint_keybindings: false,
+      mouse_capture: false,
+      surface_active: true,
+      snapshot_codecs: ["shell.snapshot.v1"],
+      surface_codecs: ["shell.surface.v1"],
+      input_codecs: ["shell.input.semantic.v1"],
+      blob_codecs: ["shell.blob.v1"],
+    };
+    this.sendControl(HELLO_KIND, JSON.stringify(hello));
+  }
+
+  private sendControl(kind: string, data: string) {
+    const w = new BinWriter();
+    w.variant(CM.EndpointControl);
+    w.string(kind);
+    w.string(data);
+    this.write(w.toBuffer());
+  }
+
+  resize(cols: number, rows: number) {
+    const w = new BinWriter();
+    w.variant(CM.ClientShellResize);
+    w.varint(0); // cell_width_px
+    w.varint(0); // cell_height_px
+    w.varint(cols);
+    w.varint(rows);
+    w.bool(false); // pixel_mouse
+    this.write(w.toBuffer());
+  }
+
+  /** Probe the server; any inbound message (pong or otherwise) is liveness. */
+  ping() {
+    this.sendControl(HEALTH_PING_KIND, "{}");
+  }
+
+  /** Deliver classified semantic input to one pane. */
+  sendPaneInput(paneId: string, events: PaneInputEvent[]) {
+    if (events.length === 0) return;
+    this.write(encodePaneInput(paneId, events));
+  }
+
+  /** Invoke an advertised endpoint method (e.g. pane.focus, pane.scroll). */
+  callEndpoint(
+    method: string,
+    params: Record<string, unknown>,
+  ): Promise<unknown> {
+    if (!this.bootId) {
+      return Promise.reject(new Error("endpoint snapshot has not arrived yet"));
+    }
+    const requestId = `gui_${++this.requestSeq}`;
+    const w = new BinWriter();
+    w.variant(CM.ClientShellEndpointRequest);
+    w.string(this.bootId);
+    w.string(JSON.stringify({ id: requestId, method, params }));
+    this.write(w.toBuffer());
+    return new Promise((resolve, reject) => {
+      this.pendingRequests.set(requestId, { resolve, reject, chunks: [] });
+    });
+  }
+
+  close() {
+    this.closed = true;
+    this.rejectWelcome(new Error("endpoint client closed during handshake"));
+    for (const pending of this.pendingRequests.values()) {
+      pending.reject(new Error("endpoint client closed"));
+    }
+    this.pendingRequests.clear();
+    this.sock?.destroy();
+  }
+
+  private write(msg: Buffer) {
+    if (this.sock && !this.closed) this.sock.write(encodeFrame(msg));
+  }
+
+  private resolveWelcome() {
+    const pending = this.pendingWelcome;
+    if (!pending) return;
+    this.pendingWelcome = undefined;
+    clearTimeout(pending.timer);
+    pending.resolve();
+  }
+
+  private rejectWelcome(error: Error) {
+    const pending = this.pendingWelcome;
+    if (!pending) return;
+    this.pendingWelcome = undefined;
+    clearTimeout(pending.timer);
+    pending.reject(error);
+  }
+
+  private onData(chunk: Buffer) {
+    this.buf = Buffer.concat([this.buf, chunk]);
+    while (this.buf.length >= 4) {
+      const len = this.buf.readUInt32LE(0);
+      if (len > 32 * 1024 * 1024) {
+        const error = new Error(`oversized frame: ${len}`);
+        this.buf = Buffer.alloc(0);
+        this.rejectWelcome(error);
+        this.close();
+        this.emit("error", error);
+        return;
+      }
+      if (this.buf.length < 4 + len) return;
+      const payload = this.buf.subarray(4, 4 + len);
+      this.buf = this.buf.subarray(4 + len);
+      this.handlePayload(payload);
+      if (this.closed) return;
+    }
+  }
+
+  private handlePayload(payload: Buffer) {
+    try {
+      const r = new BinReader(payload);
+      const variant = r.variant();
+      if (variant === SM.EndpointControl) {
+        this.handleControl(r.string(), r.string());
+      } else if (variant === SM.PaneSurface) {
+        this.handleSurface(r);
+      } else if (variant === SM.PaneSurfacePatch) {
+        this.handlePatch(r);
+      } else if (variant === SM.ClientShellSnapshot) {
+        // The server delivers snapshots as EndpointControl JSON; this variant
+        // exists in the frozen enum but is not currently sent.
+      } else if (variant === SM.ClientShellError) {
+        this.emit("shell_error", r.string());
+      } else if (variant === SM.ClientShellEndpointResponseChunk) {
+        r.string(); // boot_id
+        const requestId = r.string();
+        const finalChunk = r.bool();
+        const data = r.bytes().toString("utf8");
+        const pending = this.pendingRequests.get(requestId);
+        if (pending) {
+          pending.chunks.push(data);
+          if (finalChunk) {
+            this.pendingRequests.delete(requestId);
+            try {
+              const parsed = JSON.parse(pending.chunks.join(""));
+              if (parsed.error) {
+                pending.reject(
+                  new Error(parsed.error.message ?? "endpoint request failed"),
+                );
+              } else {
+                pending.resolve(parsed.result);
+              }
+            } catch (e) {
+              pending.reject(e instanceof Error ? e : new Error(String(e)));
+            }
+          }
+        }
+      } else if (variant === SM.Welcome) {
+        // Legacy same-install welcome: means the server predates endpoint
+        // generation 1 and could not parse our hello as EndpointControl.
+        const error = new Error(
+          "Herdr server does not speak endpoint generation 1 (needs >= 0.9.0)",
+        );
+        this.rejectWelcome(error);
+        this.close();
+        this.emit("error", error);
+      }
+      // Terminal/Notify/Clipboard/graphics variants are not used by shells.
+    } catch (e) {
+      const error = e instanceof Error ? e : new Error(String(e));
+      this.rejectWelcome(error);
+      this.close();
+      this.emit("error", error);
+    }
+  }
+
+  private handleControl(kind: string, data: string) {
+    if (kind === WELCOME_KIND) {
+      let parsed: any;
+      try {
+        parsed = JSON.parse(data);
+      } catch {
+        const error = new Error("malformed endpoint welcome");
+        this.rejectWelcome(error);
+        this.close();
+        this.emit("error", error);
+        return;
+      }
+      if (parsed.error) {
+        const error = new Error(
+          `Herdr rejected endpoint hello (${parsed.error.code}): ${parsed.error.message}`,
+        );
+        this.rejectWelcome(error);
+        this.close();
+        this.emit("error", error);
+        return;
+      }
+      const welcome: EndpointWelcome = {
+        generation: parsed.generation,
+        serverVersion: parsed.server_version,
+        methods: parsed.methods ?? [],
+        capabilities: parsed.capabilities ?? [],
+      };
+      this.emit("welcome", welcome);
+      this.resolveWelcome();
+      return;
+    }
+    if (kind === SNAPSHOT_KIND) {
+      try {
+        const raw = JSON.parse(data);
+        const snapshot: EndpointSnapshot = {
+          bootId: raw.boot_id ?? "",
+          revision: raw.revision ?? 0,
+          raw,
+        };
+        this.bootId = snapshot.bootId;
+        this.emit("snapshot", snapshot);
+      } catch (e) {
+        this.emit("error", e instanceof Error ? e : new Error(String(e)));
+      }
+      return;
+    }
+    if (kind === HEALTH_PING_KIND) {
+      this.sendControl(HEALTH_PONG_KIND, data);
+      return;
+    }
+    // Unknown named controls are optional and ignored per the contract.
+  }
+
+  private handleSurface(r: BinReader) {
+    r.string(); // boot_id
+    r.varint(); // projection_revision
+    const surfaceRevision = r.varint(); // surface_revision (u64, varint)
+    const frame = readFrameData(r);
+    const panes = readPaneSurfacePanes(r);
+    // splits / popup / graphics tail: unused by the GUI, left unread.
+    this.surface = { frame, surfaceRevision, panes };
+    this.emit("surface", this.surface);
+  }
+
+  private handlePatch(r: BinReader) {
+    r.string(); // boot_id
+    r.varint(); // projection_revision
+    const baseSurfaceRevision = r.varint();
+    const surfaceRevision = r.varint();
+    const rowCount = r.varint();
+    const rows: Array<{ x: number; y: number; cells: CellData[] }> = [];
+    for (let i = 0; i < rowCount; i++) {
+      const x = r.varint();
+      const y = r.varint();
+      const cellCount = r.varint();
+      const cells: CellData[] = new Array(cellCount);
+      for (let j = 0; j < cellCount; j++) cells[j] = readCellData(r);
+      rows.push({ x, y, cells });
+    }
+    const panes = readPaneSurfacePanes(r);
+    const cursor = r.option(
+      (): CursorState => ({
+        x: r.varint(),
+        y: r.varint(),
+        visible: r.bool(),
+        shape: r.u8(),
+      }),
+    );
+
+    const current = this.surface;
+    if (!current || current.surfaceRevision !== baseSurfaceRevision) {
+      // Base mismatch: skip the patch and wait for the next full surface.
+      // ponytail: no resend request; the server repaints on focus/resize.
+      return;
+    }
+    const { frame } = current;
+    // Copy before patching: consumers may retain earlier emitted frames.
+    const cells = frame.cells.slice();
+    const nextFrame: FrameData = { ...frame, cells };
+    for (const { x, y, cells: rowCells } of rows) {
+      if (y >= frame.height) continue;
+      const offset = y * frame.width + x;
+      for (let j = 0; j < rowCells.length && x + j < frame.width; j++) {
+        cells[offset + j] = rowCells[j];
+      }
+    }
+    if (cursor) nextFrame.cursor = cursor;
+    this.surface = { frame: nextFrame, surfaceRevision, panes };
+    this.emit("surface", this.surface);
+  }
+}
+
+function readRect(r: BinReader) {
+  return {
+    x: r.varint(),
+    y: r.varint(),
+    width: r.varint(),
+    height: r.varint(),
+  };
+}
+
+function readPaneSurfacePanes(r: BinReader): PaneSurfacePaneMeta[] {
+  const count = r.varint();
+  const panes: PaneSurfacePaneMeta[] = new Array(count);
+  for (let i = 0; i < count; i++) {
+    const paneId = r.string();
+    r.varint(); // content_revision
+    const rect = readRect(r);
+    const innerRect = readRect(r);
+    if (r.bool()) readRect(r); // scrollbar_rect
+    let scroll: PaneSurfacePaneMeta["scroll"] = null;
+    if (r.bool()) {
+      scroll = {
+        offsetFromBottom: r.varint(),
+        maxOffsetFromBottom: r.varint(),
+        viewportRows: r.varint(),
+      };
+    }
+    const focused = r.bool();
+    r.bool(); // mouse_reporting
+    r.bool(); // sgr_pixel_mouse
+    r.bool(); // alternate_screen_active
+    r.varint(); // pixel_width
+    r.varint(); // pixel_height
+    panes[i] = { paneId, rect, innerRect, scroll, focused };
+  }
+  return panes;
+}

--- a/server/src/bridge/endpoint-terminal-session.test.ts
+++ b/server/src/bridge/endpoint-terminal-session.test.ts
@@ -1,0 +1,320 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as net from "node:net";
+import * as path from "node:path";
+import { tmpdir } from "node:os";
+import { BinReader, BinWriter, encodeFrame } from "./bincode";
+import {
+  EndpointTerminalSession,
+  cropFrame,
+} from "./endpoint-terminal-session";
+import type { CellData, FrameData } from "./thin-client";
+
+const servers: net.Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map(
+        (server) =>
+          new Promise<void>((resolve) => server.close(() => resolve())),
+      ),
+  );
+});
+
+function cell(symbol: string, over: Partial<CellData> = {}): CellData {
+  return {
+    symbol,
+    fg: 0,
+    bg: 0,
+    modifier: 0,
+    skip: false,
+    hyperlink: null,
+    ...over,
+  };
+}
+
+function writeCell(w: BinWriter, c: CellData) {
+  w.string(c.symbol);
+  w.varint(c.fg);
+  w.varint(c.bg);
+  w.varint(c.modifier);
+  w.bool(c.skip);
+  w.option(c.hyperlink, (v) => w.varint(v));
+}
+
+function writeFrame(w: BinWriter, frame: FrameData) {
+  w.varint(frame.cells.length);
+  for (const c of frame.cells) writeCell(w, c);
+  w.varint(frame.width);
+  w.varint(frame.height);
+  w.option(frame.cursor, (cur) => {
+    w.varint(cur.x);
+    w.varint(cur.y);
+    w.bool(cur.visible);
+    w.u8(cur.shape);
+  });
+  w.varint(frame.hyperlinks.length);
+  for (const link of frame.hyperlinks) w.string(link);
+  w.bytes(Buffer.alloc(0));
+}
+
+function writePane(w: BinWriter, paneId: string, x = 0, y = 0) {
+  w.string(paneId);
+  w.varint(1);
+  for (const rect of [
+    { x, y, width: 10, height: 5 },
+    { x: x + 1, y: y + 1, width: 8, height: 3 },
+  ]) {
+    w.varint(rect.x);
+    w.varint(rect.y);
+    w.varint(rect.width);
+    w.varint(rect.height);
+  }
+  w.bool(false);
+  w.bool(true); // scroll metrics present
+  w.varint(0); // offset_from_bottom
+  w.varint(100); // max_offset_from_bottom
+  w.varint(3); // viewport_rows
+  w.bool(true); // focused
+  w.bool(false);
+  w.bool(false);
+  w.bool(false);
+  w.varint(0);
+  w.varint(0);
+}
+
+function surfaceFrame(revision: number, frame: FrameData): Buffer {
+  const w = new BinWriter();
+  w.variant(13);
+  w.string("boot-1");
+  w.varint(1);
+  w.varint(revision);
+  writeFrame(w, frame);
+  w.varint(1);
+  writePane(w, "w1:p1");
+  w.varint(0);
+  w.bool(false);
+  return w.toBuffer();
+}
+
+function controlFrame(kind: string, data: string): Buffer {
+  const w = new BinWriter();
+  w.variant(20);
+  w.string(kind);
+  w.string(data);
+  return w.toBuffer();
+}
+
+const WELCOME = {
+  generation: 1,
+  server_version: "0.9.0",
+  snapshot_codec: "shell.snapshot.v1",
+  surface_codec: "shell.surface.v1",
+  input_codec: "shell.input.semantic.v1",
+  blob_codec: "shell.blob.v1",
+  methods: ["pane.focus", "pane.scroll"],
+  capabilities: ["health_check"],
+};
+
+/**
+ * Fake endpoint server that answers the handshake, sends a snapshot, answers
+ * endpoint requests, and streams a two-pane surface.
+ */
+async function startSessionServer(handlers: {
+  onRequest?: (method: string, params: any) => void;
+  onPaneInput?: (paneId: string, reader: BinReader) => void;
+}) {
+  const socketPath = path.join(
+    tmpdir(),
+    `herdr-gui-eps-${process.pid}-${crypto.randomUUID()}.sock`,
+  );
+  const frame: FrameData = {
+    // Tab surface 10x5; pane w1:p1 inner rect is 1,1 8x3 => "abcdefgh" rows.
+    cells: Array.from({ length: 50 }, (_, i) =>
+      cell(String.fromCharCode(65 + (i % 26))),
+    ),
+    width: 10,
+    height: 5,
+    cursor: { x: 2, y: 2, visible: true, shape: 1 },
+    hyperlinks: [],
+  };
+  const server = net.createServer((socket) => {
+    let input = Buffer.alloc(0);
+    let greeted = false;
+    socket.on("data", (chunk) => {
+      input = Buffer.concat([
+        input,
+        Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk),
+      ]);
+      while (input.length >= 4) {
+        const length = input.readUInt32LE(0);
+        if (input.length < length + 4) return;
+        const reader = new BinReader(input.subarray(4, length + 4));
+        input = input.subarray(length + 4);
+        const variant = reader.variant();
+        if (!greeted) {
+          greeted = true;
+          reader.string(); // kind
+          reader.string(); // data
+          socket.write(
+            encodeFrame(
+              controlFrame("endpoint.welcome.v1", JSON.stringify(WELCOME)),
+            ),
+          );
+          socket.write(
+            encodeFrame(
+              controlFrame(
+                "shell.snapshot.v1",
+                JSON.stringify({ boot_id: "boot-1", revision: 1 }),
+              ),
+            ),
+          );
+          socket.write(encodeFrame(surfaceFrame(1, frame)));
+          continue;
+        }
+        if (variant === 15) {
+          // ClientShellEndpointRequest
+          reader.string(); // boot_id
+          const request = JSON.parse(reader.string());
+          handlers.onRequest?.(request.method, request.params);
+          const w = new BinWriter();
+          w.variant(18); // ClientShellEndpointResponseChunk
+          w.string("boot-1");
+          w.string(request.id);
+          w.bool(true);
+          w.bytes(Buffer.from(JSON.stringify({ id: request.id, result: {} })));
+          socket.write(encodeFrame(w.toBuffer()));
+        } else if (variant === 13) {
+          const paneId = reader.string();
+          handlers.onPaneInput?.(paneId, reader);
+        }
+      }
+    });
+  });
+  servers.push(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, resolve);
+  });
+  return socketPath;
+}
+
+describe("EndpointTerminalSession", () => {
+  test("focuses the pane and emits cropped ANSI terminal frames", async () => {
+    const requests: Array<{ method: string; params: any }> = [];
+    const socketPath = await startSessionServer({
+      onRequest: (method, params) => requests.push({ method, params }),
+    });
+    const session = new EndpointTerminalSession(
+      socketPath,
+      "term_1",
+      async (terminalId) => (terminalId === "term_1" ? "w1:p1" : null),
+    );
+    const frames: Array<{
+      width: number;
+      height: number;
+      full: boolean;
+      text: string;
+    }> = [];
+    session.on("terminal", (t) =>
+      frames.push({
+        width: t.width,
+        height: t.height,
+        full: t.full,
+        text: t.bytes.toString("utf8"),
+      }),
+    );
+    await session.connect(80, 24);
+
+    expect(requests).toEqual([
+      { method: "pane.focus", params: { pane_id: "w1:p1" } },
+    ]);
+    expect(frames.length).toBeGreaterThan(0);
+    const first = frames[0];
+    expect(first.width).toBe(8);
+    expect(first.height).toBe(3);
+    expect(first.full).toBe(true);
+    // Cropped content: inner rect starts at (1,1) of the 10x5 grid,
+    // so the first row is cells 11-18 (L..S).
+    expect(first.text).toContain("LMNOPQRS");
+    // Cursor was at (2,2) in tab space -> (1,1) in crop space.
+    expect(first.text).toContain("\x1b[2;2H");
+    session.close();
+  });
+
+  test("rejects connect when the terminal has no pane", async () => {
+    const socketPath = await startSessionServer({});
+    const session = new EndpointTerminalSession(
+      socketPath,
+      "term_x",
+      async () => null,
+    );
+    await expect(session.connect(80, 24)).rejects.toThrow("no pane found");
+  });
+
+  test("classifies input and sends pane.scroll with absolute offsets", async () => {
+    const requests: Array<{ method: string; params: any }> = [];
+    const inputs: string[] = [];
+    const socketPath = await startSessionServer({
+      onRequest: (method, params) => requests.push({ method, params }),
+      onPaneInput: (paneId, reader) => {
+        const count = reader.varint();
+        for (let i = 0; i < count; i++) {
+          const v = reader.variant();
+          if (v === 1) inputs.push(`text:${reader.string()}`);
+          else if (v === 3) inputs.push(`paste:${reader.string()}`);
+          else inputs.push(`key:${v}`);
+        }
+      },
+    });
+    const session = new EndpointTerminalSession(
+      socketPath,
+      "term_1",
+      async () => "w1:p1",
+    );
+    await session.connect(80, 24);
+    session.input(Buffer.from("hi"));
+    session.scroll("up", 3);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(inputs).toContain("text:hi");
+    expect(requests).toContainEqual({
+      method: "pane.scroll",
+      params: { pane_id: "w1:p1", offset_from_bottom: 3 },
+    });
+    session.close();
+  });
+});
+
+describe("cropFrame", () => {
+  test("crops cells and repositions the cursor", () => {
+    const frame: FrameData = {
+      cells: Array.from({ length: 12 }, (_, i) => cell(String(i))),
+      width: 4,
+      height: 3,
+      cursor: { x: 2, y: 1, visible: true, shape: 0 },
+      hyperlinks: ["https://example.com"],
+    };
+    const cropped = cropFrame(frame, { x: 1, y: 1, width: 2, height: 2 });
+    expect(cropped.width).toBe(2);
+    expect(cropped.height).toBe(2);
+    expect(cropped.cells.map((c) => c.symbol)).toEqual(["5", "6", "9", "10"]);
+    expect(cropped.cursor).toEqual({ x: 1, y: 0, visible: true, shape: 0 });
+    expect(cropped.hyperlinks).toEqual(["https://example.com"]);
+  });
+
+  test("drops an out-of-crop cursor and clamps the rect", () => {
+    const frame: FrameData = {
+      cells: Array.from({ length: 4 }, () => cell("x")),
+      width: 2,
+      height: 2,
+      cursor: { x: 0, y: 0, visible: true, shape: 0 },
+      hyperlinks: [],
+    };
+    const cropped = cropFrame(frame, { x: 1, y: 1, width: 99, height: 99 });
+    expect(cropped.width).toBe(1);
+    expect(cropped.height).toBe(1);
+    expect(cropped.cursor).toBeNull();
+  });
+});

--- a/server/src/bridge/endpoint-terminal-session.ts
+++ b/server/src/bridge/endpoint-terminal-session.ts
@@ -1,0 +1,227 @@
+import { EventEmitter } from "node:events";
+import { EndpointClient, type EndpointSurface } from "./endpoint-client";
+import { frameToAnsi } from "./frame-to-ansi";
+import type { FrameData } from "./thin-client";
+import type { Logger } from "../utils/logger";
+import { silentLogger } from "../utils/logger";
+import { VtInputClassifier } from "./vt-input-classifier";
+
+const ESC_FLUSH_MS = 25;
+const FIRST_SURFACE_WAIT_MS = 10_000;
+
+/**
+ * Terminal stream over the stable endpoint protocol (Herdr >= 0.9.0).
+ *
+ * The endpoint shell renders the focused tab, so this session focuses the
+ * pane (which focuses its tab for this shell connection only) and crops the
+ * tab surface down to the pane's content rect before re-encoding to ANSI.
+ *
+ * Members intentionally mirror the ThinClient surface the terminal bridge
+ * uses (isClosed/connecting/resize/input/scroll/close/events) so the bridge
+ * can hold either backend in one field.
+ */
+export class EndpointTerminalSession extends EventEmitter {
+  private client: EndpointClient;
+  private classifier = new VtInputClassifier();
+  private escFlushTimer: ReturnType<typeof setTimeout> | null = null;
+  private paneId: string | null = null;
+  private lastScroll: {
+    offsetFromBottom: number;
+    maxOffsetFromBottom: number;
+  } | null = null;
+  private closed = false;
+  private seq = 0;
+  connecting: Promise<void> | null = null;
+
+  constructor(
+    socketPath: string,
+    private terminalId: string,
+    private lookupPaneId: (terminalId: string) => Promise<string | null>,
+    private logger: Logger = silentLogger,
+  ) {
+    super();
+    this.client = new EndpointClient(socketPath);
+    this.client.on("surface", (s) => this.onSurface(s));
+    this.client.on("error", (e) => this.emit("error", e));
+    this.client.on("close", () => {
+      this.closed = true;
+      this.emit("close");
+    });
+    this.client.on("welcome", (w) =>
+      this.emit("welcome", {
+        version: w.serverVersion,
+        encoding: 1,
+        error: null,
+      }),
+    );
+  }
+
+  get isClosed() {
+    return this.closed;
+  }
+
+  connect(cols: number, rows: number): Promise<void> {
+    const ready = (async () => {
+      await this.client.connect(cols, rows);
+      const paneId = await this.lookupPaneId(this.terminalId);
+      if (!paneId) {
+        throw new Error(
+          `no pane found for terminal ${this.terminalId} (endpoint path)`,
+        );
+      }
+      this.paneId = paneId;
+      // Focus scopes this shell's surface to the pane's tab; per-client
+      // focus in Herdr 0.9.0 keeps this from moving other clients.
+      await this.client.callEndpoint("pane.focus", { pane_id: paneId });
+      // A surface may have arrived before the lookup resolved; process it
+      // now if it already contains the pane.
+      const current = this.client.currentSurface;
+      if (current && this.hasPane(current, paneId)) {
+        this.onSurface(current);
+      }
+      await this.waitForSurface(paneId);
+    })();
+    this.connecting = ready
+      .catch((e) => {
+        this.close();
+        throw e;
+      })
+      .finally(() => {
+        this.connecting = null;
+      });
+    return this.connecting;
+  }
+
+  private waitForSurface(paneId: string): Promise<void> {
+    if (this.hasPane(this.latestSurface(), paneId)) return Promise.resolve();
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        cleanup();
+        reject(
+          new Error(`timed out waiting for endpoint surface of ${paneId}`),
+        );
+      }, FIRST_SURFACE_WAIT_MS);
+      const onSurface = (s: EndpointSurface) => {
+        if (this.hasPane(s, paneId)) {
+          cleanup();
+          resolve();
+        }
+      };
+      const onClose = () => {
+        cleanup();
+        reject(new Error("endpoint connection closed before first surface"));
+      };
+      const cleanup = () => {
+        clearTimeout(timer);
+        this.client.off("surface", onSurface);
+        this.client.off("close", onClose);
+      };
+      this.client.on("surface", onSurface);
+      this.client.on("close", onClose);
+    });
+  }
+
+  private latestSurface(): EndpointSurface | null {
+    return this.client.currentSurface;
+  }
+
+  private hasPane(surface: EndpointSurface | null, paneId: string): boolean {
+    return surface?.panes.some((p) => p.paneId === paneId) ?? false;
+  }
+
+  private onSurface(surface: EndpointSurface) {
+    if (!this.paneId) return; // connect() replays once the lookup resolves
+    const pane = surface.panes.find((p) => p.paneId === this.paneId);
+    if (!pane) return;
+    this.lastScroll = pane.scroll
+      ? {
+          offsetFromBottom: pane.scroll.offsetFromBottom,
+          maxOffsetFromBottom: pane.scroll.maxOffsetFromBottom,
+        }
+      : null;
+    const cropped = cropFrame(surface.frame, pane.innerRect);
+    const bytes = Buffer.from(frameToAnsi(cropped), "utf8");
+    this.seq += 1;
+    this.emit("terminal", {
+      seq: this.seq,
+      width: cropped.width,
+      height: cropped.height,
+      full: true,
+      bytes,
+    });
+  }
+
+  resize(cols: number, rows: number) {
+    this.client.resize(cols, rows);
+  }
+
+  input(data: Buffer) {
+    if (!this.paneId) return;
+    const events = this.classifier.feed(data);
+    this.client.sendPaneInput(this.paneId, events);
+    if (this.escFlushTimer) clearTimeout(this.escFlushTimer);
+    this.escFlushTimer = setTimeout(() => {
+      this.escFlushTimer = null;
+      if (!this.paneId || this.closed) return;
+      const flushed = this.classifier.flush();
+      this.client.sendPaneInput(this.paneId, flushed);
+    }, ESC_FLUSH_MS);
+  }
+
+  // Extra ThinClient scroll params (column/row/source) are accepted by the
+  // bridge but unused here: endpoint scrolls by absolute offset.
+  scroll(direction: "up" | "down", lines: number) {
+    if (!this.paneId || !this.lastScroll) return;
+    const delta = direction === "up" ? lines : -lines;
+    const offset = Math.max(
+      0,
+      Math.min(
+        this.lastScroll.maxOffsetFromBottom,
+        this.lastScroll.offsetFromBottom + delta,
+      ),
+    );
+    if (offset === this.lastScroll.offsetFromBottom) return;
+    this.lastScroll.offsetFromBottom = offset;
+    this.client
+      .callEndpoint("pane.scroll", {
+        pane_id: this.paneId,
+        offset_from_bottom: offset,
+      })
+      .catch((e) =>
+        this.logger.debug("endpoint pane.scroll failed", {
+          error: e instanceof Error ? e.message : String(e),
+        }),
+      );
+  }
+
+  close() {
+    if (this.closed) return;
+    this.closed = true;
+    if (this.escFlushTimer) clearTimeout(this.escFlushTimer);
+    this.client.close();
+  }
+}
+
+/** Crop one pane's content rect out of the tab surface. */
+export function cropFrame(
+  frame: FrameData,
+  rect: { x: number; y: number; width: number; height: number },
+): FrameData {
+  const width = Math.max(0, Math.min(rect.width, frame.width - rect.x));
+  const height = Math.max(0, Math.min(rect.height, frame.height - rect.y));
+  const cells = new Array(width * height);
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      cells[y * width + x] =
+        frame.cells[(rect.y + y) * frame.width + rect.x + x];
+    }
+  }
+  let cursor = frame.cursor;
+  if (cursor) {
+    const x = cursor.x - rect.x;
+    const y = cursor.y - rect.y;
+    cursor =
+      x >= 0 && x < width && y >= 0 && y < height ? { ...cursor, x, y } : null;
+  }
+  return { cells, width, height, cursor, hyperlinks: frame.hyperlinks };
+}

--- a/server/src/bridge/frame-to-ansi.test.ts
+++ b/server/src/bridge/frame-to-ansi.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { frameToAnsi } from "./frame-to-ansi";
+import type { CellData, FrameData } from "./thin-client";
+
+function cell(symbol: string, over: Partial<CellData> = {}): CellData {
+  return {
+    symbol,
+    fg: 0,
+    bg: 0,
+    modifier: 0,
+    skip: false,
+    hyperlink: null,
+    ...over,
+  };
+}
+
+function frame(cells: CellData[], width: number, height: number): FrameData {
+  return { cells, width, height, cursor: null, hyperlinks: [] };
+}
+
+describe("frameToAnsi", () => {
+  test("emits a full repaint and hides a missing cursor", () => {
+    const out = frameToAnsi(frame([cell("h"), cell("i")], 2, 1));
+    expect(out).toStartWith("\x1b[0m\x1b[H");
+    expect(out).toContain("hi");
+    expect(out).toEndWith("\x1b[?25l");
+  });
+
+  test("encodes named, indexed, and RGB colors", () => {
+    const red = cell("r", { fg: 0x00_00_00_02 }); // named Red
+    const bright = cell("b", { fg: 0x00_00_00_0a }); // LightRed
+    const indexed = cell("i", { fg: 0x01_00_00_7b }); // palette 123
+    const rgb = cell("g", { fg: 0x02_12_34_56, bg: 0x02_ab_cd_ef });
+    const out = frameToAnsi(frame([red, bright, indexed, rgb], 4, 1));
+    expect(out).toContain("\x1b[0m\x1b[31;49m");
+    expect(out).toContain("\x1b[0m\x1b[91;49m");
+    expect(out).toContain("\x1b[0m\x1b[38;5;123;49m");
+    expect(out).toContain("\x1b[0m\x1b[38;2;18;52;86;48;2;171;205;239m");
+  });
+
+  test("encodes modifiers including styled underlines", () => {
+    const bold = cell("b", { modifier: 0x0001 });
+    const curly = cell("u", { modifier: 0x0008 | (3 << 12) });
+    const rev = cell("r", { modifier: 0x0040 });
+    const out = frameToAnsi(frame([bold, curly, rev], 3, 1));
+    expect(out).toContain("\x1b[1;39;49m");
+    expect(out).toContain("\x1b[4:3;39;49m");
+    expect(out).toContain("\x1b[7;39;49m");
+  });
+
+  test("skips spacer cells after wide graphemes", () => {
+    const out = frameToAnsi(
+      frame([cell("你"), cell("", { skip: true }), cell("x")], 3, 1),
+    );
+    expect(out).toContain("你x");
+  });
+
+  test("trims trailing default blanks but keeps styled blanks", () => {
+    const styledBlank = cell(" ", { bg: 0x00_00_00_03 });
+    const out = frameToAnsi(
+      frame([cell("a"), styledBlank, cell(" "), cell(" ")], 4, 1),
+    );
+    // Two trailing default blanks are trimmed; the styled blank remains.
+    expect(out).toContain("a\x1b[0m\x1b[39;42m ");
+    expect(out.trimEnd().endsWith("\x1b[?25l")).toBe(true);
+    expect(out).not.toContain("a\x1b[0m\x1b[39;42m   ");
+  });
+
+  test("opens and closes OSC 8 hyperlinks", () => {
+    const linked = cell("L", { hyperlink: 0 });
+    const f: FrameData = {
+      ...frame([linked, cell("x")], 2, 1),
+      hyperlinks: ["https://example.com"],
+    };
+    const out = frameToAnsi(f);
+    expect(out).toContain("\x1b]8;;https://example.com\x1b\\L");
+    expect(out).toContain("L\x1b]8;;\x1b\\");
+  });
+
+  test("positions and shapes the cursor", () => {
+    const f: FrameData = {
+      ...frame([cell("a")], 1, 1),
+      cursor: { x: 2, y: 3, visible: true, shape: 5 },
+    };
+    const out = frameToAnsi(f);
+    expect(out).toContain("\x1b[4;3H");
+    expect(out).toContain("\x1b[5 q\x1b[?25h");
+  });
+
+  test("separates rows with CRLF", () => {
+    const out = frameToAnsi(
+      frame([cell("a"), cell("b"), cell("c"), cell("d")], 2, 2),
+    );
+    // Each row restarts style tracking, so row 2 opens with a fresh SGR.
+    expect(out).toContain("ab\r\n\x1b[0m\x1b[39;49mcd");
+  });
+});

--- a/server/src/bridge/frame-to-ansi.ts
+++ b/server/src/bridge/frame-to-ansi.ts
@@ -1,0 +1,117 @@
+import type { CellData, FrameData } from "./thin-client";
+
+// Serializes a Herdr wire FrameData cell grid into ANSI bytes for xterm.js.
+// The stable endpoint path delivers server-rendered cells instead of an ANSI
+// stream, so the bridge re-encodes them here.
+//
+// ponytail: full repaint per frame, no diffing. A 100x30 frame is ~20-60KB;
+// add run/diff optimization only if websocket bandwidth measurably hurts.
+
+const RESET = "\x1b[0m";
+
+// ratatui Modifier bits (plus Herdr underline-style extension in bits 12-15).
+const MOD_BOLD = 0x0001;
+const MOD_DIM = 0x0002;
+const MOD_ITALIC = 0x0004;
+const MOD_UNDERLINED = 0x0008;
+const MOD_BLINK = 0x0010 | 0x0020;
+const MOD_REVERSED = 0x0040;
+const MOD_HIDDEN = 0x0080;
+const MOD_CROSSED_OUT = 0x0100;
+const UNDERLINE_STYLE_SHIFT = 12;
+
+function sgrColor(packed: number, foreground: boolean): string {
+  const kind = packed >>> 24;
+  const value = packed & 0x00ff_ffff;
+  if (kind === 0x00) {
+    if (value === 0) return foreground ? "39" : "49";
+    if (value <= 8) return String((foreground ? 30 : 40) + value - 1);
+    return String((foreground ? 90 : 100) + value - 9);
+  }
+  if (kind === 0x01) return `${foreground ? 38 : 48};5;${value & 0xff}`;
+  // 0x02_RR_GG_BB
+  const r = (value >>> 16) & 0xff;
+  const g = (value >>> 8) & 0xff;
+  const b = value & 0xff;
+  return `${foreground ? 38 : 48};2;${r};${g};${b}`;
+}
+
+function sgrStyle(cell: CellData): string {
+  const codes: string[] = [];
+  const mod = cell.modifier;
+  if (mod & MOD_BOLD) codes.push("1");
+  if (mod & MOD_DIM) codes.push("2");
+  if (mod & MOD_ITALIC) codes.push("3");
+  if (mod & MOD_UNDERLINED) {
+    const style = (mod & 0xf000) >>> UNDERLINE_STYLE_SHIFT;
+    codes.push(style >= 1 && style <= 5 ? `4:${style}` : "4");
+  }
+  if (mod & MOD_BLINK) codes.push("5");
+  if (mod & MOD_REVERSED) codes.push("7");
+  if (mod & MOD_HIDDEN) codes.push("8");
+  if (mod & MOD_CROSSED_OUT) codes.push("9");
+  codes.push(sgrColor(cell.fg, true));
+  codes.push(sgrColor(cell.bg, false));
+  return `\x1b[${codes.join(";")}m`;
+}
+
+function styleKey(cell: CellData): string {
+  return `${cell.fg},${cell.bg},${cell.modifier},${cell.hyperlink ?? ""}`;
+}
+
+function isDefaultBlank(cell: CellData): boolean {
+  return (
+    cell.symbol === " " &&
+    cell.fg === 0 &&
+    cell.bg === 0 &&
+    cell.modifier === 0 &&
+    cell.hyperlink === null
+  );
+}
+
+/** Serialize one frame as a full repaint: home, styled rows, cursor. */
+export function frameToAnsi(frame: FrameData): string {
+  let out = `${RESET}\x1b[H`;
+  for (let y = 0; y < frame.height; y++) {
+    const rowStart = y * frame.width;
+    let rowEnd = frame.width;
+    // Trim trailing default blanks; the terminal background fills them.
+    while (rowEnd > 0 && isDefaultBlank(frame.cells[rowStart + rowEnd - 1])) {
+      rowEnd--;
+    }
+    let lastStyle: string | null = null;
+    let linkOpen = false;
+    for (let x = 0; x < rowEnd; x++) {
+      const cell = frame.cells[rowStart + x];
+      if (cell.skip) continue; // spacer after a wide grapheme
+      const key = styleKey(cell);
+      if (key !== lastStyle) {
+        if (linkOpen) {
+          out += "\x1b]8;;\x1b\\";
+          linkOpen = false;
+        }
+        out += RESET + sgrStyle(cell);
+        const link = cell.hyperlink;
+        if (link !== null) {
+          const uri = frame.hyperlinks[link];
+          if (uri !== undefined) {
+            out += `\x1b]8;;${uri}\x1b\\`;
+            linkOpen = true;
+          }
+        }
+        lastStyle = key;
+      }
+      out += cell.symbol;
+    }
+    if (linkOpen) out += "\x1b]8;;\x1b\\";
+    if (y < frame.height - 1) out += "\r\n";
+  }
+  const cursor = frame.cursor;
+  if (cursor && cursor.visible) {
+    out += `${RESET}\x1b[${cursor.y + 1};${cursor.x + 1}H`;
+    out += `\x1b[${cursor.shape} q\x1b[?25h`;
+  } else {
+    out += "\x1b[?25l";
+  }
+  return out;
+}

--- a/server/src/bridge/frame-to-ansi.ts
+++ b/server/src/bridge/frame-to-ansi.ts
@@ -71,7 +71,7 @@ function isDefaultBlank(cell: CellData): boolean {
 
 /** Serialize one frame as a full repaint: home, styled rows, cursor. */
 export function frameToAnsi(frame: FrameData): string {
-  let out = `${RESET}\x1b[H`;
+  let out = `${RESET}\x1b[H\x1b[2J`;
   for (let y = 0; y < frame.height; y++) {
     const rowStart = y * frame.width;
     let rowEnd = frame.width;

--- a/server/src/bridge/terminal-bridge.ts
+++ b/server/src/bridge/terminal-bridge.ts
@@ -7,6 +7,7 @@ import { type Logger, silentLogger } from "../utils/logger";
 import { NO_TERMINAL_ATTACHED_MESSAGE } from "../utils/rpc-logging";
 import { ThinClient } from "./thin-client";
 import { isTerminalHelloProtocol } from "./protocol-compat";
+import { EndpointTerminalSession } from "./endpoint-terminal-session";
 
 type TerminalSession = {
   terminalId: string | null;
@@ -15,7 +16,7 @@ type TerminalSession = {
 };
 
 type SharedTerminalSession = {
-  thin: ThinClient;
+  thin: ThinClient | EndpointTerminalSession;
   connecting: Promise<void> | null;
   firstFrame: Promise<boolean>;
   resolveFirstFrame: ((seen: boolean) => void) | null;
@@ -52,6 +53,8 @@ export function createTerminalBridge(args: {
   formatError?: (error: unknown) => string;
   clientSocketPath: string;
   herdrProtocol: () => Promise<number>;
+  /** Resolve a terminal id to its owning pane id (control-socket pane.list). */
+  lookupPaneId?: (terminalId: string) => Promise<string | null>;
   safeSend: (
     ws: ServerWebSocket<unknown>,
     payload: string,
@@ -83,6 +86,15 @@ export function createTerminalBridge(args: {
   let clipboardRelaySkipped = false;
   let lifecycleRevision = 0;
   let disposed = false;
+  // Resolved once per bridge: the protocol is fixed for the server process,
+  // and a restart recreates this bridge.
+  let resolvedProtocol: number | null = null;
+  async function bridgeProtocol(): Promise<number> {
+    if (resolvedProtocol === null) {
+      resolvedProtocol = await args.herdrProtocol();
+    }
+    return resolvedProtocol;
+  }
 
   const serialize = (message: Record<string, unknown>) =>
     args.connectionId
@@ -420,13 +432,16 @@ export function createTerminalBridge(args: {
     }
   }
 
-  function getSharedTerminal(
+  async function getSharedTerminal(
     terminalId: string,
     cols: number,
     rows: number,
-  ): SharedTerminalSession {
+  ): Promise<SharedTerminalSession> {
     if (disposed) throw new Error("terminal bridge disposed");
     const creationRevision = lifecycleRevision;
+    // Resolve before checking the map so concurrent attaches for the same
+    // terminal cannot double-create while the first resolution is in flight.
+    const protocol = await bridgeProtocol();
     const existing = sharedTerminals.get(terminalId);
     if (existing && !existing.thin.isClosed) return existing;
     if (existing) {
@@ -434,7 +449,17 @@ export function createTerminalBridge(args: {
       sharedTerminals.delete(terminalId);
     }
 
-    const thin = new ThinClient(args.clientSocketPath, args.herdrProtocol);
+    const thin =
+      isTerminalHelloProtocol(protocol) &&
+      args.lookupPaneId &&
+      process.env.HERDR_GUI_DISABLE_ENDPOINT !== "1"
+        ? new EndpointTerminalSession(
+            args.clientSocketPath,
+            terminalId,
+            args.lookupPaneId,
+            logger,
+          )
+        : new ThinClient(args.clientSocketPath, args.herdrProtocol);
     let resolveFirstFrame!: (seen: boolean) => void;
     const firstFrame = new Promise<boolean>((resolve) => {
       resolveFirstFrame = resolve;
@@ -558,15 +583,24 @@ export function createTerminalBridge(args: {
         }
       }
     });
-    const terminalReady = thin
-      .connect(cols, rows, { launchMode: "terminal-attach", encoding: 1 })
-      .then(() => {
-        if (!isCurrent(creationRevision)) {
-          thin.close();
-          throw new Error("terminal bridge disposed");
-        }
-        thin.attach(terminalId, true);
-      });
+    const terminalReady = (
+      thin instanceof ThinClient
+        ? thin
+            .connect(cols, rows, { launchMode: "terminal-attach", encoding: 1 })
+            .then(() => {
+              if (!isCurrent(creationRevision)) {
+                thin.close();
+                throw new Error("terminal bridge disposed");
+              }
+              thin.attach(terminalId, true);
+            })
+        : thin.connect(cols, rows)
+    ).then(() => {
+      if (!isCurrent(creationRevision)) {
+        thin.close();
+        throw new Error("terminal bridge disposed");
+      }
+    });
     shared.connecting = terminalReady
       .then(() => undefined)
       .catch((e) => {
@@ -631,7 +665,7 @@ export function createTerminalBridge(args: {
         terminals.set(ws, { terminalId, cols, rows });
         viewed.add(terminalId);
         terminalViewers.set(ws, viewed);
-        const shared = getSharedTerminal(terminalId, cols, rows);
+        const shared = await getSharedTerminal(terminalId, cols, rows);
         shared.viewers.add(ws);
         try {
           await shared.connecting;

--- a/server/src/bridge/thin-client.ts
+++ b/server/src/bridge/thin-client.ts
@@ -398,18 +398,24 @@ export class ThinClient extends EventEmitter {
   }
 }
 
-function readFrameData(r: BinReader): FrameData {
+// Exported for the stable endpoint client (PaneSurface frames share the wire
+// FrameData layout).
+export function readCellData(r: BinReader): CellData {
+  return {
+    symbol: r.string(),
+    fg: r.varint(),
+    bg: r.varint(),
+    modifier: r.varint(),
+    skip: r.bool(),
+    hyperlink: r.option(() => r.varint()),
+  };
+}
+
+export function readFrameData(r: BinReader): FrameData {
   const cellCount = r.varint();
   const cells: CellData[] = new Array(cellCount);
   for (let i = 0; i < cellCount; i++) {
-    cells[i] = {
-      symbol: r.string(),
-      fg: r.varint(),
-      bg: r.varint(),
-      modifier: r.varint(),
-      skip: r.bool(),
-      hyperlink: r.option(() => r.varint()),
-    };
+    cells[i] = readCellData(r);
   }
   const width = r.varint();
   const height = r.varint();

--- a/server/src/bridge/vt-input-classifier.test.ts
+++ b/server/src/bridge/vt-input-classifier.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, test } from "bun:test";
+import { BinReader } from "./bincode";
+import {
+  KEY,
+  MOD_ALT,
+  MOD_CONTROL,
+  MOD_SHIFT,
+  type PaneInputEvent,
+  VtInputClassifier,
+  encodePaneInput,
+} from "./vt-input-classifier";
+
+function feed(input: string | number[]): PaneInputEvent[] {
+  const c = new VtInputClassifier();
+  return c.feed(
+    typeof input === "string" ? Buffer.from(input, "utf8") : Buffer.from(input),
+  );
+}
+
+describe("VtInputClassifier", () => {
+  test("printable text becomes one TextCommit", () => {
+    expect(feed("hello 世界")).toEqual([{ type: "text", text: "hello 世界" }]);
+  });
+
+  test("enter, backspace, tab, escape keys", () => {
+    expect(feed("\r")).toEqual([
+      {
+        type: "key",
+        code: KEY.Enter,
+        char: undefined,
+        fn: undefined,
+        modifiers: 0,
+        generatedText: undefined,
+      },
+    ]);
+    expect(feed([0x7f])).toEqual([
+      {
+        type: "key",
+        code: KEY.Backspace,
+        char: undefined,
+        fn: undefined,
+        modifiers: 0,
+        generatedText: undefined,
+      },
+    ]);
+    expect(feed("\t")).toEqual([
+      {
+        type: "key",
+        code: KEY.Tab,
+        char: undefined,
+        fn: undefined,
+        modifiers: 0,
+        generatedText: undefined,
+      },
+    ]);
+    const c = new VtInputClassifier();
+    expect(c.feed(Buffer.from([0x1b]))).toEqual([]);
+    expect(c.flush()).toEqual([
+      {
+        type: "key",
+        code: KEY.Esc,
+        char: undefined,
+        fn: undefined,
+        modifiers: 0,
+        generatedText: undefined,
+      },
+    ]);
+  });
+
+  test("ctrl+letter maps to Char with CONTROL", () => {
+    expect(feed([0x03])).toEqual([
+      {
+        type: "key",
+        code: KEY.Char,
+        char: 0x63,
+        fn: undefined,
+        modifiers: MOD_CONTROL,
+        generatedText: undefined,
+      },
+    ]);
+  });
+
+  test("arrows and modified arrows", () => {
+    expect(feed("\x1b[A")).toEqual([
+      {
+        type: "key",
+        code: KEY.Up,
+        char: undefined,
+        fn: undefined,
+        modifiers: 0,
+        generatedText: undefined,
+      },
+    ]);
+    expect(feed("\x1b[1;5D")).toEqual([
+      {
+        type: "key",
+        code: KEY.Left,
+        char: undefined,
+        fn: undefined,
+        modifiers: MOD_CONTROL,
+        generatedText: undefined,
+      },
+    ]);
+    expect(feed("\x1b[1;2C")).toEqual([
+      {
+        type: "key",
+        code: KEY.Right,
+        char: undefined,
+        fn: undefined,
+        modifiers: MOD_SHIFT,
+        generatedText: undefined,
+      },
+    ]);
+  });
+
+  test("tilde keys: delete, home, end, page up/down", () => {
+    const codeAt = (input: string) => {
+      const e = feed(input)[0];
+      return e.type === "key" ? e.code : null;
+    };
+    expect(codeAt("\x1b[3~")).toBe(KEY.Delete);
+    expect(codeAt("\x1b[1~")).toBe(KEY.Home);
+    expect(codeAt("\x1b[4~")).toBe(KEY.End);
+    expect(codeAt("\x1b[5~")).toBe(KEY.PageUp);
+    expect(codeAt("\x1b[6~")).toBe(KEY.PageDown);
+  });
+
+  test("function keys via SS3 and tilde", () => {
+    expect(feed("\x1bOP")[0]).toMatchObject({ code: KEY.F, fn: 1 });
+    expect(feed("\x1bOQ")[0]).toMatchObject({ code: KEY.F, fn: 2 });
+    expect(feed("\x1b[15~")[0]).toMatchObject({ code: KEY.F, fn: 5 });
+    expect(feed("\x1b[24~")[0]).toMatchObject({ code: KEY.F, fn: 12 });
+  });
+
+  test("alt+char", () => {
+    expect(feed("\x1bx")).toEqual([
+      {
+        type: "key",
+        code: KEY.Char,
+        char: 0x78,
+        fn: undefined,
+        modifiers: MOD_ALT,
+        generatedText: undefined,
+      },
+    ]);
+  });
+
+  test("bracketed paste becomes one Paste event", () => {
+    expect(feed("\x1b[200~pasted\r\ntext\x1b[201~")).toEqual([
+      { type: "paste", text: "pasted\r\ntext" },
+    ]);
+  });
+
+  test("mixed text and keys keep order", () => {
+    const events = feed("ab\x1b[Acd");
+    expect(events.map((e) => e.type)).toEqual(["text", "key", "text"]);
+    expect(events[0]).toMatchObject({ text: "ab" });
+    expect(events[2]).toMatchObject({ text: "cd" });
+  });
+
+  test("split sequences wait for completion", () => {
+    const c = new VtInputClassifier();
+    expect(c.feed(Buffer.from("\x1b["))).toEqual([]);
+    expect(c.feed(Buffer.from("3~"))).toEqual([
+      {
+        type: "key",
+        code: KEY.Delete,
+        char: undefined,
+        fn: undefined,
+        modifiers: 0,
+        generatedText: undefined,
+      },
+    ]);
+  });
+
+  test("split UTF-8 chars wait for completion", () => {
+    const c = new VtInputClassifier();
+    const bytes = Buffer.from("世", "utf8");
+    expect(c.feed(bytes.subarray(0, 1))).toEqual([]);
+    expect(c.feed(bytes.subarray(1))).toEqual([{ type: "text", text: "世" }]);
+  });
+
+  test("double ESC yields Esc then reprocesses", () => {
+    const events = feed("\x1b\x1b[A");
+    expect(events.map((e) => (e.type === "key" ? e.code : e.type))).toEqual([
+      KEY.Esc,
+      KEY.Up,
+    ]);
+  });
+});
+
+describe("encodePaneInput", () => {
+  test("encodes the ClientShellPaneInput frame", () => {
+    const buf = encodePaneInput("w1:p1", [
+      { type: "text", text: "hi" },
+      { type: "key", code: KEY.Enter, modifiers: 0 },
+      { type: "paste", text: "p" },
+      { type: "key", code: KEY.Char, char: 0x63, modifiers: MOD_CONTROL },
+      { type: "key", code: KEY.F, fn: 5, modifiers: MOD_SHIFT },
+    ]);
+    const r = new BinReader(buf);
+    expect(r.variant()).toBe(13); // ClientShellPaneInput
+    expect(r.string()).toBe("w1:p1");
+    expect(r.varint()).toBe(5);
+
+    expect(r.variant()).toBe(1); // TextCommit
+    expect(r.string()).toBe("hi");
+
+    expect(r.variant()).toBe(0); // Key
+    expect(r.variant()).toBe(KEY.Enter);
+    expect(r.u8()).toBe(0); // modifiers
+    expect(r.variant()).toBe(0); // Press
+    expect(r.varint()).toBe(1); // repeat_count
+    expect(r.bool()).toBe(false); // shifted_codepoint
+    expect(r.bool()).toBe(false); // generated_text
+    expect(r.bool()).toBe(false); // tracks_release
+    expect(r.bool()).toBe(false); // physical_key_id
+    expect(r.bool()).toBe(false); // windows_record
+
+    expect(r.variant()).toBe(3); // Paste
+    expect(r.string()).toBe("p");
+
+    expect(r.variant()).toBe(0); // Key Char
+    expect(r.variant()).toBe(KEY.Char);
+    expect(r.varint()).toBe(0x63);
+    expect(r.u8()).toBe(MOD_CONTROL);
+    expect(r.variant()).toBe(0); // Press
+    expect(r.varint()).toBe(1);
+    expect(r.bool()).toBe(false);
+    expect(r.bool()).toBe(false);
+    expect(r.bool()).toBe(false);
+    expect(r.bool()).toBe(false);
+    expect(r.bool()).toBe(false);
+
+    expect(r.variant()).toBe(0); // Key F
+    expect(r.variant()).toBe(KEY.F);
+    expect(r.varint()).toBe(5);
+    expect(r.u8()).toBe(MOD_SHIFT);
+  });
+});

--- a/server/src/bridge/vt-input-classifier.ts
+++ b/server/src/bridge/vt-input-classifier.ts
@@ -1,0 +1,367 @@
+import { BinWriter } from "./bincode";
+
+// Classifies browser VT input bytes (what xterm.js emits from key events)
+// into Herdr's stable semantic pane-input events, and encodes them as
+// ClientShellPaneInput frames for the endpoint path.
+//
+// ponytail: covers the common key space — printable text, Enter/Backspace/
+// Tab, arrows, Home/End/Insert/Delete/PageUp/PageDown, F1-F12, Ctrl+letter,
+// Alt+char, modified CSI keys, bracketed paste. Kitty keyboard protocol and
+// mouse SGR are not classified (dropped); add when a pane app needs them.
+
+// crossterm KeyModifiers bits used on the wire.
+export const MOD_SHIFT = 0x1;
+export const MOD_CONTROL = 0x2;
+export const MOD_ALT = 0x4;
+export const MOD_SUPER = 0x8;
+
+// ClientKeyCode variant indices (frozen wire order).
+export const KEY = {
+  Backspace: 0,
+  Enter: 1,
+  Left: 2,
+  Right: 3,
+  Up: 4,
+  Down: 5,
+  Home: 6,
+  End: 7,
+  PageUp: 8,
+  PageDown: 9,
+  Tab: 10,
+  BackTab: 11,
+  Delete: 12,
+  Insert: 13,
+  Esc: 14,
+  Char: 15,
+  F: 16,
+  Null: 17,
+} as const;
+
+export type PaneInputEvent =
+  | {
+      type: "key";
+      code: number;
+      char?: number; // codepoint for KEY.Char
+      fn?: number; // number for KEY.F
+      modifiers: number;
+      generatedText?: string;
+    }
+  | { type: "text"; text: string }
+  | { type: "paste"; text: string };
+
+/** Encode events as one ClientShellPaneInput frame payload (variant 13). */
+export function encodePaneInput(
+  paneId: string,
+  events: PaneInputEvent[],
+): Buffer {
+  const w = new BinWriter();
+  w.variant(13); // ClientMessage::ClientShellPaneInput
+  w.string(paneId);
+  w.varint(events.length);
+  for (const e of events) {
+    if (e.type === "key") {
+      w.variant(0); // ClientPaneInputEvent::Key
+      w.variant(e.code);
+      if (e.code === KEY.Char) w.varint(e.char ?? 0);
+      if (e.code === KEY.F) w.varint(e.fn ?? 1);
+      w.u8(e.modifiers);
+      w.variant(0); // ClientKeyKind::Press
+      w.varint(1); // repeat_count
+      w.bool(false); // shifted_codepoint: None
+      if (e.generatedText !== undefined) {
+        w.bool(true);
+        w.string(e.generatedText);
+      } else {
+        w.bool(false);
+      }
+      w.bool(false); // tracks_release
+      w.bool(false); // physical_key_id: None
+      w.bool(false); // windows_record: None
+    } else if (e.type === "text") {
+      w.variant(1); // ClientPaneInputEvent::TextCommit
+      w.string(e.text);
+    } else {
+      w.variant(3); // ClientPaneInputEvent::Paste
+      w.string(e.text);
+    }
+  }
+  return w.toBuffer();
+}
+
+function key(
+  code: number,
+  opts: {
+    char?: number;
+    fn?: number;
+    modifiers?: number;
+    generatedText?: string;
+  } = {},
+): PaneInputEvent {
+  return {
+    type: "key",
+    code,
+    char: opts.char,
+    fn: opts.fn,
+    modifiers: opts.modifiers ?? 0,
+    generatedText: opts.generatedText,
+  };
+}
+
+const CSI_FINALS: Record<string, number> = {
+  A: KEY.Up,
+  B: KEY.Down,
+  C: KEY.Right,
+  D: KEY.Left,
+  H: KEY.Home,
+  F: KEY.End,
+  Z: KEY.BackTab,
+};
+
+const CSI_TILDE_KEYS: Record<number, number> = {
+  1: KEY.Home,
+  2: KEY.Insert,
+  3: KEY.Delete,
+  4: KEY.End,
+  5: KEY.PageUp,
+  6: KEY.PageDown,
+  7: KEY.Home,
+  8: KEY.End,
+};
+
+const CSI_TILDE_FN: Record<number, number> = {
+  11: 1,
+  12: 2,
+  13: 3,
+  14: 4,
+  15: 5,
+  17: 6,
+  18: 7,
+  19: 8,
+  20: 9,
+  21: 10,
+  23: 11,
+  24: 12,
+};
+
+const SS3_KEYS: Record<string, PaneInputEvent> = {
+  A: key(KEY.Up),
+  B: key(KEY.Down),
+  C: key(KEY.Right),
+  D: key(KEY.Left),
+  H: key(KEY.Home),
+  F: key(KEY.End),
+  P: key(KEY.F, { fn: 1 }),
+  Q: key(KEY.F, { fn: 2 }),
+  R: key(KEY.F, { fn: 3 }),
+  S: key(KEY.F, { fn: 4 }),
+};
+
+/** xterm modifier param (1+bits: shift=1, alt=2, ctrl=4, super=8) → crossterm bits. */
+function xtermModifiers(param: number): number {
+  const bits = Math.max(0, param - 1);
+  let mods = 0;
+  if (bits & 1) mods |= MOD_SHIFT;
+  if (bits & 2) mods |= MOD_ALT;
+  if (bits & 4) mods |= MOD_CONTROL;
+  if (bits & 8) mods |= MOD_SUPER;
+  return mods;
+}
+
+/** Control byte 0x00-0x1f → key event, or null when handled elsewhere. */
+function controlByteKey(b: number): PaneInputEvent | null {
+  if (b === 0x0d || b === 0x0a) return key(KEY.Enter);
+  if (b === 0x09) return key(KEY.Tab);
+  if (b === 0x7f) return key(KEY.Backspace);
+  if (b === 0x08) return key(KEY.Char, { char: 0x68, modifiers: MOD_CONTROL }); // ctrl+h
+  if (b >= 0x01 && b <= 0x1a) {
+    return key(KEY.Char, {
+      char: 0x60 + b, // ctrl+a .. ctrl+z
+      modifiers: MOD_CONTROL,
+    });
+  }
+  if (b === 0x00) {
+    return key(KEY.Char, { char: 0x20, modifiers: MOD_CONTROL }); // ctrl+space
+  }
+  // 0x1c-0x1f: ctrl+\ ctrl+] ctrl+^ ctrl+_
+  if (b >= 0x1c && b <= 0x1f) {
+    const chars = [0x5c, 0x5d, 0x5e, 0x5f];
+    return key(KEY.Char, {
+      char: chars[b - 0x1c],
+      modifiers: MOD_CONTROL,
+    });
+  }
+  return null;
+}
+
+function utf8Length(first: number): number {
+  if (first < 0x80) return 1;
+  if (first >= 0xf0) return 4;
+  if (first >= 0xe0) return 3;
+  if (first >= 0xc0) return 2;
+  return 1; // stray continuation byte; treat as single
+}
+
+const PASTE_START = Buffer.from("\x1b[200~");
+const PASTE_END = Buffer.from("\x1b[201~");
+
+export class VtInputClassifier {
+  private pending = Buffer.alloc(0);
+
+  /** Feed one browser input chunk; returns complete events. */
+  feed(chunk: Buffer): PaneInputEvent[] {
+    this.pending = Buffer.concat([this.pending, chunk]);
+    const events: PaneInputEvent[] = [];
+    let text = "";
+    const flushText = () => {
+      if (text) {
+        events.push({ type: "text", text });
+        text = "";
+      }
+    };
+
+    let i = 0;
+    const buf = this.pending;
+    while (i < buf.length) {
+      const b = buf[i];
+
+      if (b === 0x1b) {
+        // Bracketed paste?
+        if (matchesAt(buf, i, PASTE_START)) {
+          const end = buf.indexOf(PASTE_END, i + PASTE_START.length);
+          if (end === -1) break; // wait for the rest of the paste
+          flushText();
+          events.push({
+            type: "paste",
+            text: buf.subarray(i + PASTE_START.length, end).toString("utf8"),
+          });
+          i = end + PASTE_END.length;
+          continue;
+        }
+        const parsed = this.parseEscape(buf, i);
+        if (parsed === null) break; // incomplete; wait for more bytes
+        flushText();
+        for (const e of parsed.events) events.push(e);
+        i = parsed.next;
+        continue;
+      }
+
+      if (b < 0x20 || b === 0x7f) {
+        const ev = controlByteKey(b);
+        if (ev) {
+          flushText();
+          events.push(ev);
+        }
+        i++;
+        continue;
+      }
+
+      const len = utf8Length(b);
+      if (i + len > buf.length) break; // incomplete UTF-8 char
+      text += buf.toString("utf8", i, i + len);
+      i += len;
+    }
+
+    flushText();
+    this.pending = buf.subarray(i);
+    return events;
+  }
+
+  /** Flush a lone ESC as the Esc key (call after a short idle timeout). */
+  flush(): PaneInputEvent[] {
+    if (this.pending.length === 1 && this.pending[0] === 0x1b) {
+      this.pending = Buffer.alloc(0);
+      return [key(KEY.Esc)];
+    }
+    return [];
+  }
+
+  /**
+   * Parse one escape sequence at buf[i] (buf[i] === 0x1b).
+   * Returns null when the sequence is incomplete.
+   */
+  private parseEscape(
+    buf: Buffer,
+    i: number,
+  ): { events: PaneInputEvent[]; next: number } | null {
+    if (i + 1 >= buf.length) return null; // lone ESC so far
+    const second = buf[i + 1];
+
+    if (second === 0x5b) {
+      // CSI: ESC [ params final
+      let j = i + 2;
+      while (j < buf.length && buf[j] >= 0x30 && buf[j] <= 0x3f) j++;
+      if (j >= buf.length) return null;
+      const final = String.fromCharCode(buf[j]);
+      if (buf[j] < 0x40 || buf[j] > 0x7e) {
+        // Not a valid CSI final; drop the ESC.
+        return { events: [key(KEY.Esc)], next: i + 1 };
+      }
+      const params = buf
+        .toString("ascii", i + 2, j)
+        .split(";")
+        .map((p) => (p === "" ? 1 : Number(p)));
+      const next = j + 1;
+      if (final === "~") {
+        const n = params[0] ?? 1;
+        const mods = xtermModifiers(params[1] ?? 1);
+        if (n in CSI_TILDE_KEYS) {
+          return {
+            events: [key(CSI_TILDE_KEYS[n], { modifiers: mods })],
+            next,
+          };
+        }
+        if (n in CSI_TILDE_FN) {
+          return {
+            events: [key(KEY.F, { fn: CSI_TILDE_FN[n], modifiers: mods })],
+            next,
+          };
+        }
+        return { events: [], next }; // unknown ~ sequence: swallow
+      }
+      if (final in CSI_FINALS) {
+        const mods = xtermModifiers(params[1] ?? 1);
+        return { events: [key(CSI_FINALS[final], { modifiers: mods })], next };
+      }
+      return { events: [], next }; // unknown CSI: swallow
+    }
+
+    if (second === 0x4f) {
+      // SS3: ESC O final
+      if (i + 2 >= buf.length) return null;
+      const final = String.fromCharCode(buf[i + 2]);
+      const ev = SS3_KEYS[final];
+      return { events: ev ? [ev] : [], next: i + 3 };
+    }
+
+    if (second === 0x1b) {
+      // Two ESCs: first is a real Esc, reprocess the second.
+      return { events: [key(KEY.Esc)], next: i + 1 };
+    }
+
+    // ESC + printable char → Alt+char.
+    const len = utf8Length(second);
+    if (i + 1 + len > buf.length) return null;
+    if (second >= 0x20 && second !== 0x7f) {
+      const ch = buf.toString("utf8", i + 1, i + 1 + len);
+      return {
+        events: [
+          key(KEY.Char, {
+            char: ch.codePointAt(0)!,
+            modifiers: MOD_ALT,
+          }),
+        ],
+        next: i + 1 + len,
+      };
+    }
+    // ESC + control byte: treat the ESC as Esc and reprocess the byte.
+    return { events: [key(KEY.Esc)], next: i + 1 };
+  }
+}
+
+function matchesAt(buf: Buffer, offset: number, needle: Buffer): boolean {
+  if (offset + needle.length > buf.length) return false;
+  for (let k = 0; k < needle.length; k++) {
+    if (buf[offset + k] !== needle[k]) return false;
+  }
+  return true;
+}

--- a/server/src/connections/runtime.ts
+++ b/server/src/connections/runtime.ts
@@ -198,6 +198,28 @@ export function createLegacyConnectionRuntime(args: {
       assertSupportedHerdrProtocol(protocol);
       return protocol;
     },
+    lookupPaneId: async (terminalId) => {
+      try {
+        const result = await herdr.call("pane.list", {}, 5000);
+        const panes = (result as { panes?: unknown } | null)?.panes;
+        if (!Array.isArray(panes)) return null;
+        for (const pane of panes) {
+          if (!pane || typeof pane !== "object" || Array.isArray(pane))
+            continue;
+          const record = pane as { pane_id?: unknown; terminal_id?: unknown };
+          if (
+            record.terminal_id === terminalId &&
+            typeof record.pane_id === "string" &&
+            record.pane_id.length > 0
+          ) {
+            return record.pane_id;
+          }
+        }
+        return null;
+      } catch {
+        return null;
+      }
+    },
     safeSend: args.safeSend,
     clientLabel: args.clientLabel,
     markRpcError: args.markRpcError,

--- a/server/src/probe-endpoint.ts
+++ b/server/src/probe-endpoint.ts
@@ -1,0 +1,38 @@
+import { EndpointClient } from "./bridge/endpoint-client";
+
+// Live probe for the stable endpoint path (Herdr >= 0.9.0). Usage:
+//   bun run server/src/probe-endpoint.ts [client-socket-path]
+
+const sockPath =
+  process.argv[2] ??
+  `${process.env.HOME}/.config/herdr/sessions/endpoint-spike/herdr-client.sock`;
+
+const c = new EndpointClient(sockPath);
+let surfaces = 0;
+c.on("welcome", (w) =>
+  console.log(
+    `WELCOME ${w.serverVersion} methods=${w.methods.length} caps=${w.capabilities.join(",")}`,
+  ),
+);
+c.on("snapshot", (s) =>
+  console.log(`SNAPSHOT boot=${s.bootId} rev=${s.revision}`),
+);
+c.on("surface", (s) => {
+  surfaces++;
+  if (surfaces > 3) return;
+  console.log(
+    `SURFACE #${surfaces} rev=${s.surfaceRevision} ${s.frame.width}x${s.frame.height} ` +
+      `panes=${s.panes.map((p: { paneId: string; rect: { x: number; y: number; width: number; height: number }; focused: boolean }) => `${p.paneId}@${p.rect.x},${p.rect.y} ${p.rect.width}x${p.rect.height}${p.focused ? "*" : ""}`).join("|")} ` +
+      `cursor=${s.frame.cursor ? `${s.frame.cursor.x},${s.frame.cursor.y}` : "none"}`,
+  );
+});
+c.on("shell_error", (m) => console.log("SHELL_ERROR", m));
+c.on("error", (e) => console.log("ERROR", (e as Error).message));
+c.on("close", () => console.log("CLOSED"));
+
+await c.connect(Number(process.argv[3] ?? 100), Number(process.argv[4] ?? 30));
+setTimeout(() => {
+  console.log("done, surfaces:", surfaces);
+  c.close();
+  process.exit(0);
+}, 5000);

--- a/web/src/endpointFrame.test.ts
+++ b/web/src/endpointFrame.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test";
+import { Terminal } from "@xterm/xterm";
+import { frameToAnsi } from "../../server/src/bridge/frame-to-ansi";
+import type { FrameData } from "../../server/src/bridge/thin-client";
+
+test("endpoint repaints clear shortened text, blank rows, and a smaller pane", async () => {
+  const term = new Terminal({ allowProposedApi: true, cols: 10, rows: 3 });
+  try {
+    for (const [text, width, height] of [
+      ["abcdefghij".repeat(3), 10, 3],
+      ["abc", 10, 3],
+      ["x", 2, 1],
+      ["", 2, 1],
+    ] as const) {
+      const frame: FrameData = {
+        width,
+        height,
+        cursor: null,
+        hyperlinks: [],
+        cells: Array.from(text.padEnd(width * height), (symbol) => ({
+          symbol,
+          fg: 0,
+          bg: 0,
+          modifier: 0,
+          skip: false,
+          hyperlink: null,
+        })),
+      };
+      await new Promise<void>((resolve) =>
+        term.write(frameToAnsi(frame), resolve),
+      );
+      for (let y = 0; y < 3; y++) {
+        expect(term.buffer.active.getLine(y)?.translateToString(true)).toBe(
+          text.slice(y * width, (y + 1) * width),
+        );
+      }
+    }
+  } finally {
+    term.dispose();
+  }
+});


### PR DESCRIPTION
## Summary

On Herdr 0.9.0 (protocol 22+), terminal streams now use the stable endpoint generation 1 contract instead of the private direct-attach protocol that herdr reserves for same-install clients. Legacy servers (protocol 14-20) are unaffected, and `HERDR_GUI_DISABLE_ENDPOINT=1` forces the legacy path as an escape hatch.

- **endpoint-client**: `endpoint.hello.v1` handshake, snapshot parsing, PaneSurface/PaneSurfacePatch composition, resize, health ping/pong, endpoint method calls
- **endpoint-terminal-session**: per-shell pane focus, tab surface cropped to the pane content rect, cells re-encoded to ANSI for the existing xterm.js frontend
- **vt-input-classifier**: browser VT bytes classified into semantic pane input (text, keys, modifiers, bracketed paste)
- **scrollback**: absolute `pane.scroll` offsets driven by surface scroll metrics

Known gaps on the endpoint path (noted in CHANGELOG): mouse input is not yet classified, and panes sharing a tab render at their layout size.

## Verification

- `bun test server/` — 513 pass, 0 fail (22 new tests covering handshake bytes, surface composition, ANSI encoding, input classification, session cropping/focus/scroll)
- `bun run lint`, `bun run format:check`, `bunx tsc --noEmit -p server` — clean
- Live-tested against a real Herdr 0.9.0 server: handshake, snapshot, cropped ANSI frames, input round-trip, scroll