### PR TITLE
Restore endpoint mouse input and preserve browser selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- Avoid extra spacing after Chinese and other wide characters in endpoint terminals.
 - Restore cell-based clicks, drags and wheel input in endpoint terminal apps;
   retain browser selection/copy and history scrolling outside mouse-aware apps.
   Selected endpoint output pauses visually until selection clears.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 
 ### Fixed
 
-- Avoid extra spacing after Chinese and other wide characters in endpoint terminals.
+- Preserve endpoint text and cursor alignment for Chinese and other Unicode
+  graphemes, including halfwidth kana, without adding wide-character spacing.
 - Restore cell-based clicks, drags and wheel input in endpoint terminal apps;
   retain browser selection/copy and history scrolling outside mouse-aware apps.
   Selected endpoint output pauses visually until selection clears.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@
   browser terminal now renders the pane cropped from the server-rendered tab
   surface, input is classified into semantic key events, and scrollback goes
   through `pane.scroll`. Set `HERDR_GUI_DISABLE_ENDPOINT=1` to fall back to
-  the legacy path. Known gaps on the endpoint path: mouse input is not yet
-  classified, and panes sharing a tab render at their layout size.
+  the legacy path. Panes sharing a tab still render at their layout size.
 
 ### Fixed
 
+- Restore cell-based clicks, drags and wheel input in endpoint terminal apps;
+  retain browser selection/copy and history scrolling outside mouse-aware apps.
+  Selected endpoint output pauses visually until selection clears.
 - Clear stale terminal text on endpoint repaints, wait for the initial snapshot
   before attaching, and reject pending endpoint requests when disconnected.
 

--- a/docs/endpoint-mouse-verification.md
+++ b/docs/endpoint-mouse-verification.md
@@ -1,0 +1,166 @@
+# Endpoint mouse input (issue #108)
+
+## Contract and routing
+
+The wire contract was checked against Herdr **v0.9.0**, commit
+`b99002ac99b09e00b4ca692436cb15a6b0d676f1`:
+
+- [`src/protocol/wire.rs`](https://github.com/herdrdev/herdr/blob/b99002ac99b09e00b4ca692436cb15a6b0d676f1/src/protocol/wire.rs):
+  `ClientShellPaneInput` is message 13; `ClientPaneInputEvent::Mouse` is event 2.
+  Its fields are kind, position, optional geometry, modifiers (`u8`), lines
+  (`u16`). Kind order is Down, Up, Drag (each with Left/Right/Middle), Moved,
+  ScrollUp, ScrollDown, ScrollLeft, ScrollRight. Cell position is variant 0.
+- [`src/client/shell/mouse.rs`](https://github.com/herdrdev/herdr/blob/b99002ac99b09e00b4ca692436cb15a6b0d676f1/src/client/shell/mouse.rs):
+  `pane_mouse_position` subtracts the pane inner rectangle origin; cell positions
+  are zero-based and have no geometry payload.
+- [`src/server/pane_input.rs`](https://github.com/herdrdev/herdr/blob/b99002ac99b09e00b4ca692436cb15a6b0d676f1/src/server/pane_input.rs):
+  the runtime encodes semantic mouse input for the child's negotiated modes.
+  Vertical wheel input uses `apply_scroll`; the runtime decides whether the
+  child consumes it.
+
+Studio crops each endpoint pane before displaying it. It negotiates xterm
+cell-based SGR drag reporting (`1002` + `1006`), so subtracting one from incoming
+SGR coordinates already gives pane-local cells; adding the tab offset would be
+incorrect. Full surfaces and patches carry each pane's `mouse_reporting` flag.
+The bridge forwards that flag only on endpoint terminal frames, checks mouse
+input against the current target pane's mode and bounds, and keeps history on
+`pane.scroll` when the app is not consuming mouse. A press must begin inside the
+crop; its subsequent drag/release stays owned by that pane and clamps to the crop
+edge even when the browser canvas is larger. Reporting changes and session close
+cancel gesture ownership. Half-page keyboard/mobile shortcuts carry explicit
+history intent: endpoint sessions use `pane.scroll`, while legacy connections
+retain their original Wheel source and line count.
+
+Browser selection uses xterm's native escape: **Option-drag on macOS**,
+**Shift-drag elsewhere**. Ordinary output uses an unmodified drag. Copy uses the
+existing browser copy handler. While an endpoint selection or selection drag is
+active, rendering pauses and only the latest full repaint is retained. Clearing
+the selection catches up. Reporting metadata still updates immediately; xterm
+mode activation waits until selection clears because activation clears xterm's
+selection. Pane/session changes discard pending presentation state. These frames
+contain complete cell repaints, not incremental PTY output or clipboard controls.
+
+If a repaint is already queued in xterm, selection initiation waits briefly for
+its public `write` completion callback and selects the newly drained frame. The
+original press and latest move/release are replayed locally, including short
+clicks/drags released before completion. Selection intent immediately stops new
+repaint submissions, so continuous output cannot delay initiation indefinitely.
+Only one write and the newest pending frame are retained. The first release
+freezes the captured gesture; later hover/release events remain native. A new
+native press anywhere cancels obsolete replay before sibling document listeners
+start. Blur or a pane/session reset cancels deferred initiation. Reset retains
+any physical write gate until its completion, including while reporting metadata
+is unknown; disposal prevents callbacks from reviving a dead presentation. Replay uses
+xterm's selection escape if reporting changed and cannot send application input.
+It does not replay clipboard actions or preserve privileged browser activation.
+
+Pixel mouse and other keyboard protocols are not part of this change. Legacy
+X10 byte mouse reports are not negotiated on the endpoint browser path.
+
+## Automated verification actually run
+
+`bun run precommit` and `bun run build:web` passed. Focused tests cover semantic
+wire fields, modifiers, click/drag/release/wheels, split sequences, invalid
+reports, pane bounds/isolation, full/patch mode changes, bridge ownership,
+selection routing, latest-frame coalescing, lifecycle reset and xterm mode changes.
+Existing legacy bridge, selection guard, scrolling and repaint tests also pass.
+
+An isolated **real Herdr 0.9.0 / protocol 22** server and built Studio frontend
+were exercised with a raw-mode Python child and headless Chromium on macOS:
+
+- Child received exact expected click, drag, release and both vertical wheel
+  reports from semantic input, including the original one-based VT coordinates.
+- Browser clicks, drags and both wheel directions reached that child through the
+  production TerminalView, WebSocket bridge and endpoint encoder.
+- Option-drag produced nonempty copied text; after 800 ms of streaming output,
+  copy returned the identical text and no selection gesture leaked into app input.
+- Disabling application mouse reporting during selection preserved copied text.
+  Escape cleared selection and resumed presentation; wheels then used the history
+  RPC instead of terminal input. Window blur ended native selection dragging
+  without extending the selection on later pointer movement.
+
+Only disposable test processes were stopped; the user's Herdr sessions were not
+used.
+
+### Independent-review P1 regression round
+
+All three source-backed findings were reproduced as failing tests before fixing
+them. After the fix, `bun run precommit` passed with **1091 tests passed, one
+existing live-SSH skip, zero failures**, and `bun run build:web` passed.
+
+- An 8x3 fixture accepts Down at (8,3), then clamps Drag/Up at (9,3) to the pane
+  edge. Outside initial presses cannot acquire ownership; mode changes cancel
+  ownership and events never target the neighboring pane.
+- Deterministic asynchronous tests cover an outstanding repaint, immediate
+  selection intent, latest-frame retention, parser completion, cancellation and
+  stale callbacks. The actual pinned xterm parser is also exercised.
+- Keyboard/mobile half-page tests and bridge wire tests verify coordinate-less
+  endpoint history while reporting is enabled and unchanged legacy Wheel bytes.
+- Chromium additionally received controlled full terminal frames through the
+  production WebSocket event handler while a test timer shim held zero-delay
+  callbacks. A native down/move/up completed before xterm parsed B; replay then
+  selected B, not prior A or pending C, despite queued mode activation. Later D
+  output did not change copied text or send app input. A completed short click
+  preserved down/up, button and click count; blur canceled a deferred drag.
+
+These browser race checks use public DOM/WebSocket/timer APIs, not private xterm
+parser hooks. The real Herdr smoke checks above were rerun against the fixed
+build. This was scripted validation, **not manual Vim/lazygit or Safari
+verification**.
+
+### Second review round and final reset verification
+
+The post-release hover/sibling replay and reset/write-gate failures were reproduced
+before further edits. The current focused suite passes **75 tests**; precommit
+passes **1095 tests, one existing live-SSH skip, zero failures**; the web build and
+asset budget pass. Added regressions exercise real xterm reset with reporting on
+and off, serialization across reset, and disposal before physical completion.
+
+The final two-pane Chromium run used a copied build with an observer at the
+supported `Terminal.write` callback boundary (the original delegate unchanged),
+public buffer reads and held timer callbacks. Hover after release, cancellation
+by a new outside press, and a sibling app drag passed. With A's queued write
+observably pending, B received exactly the baseline Down/Drag/Up coordinates,
+including one release, and no stale synthetic A events. The reporting-enabled
+reset scenario also passed.
+
+**The browser suite did not pass overall.** The reporting-disabled reset case
+copied B where the fixture expected no selection before its explicit drain.
+The write was proven pending before reset, but callback status at the later
+native press was not recorded: this does not establish that a physical write
+was still pending when selection began, nor prove a remaining production defect.
+That historical result remains inconclusive, not retrospectively passing.
+
+A separate focused Chromium diagnostic then recorded public write completion,
+resize calls and native mouse events with timestamps. After same-terminal reset
+with reporting disabled, B was still pending and A visible at native mousedown.
+Selection stayed empty through mouseup; only B's completion triggered replay and
+selected B. Later C preserved that copied text, the same terminal remained
+connected, and no application input was emitted. Unchanged-size browser resize
+calls returned without draining B; the earlier failure's cause is not established.
+No production code changed for this diagnostic.
+
+Final independent review confirmed both fixes and found no remaining issues,
+with the manual verification gaps below retained.
+
+## Manual checks still to run on Herdr 0.9.0
+
+Use a disposable workspace with the default endpoint path enabled:
+
+1. Start `vim -Nu NONE`, run `:set mouse=a ttymouse=sgr`, insert several lines,
+   and test click placement, left-button dragging, release, and wheel directions.
+   Repeat in `lazygit` using a disposable Git repository.
+2. Split the tab horizontally and vertically. In each pane, click the first and
+   last content cells and drag/wheel without moving the neighboring app. Repeat
+   after switching the active pane and resizing.
+3. Use Option-drag (macOS) or Shift-drag (other platforms) over a mouse-aware app;
+   copy with Cmd+C/Ctrl+C. Repeat an ordinary selection in a shell emitting
+   continuous output. Selected visible text must remain unchanged and copyable;
+   clear the selection to see the latest output.
+4. Exit the mouse-aware app. Wheel must browse server history instead of sending
+   mouse escape text to the shell. Re-enter the app and verify routing changes
+   back. Repeat with selection held during the mode change, and reconnect or
+   change panes before clearing it to check for stale output.
+5. Repeat selection/release-outside-window checks in Safari. Run Studio with
+   `HERDR_GUI_DISABLE_ENDPOINT=1` and confirm the previous legacy terminal
+   selection, copy and wheel behavior remains unchanged.

--- a/server/src/bridge/endpoint-client.test.ts
+++ b/server/src/bridge/endpoint-client.test.ts
@@ -70,7 +70,12 @@ function writeFrame(w: BinWriter, frame: FrameData) {
   w.bytes(Buffer.alloc(0)); // graphics
 }
 
-function writePane(w: BinWriter, paneId: string, focused = true) {
+function writePane(
+  w: BinWriter,
+  paneId: string,
+  focused = true,
+  mouseReporting = false,
+) {
   w.string(paneId);
   w.varint(1); // content_revision
   for (const rect of [
@@ -85,7 +90,7 @@ function writePane(w: BinWriter, paneId: string, focused = true) {
   w.bool(false); // scrollbar_rect
   w.bool(false); // scroll metrics
   w.bool(focused);
-  w.bool(false); // mouse_reporting
+  w.bool(mouseReporting); // mouse_reporting
   w.bool(false); // sgr_pixel_mouse
   w.bool(false); // alternate_screen_active
   w.varint(0); // pixel_width
@@ -115,6 +120,7 @@ function patchFrame(payload: {
   surfaceRevision: number;
   rows: Array<{ x: number; y: number; cells: CellData[] }>;
   cursor?: { x: number; y: number; visible: boolean; shape: number };
+  mouseReporting?: boolean;
 }): Buffer {
   const w = new BinWriter();
   w.variant(19); // PaneSurfacePatch
@@ -130,7 +136,7 @@ function patchFrame(payload: {
     for (const c of row.cells) writeCell(w, c);
   }
   w.varint(1);
-  writePane(w, "w1:p1");
+  writePane(w, "w1:p1", true, payload.mouseReporting);
   w.option(payload.cursor, (cur) => {
     w.varint(cur.x);
     w.varint(cur.y);
@@ -334,6 +340,7 @@ describe("EndpointClient (endpoint generation 1)", () => {
           patchFrame({
             baseSurfaceRevision: 1,
             surfaceRevision: 2,
+            mouseReporting: true,
             rows: [{ x: 2, y: 1, cells: [cell("h"), cell("i")] }],
             cursor: { x: 4, y: 1, visible: true, shape: 1 },
           }),
@@ -365,9 +372,11 @@ describe("EndpointClient (endpoint generation 1)", () => {
         innerRect: { x: 0, y: 0, width: 10, height: 5 },
         scroll: null,
         focused: true,
+        mouseReporting: false,
       },
     ]);
     const patched = surfaces[1];
+    expect(patched.panes[0].mouseReporting).toBe(true);
     expect(patched.surfaceRevision).toBe(2);
     expect(patched.frame.cells[12].symbol).toBe("h");
     expect(patched.frame.cells[13].symbol).toBe("i");

--- a/server/src/bridge/endpoint-client.ts
+++ b/server/src/bridge/endpoint-client.ts
@@ -66,6 +66,7 @@ export interface PaneSurfacePaneMeta {
     viewportRows: number;
   } | null;
   focused: boolean;
+  mouseReporting: boolean;
 }
 
 export interface EndpointSurface {
@@ -476,12 +477,12 @@ function readPaneSurfacePanes(r: BinReader): PaneSurfacePaneMeta[] {
       };
     }
     const focused = r.bool();
-    r.bool(); // mouse_reporting
+    const mouseReporting = r.bool();
     r.bool(); // sgr_pixel_mouse
     r.bool(); // alternate_screen_active
     r.varint(); // pixel_width
     r.varint(); // pixel_height
-    panes[i] = { paneId, rect, innerRect, scroll, focused };
+    panes[i] = { paneId, rect, innerRect, scroll, focused, mouseReporting };
   }
   return panes;
 }

--- a/server/src/bridge/endpoint-terminal-session.test.ts
+++ b/server/src/bridge/endpoint-terminal-session.test.ts
@@ -8,6 +8,8 @@ import {
   cropFrame,
 } from "./endpoint-terminal-session";
 import type { CellData, FrameData } from "./thin-client";
+import type { ServerWebSocket } from "bun";
+import { createTerminalBridge } from "./terminal-bridge";
 
 const servers: net.Server[] = [];
 
@@ -59,7 +61,18 @@ function writeFrame(w: BinWriter, frame: FrameData) {
   w.bytes(Buffer.alloc(0));
 }
 
-function writePane(w: BinWriter, paneId: string, x = 0, y = 0) {
+type TestPane = { paneId: string; x: number; mouseReporting: boolean };
+const DEFAULT_PANES: TestPane[] = [
+  { paneId: "w1:p1", x: 0, mouseReporting: false },
+];
+
+function writePane(
+  w: BinWriter,
+  paneId: string,
+  x = 0,
+  y = 0,
+  mouseReporting = false,
+) {
   w.string(paneId);
   w.varint(1);
   for (const rect of [
@@ -77,22 +90,27 @@ function writePane(w: BinWriter, paneId: string, x = 0, y = 0) {
   w.varint(100); // max_offset_from_bottom
   w.varint(3); // viewport_rows
   w.bool(true); // focused
-  w.bool(false);
+  w.bool(mouseReporting);
   w.bool(false);
   w.bool(false);
   w.varint(0);
   w.varint(0);
 }
 
-function surfaceFrame(revision: number, frame: FrameData): Buffer {
+function surfaceFrame(
+  revision: number,
+  frame: FrameData,
+  panes = DEFAULT_PANES,
+): Buffer {
   const w = new BinWriter();
   w.variant(13);
   w.string("boot-1");
   w.varint(1);
   w.varint(revision);
   writeFrame(w, frame);
-  w.varint(1);
-  writePane(w, "w1:p1");
+  w.varint(panes.length);
+  for (const pane of panes)
+    writePane(w, pane.paneId, pane.x, 0, pane.mouseReporting);
   w.varint(0);
   w.bool(false);
   return w.toBuffer();
@@ -124,6 +142,8 @@ const WELCOME = {
 async function startSessionServer(handlers: {
   onRequest?: (method: string, params: any) => void;
   onPaneInput?: (paneId: string, reader: BinReader) => void;
+  panes?: TestPane[];
+  onConnection?: (sendSurface: (panes: TestPane[]) => void) => void;
 }) {
   const socketPath = path.join(
     tmpdir(),
@@ -131,10 +151,10 @@ async function startSessionServer(handlers: {
   );
   const frame: FrameData = {
     // Tab surface 10x5; pane w1:p1 inner rect is 1,1 8x3 => "abcdefgh" rows.
-    cells: Array.from({ length: 50 }, (_, i) =>
+    cells: Array.from({ length: handlers.panes ? 100 : 50 }, (_, i) =>
       cell(String.fromCharCode(65 + (i % 26))),
     ),
-    width: 10,
+    width: handlers.panes ? 20 : 10,
     height: 5,
     cursor: { x: 2, y: 2, visible: true, shape: 1 },
     hyperlinks: [],
@@ -142,6 +162,10 @@ async function startSessionServer(handlers: {
   const server = net.createServer((socket) => {
     let input = Buffer.alloc(0);
     let greeted = false;
+    let revision = 1;
+    handlers.onConnection?.((panes) =>
+      socket.write(encodeFrame(surfaceFrame(++revision, frame, panes))),
+    );
     socket.on("data", (chunk) => {
       input = Buffer.concat([
         input,
@@ -170,7 +194,7 @@ async function startSessionServer(handlers: {
               ),
             ),
           );
-          socket.write(encodeFrame(surfaceFrame(1, frame)));
+          socket.write(encodeFrame(surfaceFrame(1, frame, handlers.panes)));
           continue;
         }
         if (variant === 15) {
@@ -259,6 +283,7 @@ describe("EndpointTerminalSession", () => {
     const socketPath = await startSessionServer({
       onRequest: (method, params) => requests.push({ method, params }),
       onPaneInput: (paneId, reader) => {
+        expect(paneId).toBe("w1:p1");
         const count = reader.varint();
         for (let i = 0; i < count; i++) {
           const v = reader.variant();
@@ -285,6 +310,246 @@ describe("EndpointTerminalSession", () => {
     });
     session.close();
   });
+});
+
+test("endpoint mouse stays pane-local and mode changes route application input versus history", async () => {
+  const panes: TestPane[] = [
+    { paneId: "w1:p1", x: 0, mouseReporting: false },
+    { paneId: "w1:p2", x: 10, mouseReporting: true },
+  ];
+  const inputs: Array<{
+    paneId: string;
+    kind: number;
+    column: number;
+    row: number;
+  }> = [];
+  const requests: Array<{ method: string; params: unknown }> = [];
+  const senders: Array<(panes: TestPane[]) => void> = [];
+  const socketPath = await startSessionServer({
+    panes,
+    onConnection: (send) => senders.push(send),
+    onRequest: (method, params) => requests.push({ method, params }),
+    onPaneInput: (paneId, reader) => {
+      const count = reader.varint();
+      for (let i = 0; i < count; i++) {
+        expect(reader.variant()).toBe(2);
+        const kind = reader.variant();
+        if (kind <= 2) reader.variant();
+        expect(reader.variant()).toBe(0);
+        const column = reader.varint();
+        const row = reader.varint();
+        expect(reader.bool()).toBe(false);
+        reader.u8();
+        reader.varint();
+        inputs.push({ paneId, kind, column, row });
+      }
+    },
+  });
+  const left = new EndpointTerminalSession(
+    socketPath,
+    "term-left",
+    async () => "w1:p1",
+  );
+  const right = new EndpointTerminalSession(
+    socketPath,
+    "term-right",
+    async () => "w1:p2",
+  );
+  const modes: boolean[] = [];
+  right.on("terminal", (frame) => modes.push(frame.mouseReporting));
+  try {
+    await left.connect(20, 5);
+    await right.connect(20, 5);
+    const clickDragWheel = Buffer.from(
+      "\x1b[<0;2;3M\x1b[<32;3;2M\x1b[<0;3;2m\x1b[<64;8;3M",
+    );
+    left.input(clickDragWheel); // no mouse reporting in this pane
+    right.input(clickDragWheel);
+    right.input(Buffer.from("\x1b[<0;9;1M\x1b[<0;1;4M")); // outside 8x3 crop
+    right.scroll("down", 3, 1, 2);
+    left.scroll("up", 3, 1, 2);
+    await Bun.sleep(40);
+    expect(inputs).toEqual([
+      { paneId: "w1:p2", kind: 0, column: 1, row: 2 },
+      { paneId: "w1:p2", kind: 2, column: 2, row: 1 },
+      { paneId: "w1:p2", kind: 1, column: 2, row: 1 },
+      { paneId: "w1:p2", kind: 4, column: 7, row: 2 },
+      { paneId: "w1:p2", kind: 5, column: 1, row: 2 },
+    ]);
+    expect(requests).toContainEqual({
+      method: "pane.scroll",
+      params: { pane_id: "w1:p1", offset_from_bottom: 3 },
+    });
+    // Disable reporting mid-report; no stale mouse is delivered after the mode change.
+    right.input(Buffer.from("\x1b[<0;"));
+    const disabled = panes.map((pane) => ({ ...pane, mouseReporting: false }));
+    for (const send of senders) send(disabled);
+    await Bun.sleep(40);
+    right.input(Buffer.from("2;3M"));
+    right.scroll("up", 4, 1, 2);
+    right.scroll("up", Number.NaN);
+    await Bun.sleep(40);
+    expect(inputs).toHaveLength(5);
+    expect(modes).toContain(true);
+    expect(modes.at(-1)).toBe(false);
+    expect(requests).toContainEqual({
+      method: "pane.scroll",
+      params: { pane_id: "w1:p2", offset_from_bottom: 4 },
+    });
+    for (const send of senders) send(panes);
+    await Bun.sleep(40);
+    right.input(Buffer.from("\x1b[<0;1;1M"));
+    left.input(Buffer.from("\x1b[<0;1;1M"));
+    await Bun.sleep(40);
+    expect(inputs.at(-1)).toEqual({
+      paneId: "w1:p2",
+      kind: 0,
+      column: 0,
+      row: 0,
+    });
+    expect(inputs).toHaveLength(6);
+  } finally {
+    left.close();
+    right.close();
+  }
+});
+
+test("accepted presses retain clamped drag and release ownership outside the pane crop", async () => {
+  const panes: TestPane[] = [
+    { paneId: "w1:p1", x: 0, mouseReporting: true },
+    { paneId: "w1:p2", x: 10, mouseReporting: true },
+  ];
+  const inputs: Array<{
+    paneId: string;
+    kind: number;
+    column: number;
+    row: number;
+  }> = [];
+  let sendSurface!: (panes: TestPane[]) => void;
+  const socketPath = await startSessionServer({
+    panes,
+    onConnection: (send) => {
+      sendSurface = send;
+    },
+    onPaneInput: (paneId, reader) => {
+      const count = reader.varint();
+      for (let i = 0; i < count; i++) {
+        expect(reader.variant()).toBe(2);
+        const kind = reader.variant();
+        reader.variant(); // button
+        expect(reader.variant()).toBe(0);
+        const column = reader.varint(),
+          row = reader.varint();
+        reader.bool();
+        reader.u8();
+        reader.varint();
+        inputs.push({ paneId, kind, column, row });
+      }
+    },
+  });
+  const session = new EndpointTerminalSession(
+    socketPath,
+    "right",
+    async () => "w1:p2",
+  );
+  try {
+    await session.connect(20, 5);
+    session.input(Buffer.from("\x1b[<0;8;3M\x1b[<32;9;3M\x1b[<0;9;3m"));
+    await Bun.sleep(40);
+    expect(inputs).toEqual(
+      [0, 2, 1].map((kind) => ({ paneId: "w1:p2", kind, column: 7, row: 2 })),
+    );
+    session.input(Buffer.from("\x1b[<0;9;3M\x1b[<32;8;3M\x1b[<0;8;3m"));
+    await Bun.sleep(40);
+    expect(inputs).toHaveLength(3); // an outside press cannot acquire ownership
+    session.input(Buffer.from("\x1b[<0;8;3M"));
+    await Bun.sleep(40);
+    sendSurface(panes.map((pane) => ({ ...pane, mouseReporting: false })));
+    await Bun.sleep(40);
+    sendSurface(panes);
+    await Bun.sleep(40);
+    session.input(Buffer.from("\x1b[<32;9;3M\x1b[<0;9;3m"));
+    await Bun.sleep(40);
+    expect(inputs).toHaveLength(4); // mode changes cancel gesture ownership
+  } finally {
+    session.close();
+  }
+});
+
+test("terminal bridge carries endpoint mouse state and targets each attached terminal explicitly", async () => {
+  const inputs: string[] = [];
+  const scrollRequests: unknown[] = [];
+  const socketPath = await startSessionServer({
+    onRequest: (method, params) => {
+      if (method === "pane.scroll") scrollRequests.push(params);
+    },
+    panes: [
+      { paneId: "w1:p1", x: 0, mouseReporting: true },
+      { paneId: "w1:p2", x: 10, mouseReporting: true },
+    ],
+    onPaneInput: (paneId) => inputs.push(paneId),
+  });
+  const frames: Array<{ terminal_id: string; mouse_reporting: boolean }> = [];
+  const errors: string[] = [];
+  const ws = {} as ServerWebSocket<unknown>;
+  const bridge = createTerminalBridge({
+    clientSocketPath: socketPath,
+    herdrProtocol: async () => 22,
+    lookupPaneId: async (id) => (id === "left" ? "w1:p1" : "w1:p2"),
+    safeSend: (_ws, payload) => {
+      const message = JSON.parse(payload);
+      if (message.terminal) frames.push(message.terminal);
+      return true;
+    },
+    clientLabel: () => "test",
+    markRpcError: (_ws, _id, detail) => errors.push(detail ?? "error"),
+  });
+  try {
+    for (const terminalId of ["left", "right"]) {
+      await bridge.handleTerminalRpc(ws, "attach", "terminal.attach", {
+        terminal_id: terminalId,
+        cols: 20,
+        rows: 5,
+        relay_active: false,
+      });
+    }
+    expect(frames).toContainEqual(
+      expect.objectContaining({ terminal_id: "left", mouse_reporting: true }),
+    );
+    expect(frames).toContainEqual(
+      expect.objectContaining({ terminal_id: "right", mouse_reporting: true }),
+    );
+    for (const terminalId of ["left", "right", "unattached"]) {
+      await bridge.handleTerminalRpc(ws, "input", "terminal.input", {
+        terminal_id: terminalId,
+        data: Buffer.from("\x1b[<0;2;2M").toString("base64"),
+      });
+    }
+    await Bun.sleep(40);
+    expect(inputs).toEqual(["w1:p1", "w1:p2"]);
+    expect(errors).toHaveLength(1);
+    for (const [direction, source] of [
+      ["up", "history"],
+      ["down", "history"],
+      ["up", "page-key"],
+    ]) {
+      await bridge.handleTerminalRpc(ws, "history", "terminal.scroll", {
+        terminal_id: "right",
+        direction,
+        lines: 7,
+        source,
+      });
+    }
+    await Bun.sleep(40);
+    expect(scrollRequests).toEqual([
+      { pane_id: "w1:p2", offset_from_bottom: 7 },
+      { pane_id: "w1:p2", offset_from_bottom: 0 },
+      { pane_id: "w1:p2", offset_from_bottom: 7 },
+    ]);
+    expect(inputs).toHaveLength(2);
+  } finally {
+    bridge.dispose();
+  }
 });
 
 describe("cropFrame", () => {

--- a/server/src/bridge/endpoint-terminal-session.ts
+++ b/server/src/bridge/endpoint-terminal-session.ts
@@ -4,7 +4,7 @@ import { frameToAnsi } from "./frame-to-ansi";
 import type { FrameData } from "./thin-client";
 import type { Logger } from "../utils/logger";
 import { silentLogger } from "../utils/logger";
-import { VtInputClassifier } from "./vt-input-classifier";
+import { MOUSE_KIND, VtInputClassifier } from "./vt-input-classifier";
 
 const ESC_FLUSH_MS = 25;
 const FIRST_SURFACE_WAIT_MS = 10_000;
@@ -23,6 +23,7 @@ const FIRST_SURFACE_WAIT_MS = 10_000;
 export class EndpointTerminalSession extends EventEmitter {
   private client: EndpointClient;
   private classifier = new VtInputClassifier();
+  private pressedMouseButtons = new Set<number>();
   private escFlushTimer: ReturnType<typeof setTimeout> | null = null;
   private paneId: string | null = null;
   private lastScroll: {
@@ -44,6 +45,7 @@ export class EndpointTerminalSession extends EventEmitter {
     this.client.on("surface", (s) => this.onSurface(s));
     this.client.on("error", (e) => this.emit("error", e));
     this.client.on("close", () => {
+      this.pressedMouseButtons.clear();
       this.closed = true;
       this.emit("close");
     });
@@ -132,6 +134,7 @@ export class EndpointTerminalSession extends EventEmitter {
   private onSurface(surface: EndpointSurface) {
     if (!this.paneId) return; // connect() replays once the lookup resolves
     const pane = surface.panes.find((p) => p.paneId === this.paneId);
+    if (!pane?.mouseReporting) this.pressedMouseButtons.clear();
     if (!pane) return;
     this.lastScroll = pane.scroll
       ? {
@@ -147,6 +150,7 @@ export class EndpointTerminalSession extends EventEmitter {
       width: cropped.width,
       height: cropped.height,
       full: true,
+      mouseReporting: pane.mouseReporting,
       bytes,
     });
   }
@@ -156,8 +160,40 @@ export class EndpointTerminalSession extends EventEmitter {
   }
 
   input(data: Buffer) {
-    if (!this.paneId) return;
-    const events = this.classifier.feed(data);
+    if (!this.paneId || this.closed) return;
+    const pane = this.latestSurface()?.panes.find(
+      (p) => p.paneId === this.paneId,
+    );
+    const events = this.classifier.feed(data).filter((event) => {
+      if (event.type !== "mouse") return true;
+      if (
+        !pane?.mouseReporting ||
+        pane.innerRect.width < 1 ||
+        pane.innerRect.height < 1
+      ) {
+        this.pressedMouseButtons.clear();
+        return false;
+      }
+      const inside =
+        event.column < pane.innerRect.width &&
+        event.row < pane.innerRect.height;
+      if (event.kind === MOUSE_KIND.Down) {
+        this.pressedMouseButtons.delete(event.button!);
+        if (inside) this.pressedMouseButtons.add(event.button!);
+        return inside;
+      }
+      if (event.kind === MOUSE_KIND.Drag || event.kind === MOUSE_KIND.Up) {
+        if (!this.pressedMouseButtons.has(event.button!)) return false;
+        // The browser canvas can exceed the crop. A gesture that began inside
+        // still owns its release when it crosses into that blank canvas area.
+        event.column = Math.min(event.column, pane.innerRect.width - 1);
+        event.row = Math.min(event.row, pane.innerRect.height - 1);
+        if (event.kind === MOUSE_KIND.Up)
+          this.pressedMouseButtons.delete(event.button!);
+        return true;
+      }
+      return inside;
+    });
     this.client.sendPaneInput(this.paneId, events);
     if (this.escFlushTimer) clearTimeout(this.escFlushTimer);
     this.escFlushTimer = setTimeout(() => {
@@ -168,10 +204,44 @@ export class EndpointTerminalSession extends EventEmitter {
     }, ESC_FLUSH_MS);
   }
 
-  // Extra ThinClient scroll params (column/row/source) are accepted by the
-  // bridge but unused here: endpoint scrolls by absolute offset.
-  scroll(direction: "up" | "down", lines: number) {
-    if (!this.paneId || !this.lastScroll) return;
+  scroll(
+    direction: "up" | "down",
+    lines: number,
+    column?: number | null,
+    row?: number | null,
+    source: "wheel" | "page-key" = "wheel",
+  ) {
+    if (!this.paneId || !Number.isFinite(lines) || lines <= 0) return;
+    lines = Math.max(1, Math.min(65535, Math.floor(lines)));
+    const pane = this.latestSurface()?.panes.find(
+      (p) => p.paneId === this.paneId,
+    );
+    // Touch scrolling uses the same bridge RPC as wheels. A page key remains
+    // an explicit history action, as it was before endpoint mouse support.
+    if (source === "wheel" && pane?.mouseReporting) {
+      if (
+        !Number.isInteger(column) ||
+        !Number.isInteger(row) ||
+        column! < 0 ||
+        row! < 0 ||
+        column! >= pane.innerRect.width ||
+        row! >= pane.innerRect.height
+      )
+        return;
+      this.client.sendPaneInput(this.paneId, [
+        {
+          type: "mouse",
+          kind:
+            direction === "up" ? MOUSE_KIND.ScrollUp : MOUSE_KIND.ScrollDown,
+          column: column!,
+          row: row!,
+          modifiers: 0,
+          lines,
+        },
+      ]);
+      return;
+    }
+    if (!this.lastScroll) return;
     const delta = direction === "up" ? lines : -lines;
     const offset = Math.max(
       0,
@@ -197,6 +267,7 @@ export class EndpointTerminalSession extends EventEmitter {
   close() {
     if (this.closed) return;
     this.closed = true;
+    this.pressedMouseButtons.clear();
     if (this.escFlushTimer) clearTimeout(this.escFlushTimer);
     this.client.close();
   }

--- a/server/src/bridge/frame-to-ansi.test.ts
+++ b/server/src/bridge/frame-to-ansi.test.ts
@@ -55,6 +55,22 @@ describe("frameToAnsi", () => {
     expect(out).toContain("你x");
   });
 
+  test.each(["中", "🙂", "👩‍💻", "🇨🇳", "ｶﾞ"])(
+    "skips unmarked padding after %s without removing a real space",
+    (symbol) => {
+      const out = frameToAnsi(
+        frame([cell(symbol), cell(" "), cell(" "), cell("x")], 4, 1),
+      );
+      expect(out).toContain(`${symbol} x`);
+      expect(out).not.toContain(`${symbol}  x`);
+    },
+  );
+
+  test("does not skip the cell after a narrow combining grapheme", () => {
+    const out = frameToAnsi(frame([cell("e\u0301"), cell("x")], 2, 1));
+    expect(out).toContain("e\u0301x");
+  });
+
   test("trims trailing default blanks but keeps styled blanks", () => {
     const styledBlank = cell(" ", { bg: 0x00_00_00_03 });
     const out = frameToAnsi(

--- a/server/src/bridge/frame-to-ansi.test.ts
+++ b/server/src/bridge/frame-to-ansi.test.ts
@@ -52,7 +52,7 @@ describe("frameToAnsi", () => {
     const out = frameToAnsi(
       frame([cell("你"), cell("", { skip: true }), cell("x")], 3, 1),
     );
-    expect(out).toContain("你x");
+    expect(out).toContain("你\x1b[3Gx");
   });
 
   test.each(["中", "🙂", "👩‍💻", "🇨🇳", "ｶﾞ"])(
@@ -61,7 +61,7 @@ describe("frameToAnsi", () => {
       const out = frameToAnsi(
         frame([cell(symbol), cell(" "), cell(" "), cell("x")], 4, 1),
       );
-      expect(out).toContain(`${symbol} x`);
+      expect(out).toContain(`${symbol}\x1b[3G x`);
       expect(out).not.toContain(`${symbol}  x`);
     },
   );

--- a/server/src/bridge/frame-to-ansi.ts
+++ b/server/src/bridge/frame-to-ansi.ts
@@ -83,7 +83,7 @@ export function frameToAnsi(frame: FrameData): string {
     let linkOpen = false;
     for (let x = 0; x < rowEnd; x++) {
       const cell = frame.cells[rowStart + x];
-      if (cell.skip) continue; // spacer after a wide grapheme
+      if (cell.skip) continue;
       const key = styleKey(cell);
       if (key !== lastStyle) {
         if (linkOpen) {
@@ -102,6 +102,9 @@ export function frameToAnsi(frame: FrameData): string {
         lastStyle = key;
       }
       out += cell.symbol;
+      // Herdr's wide-character padding is often a normal blank (skip=false).
+      // The grapheme already advances xterm across those cells.
+      x += Math.max(0, Bun.stringWidth(cell.symbol) - 1);
     }
     if (linkOpen) out += "\x1b]8;;\x1b\\";
     if (y < frame.height - 1) out += "\r\n";

--- a/server/src/bridge/frame-to-ansi.ts
+++ b/server/src/bridge/frame-to-ansi.ts
@@ -103,8 +103,10 @@ export function frameToAnsi(frame: FrameData): string {
       }
       out += cell.symbol;
       // Herdr's wide-character padding is often a normal blank (skip=false).
-      // The grapheme already advances xterm across those cells.
-      x += Math.max(0, Bun.stringWidth(cell.symbol) - 1);
+      const padding = Math.max(0, Bun.stringWidth(cell.symbol) - 1);
+      x += padding;
+      // xterm can render the same grapheme narrower; anchor the next source cell.
+      if (padding && x + 1 < rowEnd) out += `\x1b[${x + 2}G`;
     }
     if (linkOpen) out += "\x1b]8;;\x1b\\";
     if (y < frame.height - 1) out += "\r\n";

--- a/server/src/bridge/terminal-bridge.test.ts
+++ b/server/src/bridge/terminal-bridge.test.ts
@@ -6,6 +6,45 @@ import { tmpdir } from "node:os";
 import { BinReader, BinWriter, encodeFrame } from "./bincode";
 import { createTerminalBridge } from "./terminal-bridge";
 
+test("explicit half-page history retains legacy Wheel source and line count", async () => {
+  const sources: number[] = [];
+  const socketPath = await startThinServer({
+    onScroll: (reader) => {
+      sources.push(reader.variant());
+      expect(reader.variant()).toBe(0); // Up
+      expect(reader.varint()).toBe(14);
+      expect(reader.bool()).toBe(false); // no column
+      expect(reader.bool()).toBe(false); // no row
+    },
+  });
+  const ws = {} as ServerWebSocket<unknown>;
+  const bridge = createTerminalBridge({
+    clientSocketPath: socketPath,
+    herdrProtocol: async () => 17,
+    safeSend: () => true,
+    clientLabel: () => "test",
+    markRpcError: () => {},
+  });
+  try {
+    await bridge.handleTerminalRpc(ws, "attach", "terminal.attach", {
+      terminal_id: "legacy",
+      cols: 80,
+      rows: 30,
+      relay_active: false,
+    });
+    await bridge.handleTerminalRpc(ws, "scroll", "terminal.scroll", {
+      terminal_id: "legacy",
+      direction: "up",
+      lines: 14,
+      source: "history",
+    });
+    await Bun.sleep(40);
+    expect(sources).toEqual([0]);
+  } finally {
+    bridge.dispose();
+  }
+});
+
 const servers: net.Server[] = [];
 const serverConnections = new Set<net.Socket>();
 
@@ -51,6 +90,7 @@ async function startThinServer(
     directFrameDelayMs?: number;
     skipDirectFrame?: boolean;
     onDirectAttach?: (socket: net.Socket) => void;
+    onScroll?: (reader: BinReader) => void;
     tracker?: {
       appConnects: number;
       appCloses: number;
@@ -173,6 +213,7 @@ async function startThinServer(
           }
         } else if (variant === 6) {
           options.tracker?.events.push("scroll");
+          options.onScroll?.(reader);
         }
       }
     });

--- a/server/src/bridge/terminal-bridge.ts
+++ b/server/src/bridge/terminal-bridge.ts
@@ -516,6 +516,9 @@ export function createTerminalBridge(args: {
           width: t.width,
           height: t.height,
           full: t.full,
+          ...(typeof t.mouseReporting === "boolean"
+            ? { mouse_reporting: t.mouseReporting }
+            : {}),
           bytes: Buffer.from(t.bytes).toString("base64"),
         },
       });
@@ -821,7 +824,14 @@ export function createTerminalBridge(args: {
         const column =
           typeof params.column === "number" ? Number(params.column) : null;
         const row = typeof params.row === "number" ? Number(params.row) : null;
-        const source = params.source === "page-key" ? "page-key" : "wheel";
+        // Explicit half-page shortcuts use pane.scroll on endpoints, while
+        // legacy AttachScroll keeps its original Wheel source and line count.
+        const source =
+          params.source === "page-key" ||
+          (params.source === "history" &&
+            thin instanceof EndpointTerminalSession)
+            ? "page-key"
+            : "wheel";
         thin.scroll(direction, lines, column, row, source);
         return reply({ ok: true });
       }

--- a/server/src/bridge/vt-input-classifier.test.ts
+++ b/server/src/bridge/vt-input-classifier.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { BinReader } from "./bincode";
 import {
   KEY,
+  MOUSE_KIND,
   MOD_ALT,
   MOD_CONTROL,
   MOD_SHIFT,
@@ -186,6 +187,119 @@ describe("VtInputClassifier", () => {
       KEY.Esc,
       KEY.Up,
     ]);
+  });
+});
+
+describe("SGR cell mouse input", () => {
+  test("click, release, drag, motion and all wheel directions use pane-local cells", () => {
+    const reports = [
+      [0, "M", MOUSE_KIND.Down, 0],
+      [0, "m", MOUSE_KIND.Up, 0],
+      [1, "M", MOUSE_KIND.Down, 2],
+      [2, "m", MOUSE_KIND.Up, 1],
+      [32, "M", MOUSE_KIND.Drag, 0],
+      [34, "M", MOUSE_KIND.Drag, 1],
+      [35, "M", MOUSE_KIND.Moved, undefined],
+      [64, "M", MOUSE_KIND.ScrollUp, undefined],
+      [65, "M", MOUSE_KIND.ScrollDown, undefined],
+      [66, "M", MOUSE_KIND.ScrollLeft, undefined],
+      [67, "M", MOUSE_KIND.ScrollRight, undefined],
+    ] as const;
+    for (const [code, final, kind, button] of reports) {
+      expect(feed(`\x1b[<${code};8;3${final}`)).toEqual([
+        {
+          type: "mouse",
+          kind,
+          ...(button === undefined ? {} : { button }),
+          column: 7,
+          row: 2,
+          modifiers: 0,
+          lines: 1,
+        },
+      ]);
+    }
+    expect(feed("\x1b[<28;1;1M")[0]).toMatchObject({
+      column: 0,
+      row: 0,
+      modifiers: MOD_SHIFT | MOD_ALT | MOD_CONTROL,
+    });
+  });
+
+  test("every split point buffers the report without leaking text; paste stays paste", () => {
+    const report = Buffer.from("\x1b[<32;256;12M");
+    for (let i = 1; i < report.length; i++) {
+      const classifier = new VtInputClassifier();
+      expect(classifier.feed(report.subarray(0, i))).toEqual([]);
+      // The existing idle timer intentionally flushes a lone ESC as a key.
+      if (i > 1) expect(classifier.flush()).toEqual([]);
+      expect(classifier.feed(report.subarray(i))).toEqual(
+        feed(report.toString()),
+      );
+    }
+    expect(feed(`a${report.toString()}b`).map((event) => event.type)).toEqual([
+      "text",
+      "mouse",
+      "text",
+    ]);
+    expect(feed(`\x1b[200~${report.toString()}\x1b[201~`)).toEqual([
+      { type: "paste", text: report.toString() },
+    ]);
+  });
+
+  test("rejects malformed fields, unsupported buttons, impossible kinds and out-of-range cells", () => {
+    for (const report of [
+      "<0;0;1M",
+      "<-1;1;1M",
+      "<0;-1;1M",
+      "<0; 1;1M",
+      "<0;1;0M",
+      "<0;65537;1M",
+      "<0;1;999999999999999999999M",
+      "<128;1;1M",
+      "<999999999999999999;1;1M",
+      "<3;1;1M",
+      "<3;1;1m",
+      "<64;1;1m",
+      "<96;1;1M",
+      "<32;1;1m",
+      "<0;;1M",
+      "<0;1;1;2M",
+      "<0:1;1;1M",
+      "<0;1;1~",
+    ]) {
+      expect(feed(`\x1b[${report}ok`)).toEqual([{ type: "text", text: "ok" }]);
+    }
+    expect(feed("\x1b[<0;1;\x1b[A")).toEqual(feed("\x1b[A"));
+    expect(feed("\x1b[<0;65536;65536M")[0]).toMatchObject({
+      column: 65535,
+      row: 65535,
+    });
+  });
+
+  test("encodes the frozen generation-1 mouse fields including absent geometry", () => {
+    // v0.9.0 protocol/wire.rs: message 13, Mouse 2, Down(Left), Cell,
+    // zero-based (1,2), geometry None, modifiers 0, lines 1.
+    expect(encodePaneInput("w1:p1", feed("\x1b[<0;2;3M")).toString("hex")).toBe(
+      "0d0577313a703101020000000102000001",
+    );
+    for (const report of ["\x1b[<1;256;3m", "\x1b[<34;2;3M", "\x1b[<80;2;3M"]) {
+      const event = feed(report)[0];
+      if (event.type !== "mouse") throw new Error("expected mouse");
+      const reader = new BinReader(encodePaneInput("other-pane", [event]));
+      expect(reader.variant()).toBe(13);
+      expect(reader.string()).toBe("other-pane");
+      expect(reader.varint()).toBe(1);
+      expect(reader.variant()).toBe(2);
+      expect(reader.variant()).toBe(event.kind);
+      if (event.kind <= MOUSE_KIND.Drag)
+        expect(reader.variant()).toBe(event.button!);
+      expect(reader.variant()).toBe(0);
+      expect(reader.varint()).toBe(event.column);
+      expect(reader.varint()).toBe(event.row);
+      expect(reader.bool()).toBe(false);
+      expect(reader.u8()).toBe(event.modifiers);
+      expect(reader.varint()).toBe(1);
+    }
   });
 });
 

--- a/server/src/bridge/vt-input-classifier.ts
+++ b/server/src/bridge/vt-input-classifier.ts
@@ -6,8 +6,8 @@ import { BinWriter } from "./bincode";
 //
 // ponytail: covers the common key space — printable text, Enter/Backspace/
 // Tab, arrows, Home/End/Insert/Delete/PageUp/PageDown, F1-F12, Ctrl+letter,
-// Alt+char, modified CSI keys, bracketed paste. Kitty keyboard protocol and
-// mouse SGR are not classified (dropped); add when a pane app needs them.
+// Alt+char, modified CSI keys, bracketed paste and SGR cell mouse reports.
+// Kitty keyboard protocol and pixel mouse are not supported.
 
 // crossterm KeyModifiers bits used on the wire.
 export const MOD_SHIFT = 0x1;
@@ -37,7 +37,30 @@ export const KEY = {
   Null: 17,
 } as const;
 
+// Herdr v0.9.0 src/protocol/wire.rs (endpoint generation 1 frozen order).
+export const MOUSE_KIND = {
+  Down: 0,
+  Up: 1,
+  Drag: 2,
+  Moved: 3,
+  ScrollUp: 4,
+  ScrollDown: 5,
+  ScrollLeft: 6,
+  ScrollRight: 7,
+} as const;
+
+export type PaneMouseEvent = {
+  type: "mouse";
+  kind: number;
+  button?: number; // ClientMouseButton: Left=0, Right=1, Middle=2
+  column: number; // zero-based, relative to the cropped pane content
+  row: number;
+  modifiers: number;
+  lines: number;
+};
+
 export type PaneInputEvent =
+  | PaneMouseEvent
   | {
       type: "key";
       code: number;
@@ -77,6 +100,16 @@ export function encodePaneInput(
       w.bool(false); // tracks_release
       w.bool(false); // physical_key_id: None
       w.bool(false); // windows_record: None
+    } else if (e.type === "mouse") {
+      w.variant(2); // ClientPaneInputEvent::Mouse
+      w.variant(e.kind);
+      if (e.kind <= MOUSE_KIND.Drag) w.variant(e.button!);
+      w.variant(0); // ClientMousePosition::Cell
+      w.varint(e.column);
+      w.varint(e.row);
+      w.bool(false); // geometry: None (only needed for pixels)
+      w.u8(e.modifiers);
+      w.varint(e.lines);
     } else if (e.type === "text") {
       w.variant(1); // ClientPaneInputEvent::TextCommit
       w.string(e.text);
@@ -286,6 +319,22 @@ export class VtInputClassifier {
     if (i + 1 >= buf.length) return null; // lone ESC so far
     const second = buf[i + 1];
 
+    if (second === 0x5b && buf[i + 2] === 0x3c) {
+      // Keep malformed SGR mouse fields out of the text/key path too. A new
+      // ESC cancels a truncated report and is reprocessed independently.
+      let j = i + 3;
+      while (j < buf.length && (buf[j] < 0x40 || buf[j] > 0x7e)) {
+        if (buf[j] === 0x1b) return { events: [], next: j };
+        j++;
+      }
+      if (j >= buf.length) return null;
+      const event = parseSgrMouse(
+        buf.toString("utf8", i + 2, j),
+        String.fromCharCode(buf[j]),
+      );
+      return { events: event ? [event] : [], next: j + 1 };
+    }
+
     if (second === 0x5b) {
       // CSI: ESC [ params final
       let j = i + 2;
@@ -356,6 +405,58 @@ export class VtInputClassifier {
     // ESC + control byte: treat the ESC as Esc and reprocess the byte.
     return { events: [key(KEY.Esc)], next: i + 1 };
   }
+}
+
+/** SGR is explicitly negotiated by the endpoint frontend; coordinates are cells. */
+function parseSgrMouse(params: string, final: string): PaneMouseEvent | null {
+  if ((final !== "M" && final !== "m") || !/^<\d+;\d+;\d+$/.test(params)) {
+    return null;
+  }
+  const [code, x, y] = params.slice(1).split(";").map(Number);
+  if (
+    !Number.isInteger(code) ||
+    code < 0 ||
+    code > 127 ||
+    !Number.isInteger(x) ||
+    x < 1 ||
+    x > 65536 ||
+    !Number.isInteger(y) ||
+    y < 1 ||
+    y > 65536
+  )
+    return null;
+  const button = code & 3;
+  const motion = (code & 32) !== 0;
+  const wheel = (code & 64) !== 0;
+  // Wheel releases, wheel motion and anonymous button releases are not SGR events.
+  if (
+    (wheel && (motion || final === "m")) ||
+    (!wheel && ((motion && final === "m") || (!motion && button === 3)))
+  ) {
+    return null;
+  }
+  let modifiers = 0;
+  if (code & 4) modifiers |= MOD_SHIFT;
+  if (code & 8) modifiers |= MOD_ALT;
+  if (code & 16) modifiers |= MOD_CONTROL;
+  const kind = wheel
+    ? MOUSE_KIND.ScrollUp + button
+    : motion
+      ? button === 3
+        ? MOUSE_KIND.Moved
+        : MOUSE_KIND.Drag
+      : final === "m"
+        ? MOUSE_KIND.Up
+        : MOUSE_KIND.Down;
+  return {
+    type: "mouse",
+    kind,
+    ...(kind <= MOUSE_KIND.Drag ? { button: [0, 2, 1][button] } : {}),
+    column: x - 1,
+    row: y - 1,
+    modifiers,
+    lines: 1,
+  };
 }
 
 function matchesAt(buf: Buffer, offset: number, needle: Buffer): boolean {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -177,6 +177,8 @@ export interface TerminalPush {
   width: number;
   height: number;
   full: boolean;
+  /** Present only for endpoint full pane repaints; absent on legacy streams. */
+  mouse_reporting?: boolean;
   /** base64-encoded ANSI bytes */
   bytes: string;
 }

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -53,6 +53,10 @@ import {
   type TerminalFileLinkCandidate,
   TerminalFileResolutionCache,
 } from "../terminalFileLinks";
+import {
+  TerminalEndpointPresentation,
+  terminalMouseUsesSelection,
+} from "../terminalEndpointPresentation";
 import { terminalFocusBlockedByOverlay } from "../terminalFocus";
 import { uploadTerminalImage } from "../terminalImageUpload";
 import {
@@ -495,6 +499,9 @@ export function TerminalView({
     [],
   );
   const termRef = useRef<Terminal | null>(null);
+  const endpointPresentationRef = useRef<TerminalEndpointPresentation | null>(
+    null,
+  );
   // Mirrors termRef as state so the attach effect re-runs when the xterm
   // instance is recreated: the init effect's cleanup resets the attach refs,
   // and without an instance change in the deps the attach effect would not
@@ -847,8 +854,10 @@ export function TerminalView({
     let pasteTextareaBeforeInput: TerminalPasteTextareaSnapshot | null = null;
     let pastePaneIdBeforeInput: string | null = null;
     let lastTerminalTextareaSnapshot = readTerminalTextareaSnapshot();
+    let replayingSelection = false;
     term.onData((data) => {
-      if (composerOpenRef.current) return;
+      // Replaying a delayed local selection must never synthesize pane input.
+      if (composerOpenRef.current || replayingSelection) return;
       const unsuppressedData = imeTextareaFallback.recordXtermData(data);
       if (!unsuppressedData) return;
       const dataAt = performance.now();
@@ -864,6 +873,14 @@ export function TerminalView({
       sendBytes(connectionClient, bytes, terminalId).catch(() => {});
     });
 
+    const endpointPresentation = new TerminalEndpointPresentation(
+      () => term.hasSelection(),
+      (text, parsed) => term.write(colorHttpLinks(text), parsed),
+    );
+    endpointPresentationRef.current = endpointPresentation;
+    const selectionChange = term.onSelectionChange(() =>
+      endpointPresentation.flush(),
+    );
     const off = bridge.onTerminal((t) => {
       // A mount owns exactly one connection generation. Drop frames from an
       // inactive connection or a prior terminal attach before touching xterm.
@@ -883,7 +900,12 @@ export function TerminalView({
       attachTimeoutCountRef.current = 0;
       setTerminalLoading(false);
       setTerminalAttachError("");
-      term.write(colorHttpLinks(text));
+      if (typeof t.mouse_reporting === "boolean") {
+        term.options.macOptionClickForcesSelection = true;
+        endpointPresentation.update(text, t.mouse_reporting);
+      } else {
+        term.write(colorHttpLinks(text));
+      }
       focusTerminalSoon();
     });
     const offClipboard = bridge.onTerminalClipboard((clipboard) => {
@@ -916,6 +938,7 @@ export function TerminalView({
       // Herdr closes the direct attach when another client takes the
       // terminal over (or its stream dies). Re-attach, but bound takeover
       // wars between two clients so they cannot evict each other forever.
+      endpointPresentation.reset();
       attachedRef.current = null;
       attachingRef.current = null;
       const now = Date.now();
@@ -1548,6 +1571,14 @@ export function TerminalView({
     container.addEventListener("copy", onCopy, { capture: true });
 
     const onClick = (e: MouseEvent) => {
+      if (
+        !terminalMouseUsesSelection(
+          endpointPresentation.mouseReporting,
+          e,
+          applePlatform,
+        )
+      )
+        return;
       if (!isSafariBrowser() || term.hasSelection()) return;
       term.clearSelection();
       container.ownerDocument.dispatchEvent(
@@ -1572,9 +1603,138 @@ export function TerminalView({
     // every later move keeps growing the selection without a button pressed.
     // Detect the lost release on the first button-less move and force it.
     const selectionDragGuard = new TerminalSelectionDragGuard();
-    const onTerminalMouseDown = (e: MouseEvent) =>
+    let deferredMove: MouseEvent | null = null;
+    let deferredUp: MouseEvent | null = null;
+    const replayMouse = (target: EventTarget, event: MouseEvent) => {
+      // The reporting mode may have changed while parsing. Preserve the
+      // original modifiers and add only xterm's local selection escape.
+      const forceSelection = term.modes.mouseTrackingMode !== "none";
+      target.dispatchEvent(
+        new MouseEvent(event.type, {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+          button: event.button,
+          buttons: event.buttons,
+          detail: event.detail,
+          clientX: event.clientX,
+          clientY: event.clientY,
+          screenX: event.screenX,
+          screenY: event.screenY,
+          ctrlKey: event.ctrlKey,
+          metaKey: event.metaKey,
+          altKey: event.altKey || (forceSelection && applePlatform),
+          shiftKey: event.shiftKey || (forceSelection && !applePlatform),
+        }),
+      );
+    };
+    const onTerminalMouseDown = (e: MouseEvent) => {
+      if (replayingSelection) return;
+      if (
+        !terminalMouseUsesSelection(
+          endpointPresentation.mouseReporting,
+          e,
+          applePlatform,
+        )
+      )
+        return;
       selectionDragGuard.mouseDown(e.button);
-    const onDocumentMouseUp = () => selectionDragGuard.mouseUp();
+      if (e.button !== 0) return;
+      if (
+        endpointPresentation.mouseReporting === undefined &&
+        !endpointPresentation.writePending
+      ) {
+        endpointPresentation.selectionDrag = true;
+        return;
+      }
+      const terminalId = desiredTerminalRef.current;
+      deferredMove = deferredUp = null;
+      if (
+        !endpointPresentation.beginSelection(() => {
+          if (
+            terminalEffectDisposed ||
+            !connectionClient.isCurrent() ||
+            terminalId !== desiredTerminalRef.current ||
+            !(e.target instanceof Node) ||
+            !e.target.isConnected
+          )
+            return;
+          replayingSelection = true;
+          try {
+            replayMouse(e.target, e);
+            if (deferredMove)
+              replayMouse(container.ownerDocument, deferredMove);
+            if (deferredUp) replayMouse(container.ownerDocument, deferredUp);
+          } finally {
+            replayingSelection = false;
+            deferredMove = deferredUp = null;
+          }
+        })
+      ) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+      }
+    };
+    const onDeferredMouseMove = (e: MouseEvent) => {
+      if (!endpointPresentation.selectionPending || deferredUp) return;
+      if (e.buttons === 0) {
+        // A lost release finalizes at the last held-button move, not this hover.
+        deferredUp = new MouseEvent("mouseup", e);
+        selectionDragGuard.mouseUp();
+      } else {
+        deferredMove = e;
+      }
+      e.preventDefault();
+      e.stopImmediatePropagation();
+    };
+    const onDocumentMouseUp = (e: MouseEvent) => {
+      if (endpointPresentation.selectionPending) {
+        if (deferredUp) return; // the first release froze this gesture
+        deferredUp = e;
+        selectionDragGuard.mouseUp();
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        return;
+      }
+      selectionDragGuard.mouseUp();
+      endpointPresentation.selectionDrag = false;
+      queueMicrotask(() => {
+        if (!terminalEffectDisposed) endpointPresentation.flush();
+      });
+    };
+    const onNativeMouseDown = (e: MouseEvent) => {
+      // A new physical gesture anywhere owns document listeners now. Cancel
+      // this deferred replay before a sibling terminal can start an app drag.
+      // Synthetic selection replay must not cancel another pane's intent.
+      if (!e.isTrusted || !endpointPresentation.selectionPending) return;
+      deferredMove = deferredUp = null;
+      selectionDragGuard.reset();
+      endpointPresentation.cancelSelection();
+    };
+    const onSelectionBlur = () => {
+      if (endpointPresentation.selectionPending) {
+        deferredMove = deferredUp = null;
+        selectionDragGuard.reset();
+        endpointPresentation.cancelSelection();
+        return;
+      }
+      if (
+        endpointPresentation.mouseReporting === undefined ||
+        !endpointPresentation.selectionDrag
+      )
+        return;
+      // End xterm's document listeners too; merely resetting our guard would
+      // leave a lost native release extending the selection on later moves.
+      container.ownerDocument.dispatchEvent(
+        new MouseEvent("mouseup", {
+          bubbles: true,
+          cancelable: true,
+          view: window,
+          button: 0,
+          buttons: 0,
+        }),
+      );
+    };
     const onDocumentMouseMove = (e: MouseEvent) => {
       if (!selectionDragGuard.mouseMoveNeedsRelease(e.buttons)) return;
       container.ownerDocument.dispatchEvent(
@@ -1591,11 +1751,38 @@ export function TerminalView({
         }),
       );
     };
-    container.addEventListener("mousedown", onTerminalMouseDown);
+    container.addEventListener("mousedown", onTerminalMouseDown, {
+      capture: true,
+    });
+    window.addEventListener("blur", onSelectionBlur);
+    document.addEventListener("mousedown", onNativeMouseDown, {
+      capture: true,
+    });
     document.addEventListener("mouseup", onDocumentMouseUp, { capture: true });
+    document.addEventListener("mousemove", onDeferredMouseMove, {
+      capture: true,
+    });
     document.addEventListener("mousemove", onDocumentMouseMove);
 
     const onWheel = (e: WheelEvent) => {
+      if (endpointPresentation.mouseReporting !== undefined) {
+        if (
+          term.hasSelection() ||
+          endpointPresentation.selectionDrag ||
+          composerOpenRef.current
+        ) {
+          e.preventDefault();
+          e.stopPropagation();
+          return;
+        }
+        // Let xterm produce pane-local SGR coordinates and modifiers only on
+        // endpoint streams. Legacy AttachScroll routing stays unchanged.
+        if (
+          endpointPresentation.mouseReporting &&
+          term.modes.mouseTrackingMode !== "none"
+        )
+          return;
+      }
       const scroll = terminalWheelScroll(e.deltaY, e.deltaMode, term.rows);
       const terminalId = desiredTerminalRef.current;
       if (!scroll || !terminalId) return;
@@ -1622,6 +1809,16 @@ export function TerminalView({
       touchRemainder = 0;
     };
     const onTouchMove = (e: TouchEvent) => {
+      if (
+        endpointPresentation.mouseReporting !== undefined &&
+        (term.hasSelection() ||
+          endpointPresentation.selectionDrag ||
+          composerOpenRef.current)
+      ) {
+        e.preventDefault();
+        e.stopPropagation();
+        return;
+      }
       if (e.touches.length !== 1 || touchLastY === null) return;
       const touch = e.touches[0];
       const deltaY = touchLastY - touch.clientY;
@@ -1674,6 +1871,9 @@ export function TerminalView({
     return () => {
       terminalEffectDisposed = true;
       off();
+      selectionChange.dispose();
+      endpointPresentation.dispose();
+      endpointPresentationRef.current = null;
       offClipboard();
       offClosed();
       unregisterConnectionDisposer();
@@ -1715,8 +1915,17 @@ export function TerminalView({
       document.removeEventListener("paste", onPaste, { capture: true });
       container.removeEventListener("copy", onCopy, { capture: true });
       container.removeEventListener("click", onClick);
-      container.removeEventListener("mousedown", onTerminalMouseDown);
+      container.removeEventListener("mousedown", onTerminalMouseDown, {
+        capture: true,
+      });
+      window.removeEventListener("blur", onSelectionBlur);
+      document.removeEventListener("mousedown", onNativeMouseDown, {
+        capture: true,
+      });
       document.removeEventListener("mouseup", onDocumentMouseUp, {
+        capture: true,
+      });
+      document.removeEventListener("mousemove", onDeferredMouseMove, {
         capture: true,
       });
       document.removeEventListener("mousemove", onDocumentMouseMove);
@@ -1773,7 +1982,14 @@ export function TerminalView({
     if (!connectionClient.isCurrent()) return;
     const term = termInstance;
     const paneTerminalId = pane?.terminal_id ?? null;
+    if (
+      desiredTerminalRef.current !== paneTerminalId ||
+      s.status !== "connected"
+    ) {
+      endpointPresentationRef.current?.reset();
+    }
     if (terminalAttachEpochRef.current !== s.terminalAttachEpoch) {
+      endpointPresentationRef.current?.reset();
       terminalAttachEpochRef.current = s.terminalAttachEpoch;
       attachedRef.current = null;
       attachingRef.current = null;

--- a/web/src/endpointFrame.test.ts
+++ b/web/src/endpointFrame.test.ts
@@ -1,7 +1,52 @@
 import { expect, test } from "bun:test";
+import { UnicodeGraphemesAddon } from "@xterm/addon-unicode-graphemes";
 import { Terminal } from "@xterm/xterm";
 import { frameToAnsi } from "../../server/src/bridge/frame-to-ansi";
 import type { FrameData } from "../../server/src/bridge/thin-client";
+
+test.each(["中", "🙂", "👩‍💻", "🇨🇳", "ｶﾞ", "e\u0301"])(
+  "keeps source columns and cursor after %s with production Unicode rendering",
+  async (symbol) => {
+    for (const cols of [5, 10]) {
+      const term = new Terminal({ allowProposedApi: true, cols, rows: 3 });
+      term.loadAddon(new UnicodeGraphemesAddon());
+      try {
+        const frame: FrameData = {
+          width: 5,
+          height: 2,
+          cursor: { x: 4, y: 0, visible: true, shape: 1 },
+          hyperlinks: [],
+          cells: ["a", symbol, " ", " ", "x", symbol, " ", " ", "x", " "].map(
+            (symbol) => ({
+              symbol,
+              fg: 0,
+              bg: 0,
+              modifier: 0,
+              skip: false,
+              hyperlink: null,
+            }),
+          ),
+        };
+        await new Promise<void>((resolve) =>
+          term.write(frameToAnsi(frame), resolve),
+        );
+        const first = term.buffer.active.getLine(0)!;
+        const second = term.buffer.active.getLine(1)!;
+        expect(first.getCell(0)?.getChars()).toBe("a");
+        expect(first.getCell(1)?.getChars()).toBe(symbol);
+        expect(first.getCell(3)?.getChars()).toBe(" ");
+        expect(first.getCell(4)?.getChars()).toBe("x");
+        expect(second.getCell(0)?.getChars()).toBe(symbol);
+        expect(second.getCell(2)?.getChars()).toBe(" ");
+        expect(second.getCell(3)?.getChars()).toBe("x");
+        expect(term.buffer.active.cursorX).toBe(4);
+        expect(term.buffer.active.cursorY).toBe(0);
+      } finally {
+        term.dispose();
+      }
+    }
+  },
+);
 
 test("endpoint repaints clear shortened text, blank rows, and a smaller pane", async () => {
   const term = new Terminal({ allowProposedApi: true, cols: 10, rows: 3 });

--- a/web/src/mobileTerminalShortcutAction.test.ts
+++ b/web/src/mobileTerminalShortcutAction.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { mobileTerminalShortcutExecution } from "./mobileTerminalShortcutAction";
+import { terminalPageScroll } from "./terminalScroll";
 
 describe("mobile terminal shortcut execution", () => {
   test("sends ordinary configured keys as terminal input", () => {
@@ -11,6 +12,20 @@ describe("mobile terminal shortcut execution", () => {
       type: "input",
       bytes: [0x1b, 0x5b, 0x31, 0x3b, 0x33, 0x41],
     });
+  });
+
+  test("mobile half-page actions carry explicit history intent like keyboard shortcuts", () => {
+    for (const action of ["alt-page-up", "alt-page-down"] as const) {
+      const execution = mobileTerminalShortcutExecution(action);
+      if (execution?.type !== "scroll") throw new Error("expected scroll");
+      expect(
+        terminalPageScroll(execution.direction, 30, execution.amount),
+      ).toEqual({
+        direction: execution.direction,
+        lines: 14,
+        source: "history",
+      });
+    }
   });
 
   test("routes page actions to full or half scrollback", () => {

--- a/web/src/terminalEndpointPresentation.test.ts
+++ b/web/src/terminalEndpointPresentation.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, test } from "bun:test";
+import { Terminal } from "@xterm/xterm";
+import {
+  TerminalEndpointPresentation,
+  terminalMouseUsesSelection,
+} from "./terminalEndpointPresentation";
+
+describe("endpoint selection presentation", () => {
+  test("selection cannot begin while an endpoint frame is still queued for parsing", async () => {
+    let selected = false;
+    let visible = "A";
+    let drain: (() => void) | undefined;
+    const presentation = new TerminalEndpointPresentation(
+      () => selected,
+      (text, parsed) => {
+        drain = () => {
+          visible = text;
+          parsed();
+        };
+      },
+    );
+    presentation.update("B", true);
+    let copied = "";
+    expect(
+      presentation.beginSelection(() => {
+        selected = true;
+        copied = visible;
+      }),
+    ).toBe(false);
+    presentation.update("C", false);
+    presentation.update("D", true);
+    expect(selected).toBe(false); // native selection has not begun on A
+    expect(visible).toBe("A");
+    await Promise.resolve();
+    drain!();
+    expect(selected).toBe(true);
+    expect(copied).toBe("\x1b[?1006h\x1b[?1002hB");
+    presentation.flush();
+    expect(visible).toBe(copied);
+    selected = false;
+    presentation.selectionDrag = false;
+    presentation.flush();
+    drain!();
+    expect(visible).toBe("D");
+  });
+  test("coalesces full output during selection and applies only newest mode/frame on clear", () => {
+    let selected = false;
+    let visible = "";
+    const writes: string[] = [];
+    const presentation = new TerminalEndpointPresentation(
+      () => selected,
+      (text, parsed) => {
+        visible = text;
+        writes.push(text);
+        parsed();
+      },
+    );
+    presentation.update("original selected text", false);
+    selected = true;
+    const copiedText = visible;
+    presentation.update("new output", true);
+    presentation.update("newest output", false);
+    presentation.update("latest output", true);
+    expect(presentation.mouseReporting).toBe(true); // metadata is immediate
+    expect(visible).toBe(copiedText); // copy still sees precisely the selected output
+    expect(writes).toHaveLength(1);
+    selected = false;
+    presentation.flush();
+    expect(writes).toHaveLength(2);
+    expect(visible).toBe("\x1b[?1006h\x1b[?1002hlatest output");
+    presentation.flush();
+    expect(writes).toHaveLength(2);
+    presentation.update("next output", true);
+    expect(visible).toBe("next output"); // do not reassert modes and clear selection
+  });
+
+  test("selection drag pauses before a range exists; application drag does not", () => {
+    const writes: string[] = [];
+    const presentation = new TerminalEndpointPresentation(
+      () => false,
+      (text, parsed) => {
+        writes.push(text);
+        parsed();
+      },
+    );
+    presentation.selectionDrag = true;
+    presentation.update("first", false);
+    presentation.update("last", false);
+    expect(writes).toEqual([]);
+    presentation.selectionDrag = false; // mouseup/lost release/window blur
+    presentation.flush();
+    expect(writes).toEqual(["\x1b[?1002l\x1b[?1006llast"]);
+    presentation.update("app output", true);
+    expect(writes[writes.length - 1]).toContain("app output");
+  });
+
+  test("reset drops pending output, mode and drag across pane/session changes or teardown", () => {
+    const writes: string[] = [];
+    const presentation = new TerminalEndpointPresentation(
+      () => false,
+      (text, parsed) => {
+        writes.push(text);
+        parsed();
+      },
+    );
+    presentation.selectionDrag = true;
+    presentation.update("old pane", true);
+    presentation.reset();
+    presentation.flush();
+    expect(writes).toEqual([]);
+    expect(presentation.mouseReporting).toBeUndefined();
+    expect(presentation.selectionDrag).toBe(false);
+    presentation.update("new pane", false);
+    expect(writes).toEqual(["\x1b[?1002l\x1b[?1006lnew pane"]);
+  });
+
+  test.each(["reset", "blur"])(
+    "%s cancels deferred initiation and late callbacks cannot replay it",
+    async (reason) => {
+      let drain!: () => void;
+      let replayed = 0;
+      const presentation = new TerminalEndpointPresentation(
+        () => false,
+        (_text, parsed) => {
+          drain = parsed;
+        },
+      );
+      presentation.update("old", true);
+      expect(
+        presentation.beginSelection(() => {
+          replayed++;
+        }),
+      ).toBe(false);
+      if (reason === "reset") presentation.reset();
+      else presentation.cancelSelection();
+      await Promise.resolve();
+      drain();
+      expect(replayed).toBe(0);
+      expect(presentation.selectionPending).toBe(false);
+      expect(presentation.selectionDrag).toBe(false);
+    },
+  );
+
+  test.each([false, true])(
+    "reset retains the physical write gate for a new selection (reporting=%s)",
+    async (reporting) => {
+      const terminal = new Terminal({
+        allowProposedApi: true,
+        cols: 10,
+        rows: 3,
+      });
+      let selected = false;
+      let copied = "";
+      const presentation = new TerminalEndpointPresentation(
+        () => selected,
+        (text, parsed) => terminal.write(text, parsed),
+      );
+      try {
+        await new Promise<void>((resolve) => terminal.write("A", resolve));
+        presentation.update("\x1b[HB", reporting);
+        presentation.reset(); // same xterm is retained on close/reconnect
+        expect(presentation.mouseReporting).toBeUndefined();
+        expect(
+          presentation.beginSelection(() => {
+            selected = true;
+            copied = terminal.buffer.active.getLine(0)!.translateToString(true);
+          }),
+        ).toBe(false);
+        await Bun.sleep(30);
+        expect(copied).toBe("B");
+        expect(selected).toBe(true);
+        presentation.update("\x1b[HC", false);
+        await Bun.sleep(30);
+        expect(terminal.buffer.active.getLine(0)!.translateToString(true)).toBe(
+          "B",
+        );
+      } finally {
+        presentation.reset();
+        terminal.dispose();
+      }
+    },
+  );
+
+  test("reset cannot submit a second physical write before the first callback", () => {
+    const callbacks: Array<() => void> = [];
+    const writes: string[] = [];
+    const presentation = new TerminalEndpointPresentation(
+      () => false,
+      (text, parsed) => {
+        writes.push(text);
+        callbacks.push(parsed);
+      },
+    );
+    presentation.update("B", true);
+    presentation.reset();
+    presentation.update("C", false);
+    expect(writes).toHaveLength(1);
+    callbacks[0]();
+    expect(writes).toHaveLength(2);
+    expect(writes[1]).toContain("C");
+    callbacks[1]();
+  });
+
+  test("disposal prevents a late physical completion from reviving writes or replay", () => {
+    const callbacks: Array<() => void> = [];
+    const writes: string[] = [];
+    let replayed = false;
+    const presentation = new TerminalEndpointPresentation(
+      () => false,
+      (text, parsed) => {
+        writes.push(text);
+        callbacks.push(parsed);
+      },
+    );
+    presentation.update("B", true);
+    presentation.reset();
+    expect(presentation.writePending).toBe(true);
+    expect(
+      presentation.beginSelection(() => {
+        replayed = true;
+      }),
+    ).toBe(false);
+    presentation.update("C", false);
+    presentation.dispose();
+    callbacks[0]();
+    presentation.update("D", true);
+    presentation.flush();
+    expect(replayed).toBe(false);
+    expect(writes).toHaveLength(1);
+    expect(presentation.selectionPending).toBe(false);
+    expect(presentation.mouseReporting).toBeUndefined();
+  });
+
+  test("native selection escape is platform-correct; ordinary/legacy output stays selectable", () => {
+    const plain = { shiftKey: false, altKey: false };
+    for (const apple of [false, true]) {
+      expect(terminalMouseUsesSelection(false, plain, apple)).toBe(true);
+      expect(terminalMouseUsesSelection(undefined, plain, apple)).toBe(true);
+      expect(terminalMouseUsesSelection(true, plain, apple)).toBe(false);
+      expect(
+        terminalMouseUsesSelection(true, { ...plain, shiftKey: true }, apple),
+      ).toBe(!apple);
+      expect(
+        terminalMouseUsesSelection(true, { ...plain, altKey: true }, apple),
+      ).toBe(apple);
+    }
+  });
+
+  test("selection initiation awaits the real xterm parser before later output is retained", async () => {
+    const terminal = new Terminal({
+      allowProposedApi: true,
+      cols: 10,
+      rows: 3,
+    });
+    let selected = false;
+    let copied = "";
+    const presentation = new TerminalEndpointPresentation(
+      () => selected,
+      (text, parsed) => terminal.write(text, parsed),
+    );
+    try {
+      await new Promise<void>((resolve) => terminal.write("A", resolve));
+      presentation.update("\x1b[HB", true);
+      expect(
+        presentation.beginSelection(() => {
+          selected = true;
+          copied = terminal.buffer.active.getLine(0)!.translateToString(true);
+        }),
+      ).toBe(false);
+      expect(selected).toBe(false);
+      await Bun.sleep(30);
+      expect(copied).toBe("B");
+      expect(terminal.modes.mouseTrackingMode).toBe("drag");
+      presentation.update("\x1b[HC", false);
+      await Bun.sleep(30);
+      expect(terminal.buffer.active.getLine(0)!.translateToString(true)).toBe(
+        "B",
+      );
+      selected = false;
+      presentation.selectionDrag = false;
+      presentation.flush();
+      await Bun.sleep(30);
+      expect(terminal.buffer.active.getLine(0)!.translateToString(true)).toBe(
+        "C",
+      );
+      expect(terminal.modes.mouseTrackingMode).toBe("none");
+    } finally {
+      presentation.reset();
+      terminal.dispose();
+    }
+  });
+
+  test("the pinned xterm negotiates cell drag reports and returns to selection mode", async () => {
+    const terminal = new Terminal({
+      allowProposedApi: true,
+      cols: 10,
+      rows: 3,
+    });
+    const writes: Promise<void>[] = [];
+    const presentation = new TerminalEndpointPresentation(
+      () => false,
+      (text, parsed) => {
+        writes.push(
+          new Promise<void>((resolve) =>
+            terminal.write(text, () => {
+              parsed();
+              resolve();
+            }),
+          ),
+        );
+      },
+    );
+    try {
+      presentation.update("hello", true);
+      await Promise.all(writes);
+      expect(terminal.modes.mouseTrackingMode).toBe("drag");
+      presentation.update("hello", false);
+      await Promise.all(writes);
+      expect(terminal.modes.mouseTrackingMode).toBe("none");
+    } finally {
+      terminal.dispose();
+    }
+  });
+});

--- a/web/src/terminalEndpointPresentation.ts
+++ b/web/src/terminalEndpointPresentation.ts
@@ -1,0 +1,112 @@
+/** xterm's native selection escape: Shift on non-Mac, Option on Mac. */
+export function terminalMouseUsesSelection(
+  mouseReporting: boolean | undefined,
+  event: { shiftKey: boolean; altKey: boolean },
+  applePlatform: boolean,
+): boolean {
+  return (
+    mouseReporting !== true || (applePlatform ? event.altKey : event.shiftKey)
+  );
+}
+
+/**
+ * Endpoint frames are self-contained repaints, not an incremental PTY stream.
+ * Retain just the newest while selecting so copied text stays the visible text.
+ * Legacy streams never pass through this helper.
+ */
+export class TerminalEndpointPresentation {
+  mouseReporting: boolean | undefined;
+  selectionDrag = false;
+  private appliedMouseReporting: boolean | undefined;
+  private pendingFrame: string | null = null;
+  private writing = false;
+  private disposed = false;
+  private deferredSelection: (() => void) | null = null;
+
+  constructor(
+    private hasSelection: () => boolean,
+    private write: (text: string, parsed: () => void) => void,
+  ) {}
+
+  get selectionPending(): boolean {
+    return this.deferredSelection !== null;
+  }
+
+  get writePending(): boolean {
+    return this.writing;
+  }
+
+  /** Reserve selection immediately; replay native initiation only after parsing. */
+  beginSelection(replay: () => void): boolean {
+    if (this.disposed) return false;
+    this.selectionDrag = true;
+    if (!this.writing) return true;
+    this.deferredSelection = replay;
+    return false;
+  }
+
+  cancelSelection(): void {
+    this.deferredSelection = null;
+    this.selectionDrag = false;
+    this.flush();
+  }
+
+  update(text: string, mouseReporting: boolean): void {
+    if (this.disposed) return;
+    this.mouseReporting = mouseReporting;
+    this.pendingFrame = text;
+    this.flush();
+  }
+
+  flush(): void {
+    if (
+      this.disposed ||
+      this.writing ||
+      this.selectionDrag ||
+      this.hasSelection()
+    )
+      return;
+    let prefix = "";
+    if (
+      this.mouseReporting !== undefined &&
+      this.appliedMouseReporting !== this.mouseReporting
+    ) {
+      // Activation clears xterm selection, so apply only after selection ends.
+      // Drag tracking suffices for pane applications; no hover reports that
+      // could clear a retained browser selection after the escape is released.
+      prefix = this.mouseReporting
+        ? "\x1b[?1006h\x1b[?1002h"
+        : "\x1b[?1002l\x1b[?1006l";
+      this.appliedMouseReporting = this.mouseReporting;
+    }
+    const frame = this.pendingFrame;
+    this.pendingFrame = null;
+    if (prefix || frame !== null) {
+      this.writing = true;
+      this.write(prefix + (frame ?? ""), () => {
+        // reset() cannot cancel the physical xterm write. Its completion must
+        // still release the gate for current intent, never restore old state.
+        this.writing = false;
+        if (this.disposed) return;
+        const replay = this.deferredSelection;
+        this.deferredSelection = null;
+        if (replay) replay();
+        this.flush();
+      });
+    }
+  }
+
+  reset(): void {
+    // Invalidate presentation/replay, not the outstanding parser operation.
+    this.deferredSelection = null;
+    this.mouseReporting = undefined;
+    this.appliedMouseReporting = undefined;
+    this.pendingFrame = null;
+    this.selectionDrag = false;
+  }
+
+  dispose(): void {
+    this.reset();
+    this.disposed = true;
+  }
+}

--- a/web/src/terminalScroll.test.ts
+++ b/web/src/terminalScroll.test.ts
@@ -35,15 +35,11 @@ describe("terminal wheel scrolling", () => {
   });
 
   test("supports half-page scrollback with a readable overlap", () => {
-    expect(terminalPageScroll("up", 30, "half")).toEqual({
-      direction: "up",
-      lines: 14,
-      source: "wheel",
-    });
-    expect(terminalPageScroll("down", 2, "half")).toEqual({
-      direction: "down",
-      lines: 1,
-      source: "wheel",
-    });
+    const up = terminalPageScroll("up", 30, "half");
+    const down = terminalPageScroll("down", 2, "half");
+    expect(up.lines).toBe(14);
+    expect(down.lines).toBe(1);
+    expect(String(up.source)).toBe("history");
+    expect(String(down.source)).toBe("history");
   });
 });

--- a/web/src/terminalScroll.ts
+++ b/web/src/terminalScroll.ts
@@ -1,7 +1,7 @@
 export type TerminalScroll = {
   direction: "up" | "down";
   lines: number;
-  source: "wheel" | "page-key";
+  source: "wheel" | "page-key" | "history";
 };
 
 export type TerminalWheelScroll = TerminalScroll & { source: "wheel" };
@@ -47,6 +47,8 @@ export function terminalPageScroll(
       amount === "half"
         ? Math.max(1, Math.floor(viewportLines / 2))
         : viewportLines,
-    source: amount === "full" ? "page-key" : "wheel",
+    // The bridge retains legacy wheel semantics for half pages, but endpoint
+    // sessions must distinguish these coordinate-less shortcuts from a mouse.
+    source: amount === "full" ? "page-key" : "history",
   };
 }


### PR DESCRIPTION
## Summary

Closes #108.

- Forward endpoint SGR cell clicks, drags, releases and wheel input to the explicitly attached pane using Herdr 0.9.0's stable semantic mouse contract.
- Honor per-pane reporting state; preserve explicit keyboard/mobile history scrolling and legacy Wheel behavior. Clamp owned drag/release at crop edges without admitting outside initial presses.
- Preserve browser selection/copy during streaming output. Endpoint rendering retains only the latest full repaint while selected; a selection started during an outstanding xterm write waits for parser completion. Reset and cross-pane gesture handling retain correct ownership.

## Verification

- `bun run precommit`: 1095 passed, 1 existing live-SSH skip; formatting, lint and typechecks passed.
- Focused regression suite: 75 passed, 488 assertions across 9 files.
- `bun run build:web`: passed, asset budget 118/160 files and 9.5/12 MiB.
- Final documentation-only update: `bun run format:check` and `git diff --check` passed.
- Isolated Herdr 0.9.0 + Chromium: semantic mouse bytes, production browser delivery, streaming selection/copy, mode changes, cross-pane gesture isolation and reset/write completion verified.
- Independent review: OK with notes; all identified P1 findings resolved.

See `docs/endpoint-mouse-verification.md` for protocol evidence, behavior and manual checklist.

## Limitations / review notes

- Endpoint output pauses visually while text is selected; clearing selection catches up. Initiation may briefly wait for an already-queued repaint.
- One older reset browser fixture failed without recording whether the write was pending at mouse-down. That historical result remains inconclusive. A separate timestamped diagnostic established the pending-write precondition and verified correct selection delay and retention without changing production code.
- Interactive Vim/lazygit, Safari, non-macOS selection, interactive resizing and live legacy-browser checks remain unrun. Scripted Chromium/two-pane and unit coverage do not substitute for these manual checks.
- Pixel mouse and other issues are outside scope. No dependencies or lockfiles changed.
