### PR TITLE
Restore endpoint OSC 52 clipboard forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 
 ### Fixed
 
+- Restore terminal-program OSC 52 clipboard writes on Herdr 0.9.0 endpoints,
+  using its foreground recipient and Studio's recent-input filtering. Herdr
+  does not identify the producing pane; delayed/background writes can reach
+  the new foreground recipient. The legacy fallback remains unsupported.
+
 - Preserve endpoint text and cursor alignment for Chinese and other Unicode
   graphemes, including halfwidth kana, without adding wide-character spacing.
 - Restore cell-based clicks, drags and wheel input in endpoint terminal apps;

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -50,8 +50,9 @@ Closed panes are removed from the history automatically.
 - Paste multiline text through terminal paste handling.
 - Paste a clipboard image to upload it on the Herdr host and insert the resulting
   path into the terminal. This also works through `--ssh-host`.
-- Relay OSC 52 clipboard writes from local or remote terminal applications to
-  the initiating browser.
+- Relay OSC 52 clipboard writes from local or remote terminal applications.
+  On Herdr 0.9.0 endpoints, delivery follows the foreground recipient, not
+  proven originating-pane ownership; see [clipboard compatibility](docs/DEPLOYMENT.md#herdr-compatibility).
 - `Cmd/Ctrl`-click HTTP(S) links to open them safely in a new tab.
 - `Cmd/Ctrl`-click workspace-relative or absolute file paths in terminal output
   to preview text, Markdown, or images without leaving the terminal.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -23,20 +23,27 @@ Use a Studio build explicitly supporting your server, or a separate compatible
 server; do not downgrade a live server. These changes target a future Studio
 0.5.3 and do not change already-published binaries.
 
-Herdr 0.9.0 support is **basic direct-terminal compatibility**, not migration to
-stable endpoint generation 1 (which is distinct from terminal protocol 22):
+Herdr 0.9.0 terminals use **stable endpoint generation 1** (distinct from
+terminal protocol 22). Set `HERDR_GUI_DISABLE_ENDPOINT=1` to use the legacy
+direct-terminal fallback:
 
-- ANSI rendering, ordinary input/paste, cell-based resizing, and Studio's shared
-  browser terminal sessions retain the existing per-terminal attachment path.
-  Attaching uses takeover and can disconnect another direct-terminal owner.
-- Terminal-program OSC 52 clipboard delivery is unavailable on 0.9.0: the legacy
-  app relay is disabled because only shell endpoints receive these messages.
-  Ordinary browser selection copy and paste remain available. Legacy servers
-  retain their clipboard relay and input-owner filtering.
+- Endpoint rendering crops the server-rendered tab to each pane. The legacy
+  fallback uses takeover and can disconnect another direct-terminal owner.
+- Terminal-program OSC 52 writes follow Herdr's **foreground-recipient**
+  behavior: Studio sends only to the browser with input in the last 30 seconds
+  matching the receiving endpoint session, never to passive viewers. Herdr
+  sends no producing-pane or input identity: a delayed/background write from
+  pane A after B becomes foreground can reach B's recent input owner. This is
+  not source-PTY isolation or a guarantee of the original initiating browser.
+  Detach, session replacement, and connection disposal invalidate ownership.
+  Clipboard reads remain disabled; browser permission failures retain the
+  existing copy-retry UI. Ordinary browser selection copy and paste are unchanged.
+  OSC 52 remains unavailable on the **0.9.0 legacy fallback** because only shell
+  endpoints receive it. Legacy servers retain their existing clipboard relay.
 - Public JSON workspace/tab/pane focus remains session-wide; Studio does not
   promise independent navigation alongside other Herdr clients. Enhanced Kitty
-  keyboard / modifyOtherKeys parity, pixel mouse and semantic endpoint rendering
-  are not supported. Keyboard-mode messages are decoded, not applied in-browser.
+  keyboard / modifyOtherKeys parity and pixel mouse are not supported. Legacy
+  keyboard-mode messages are decoded, not applied in-browser.
 - Closing a workspace does not implicitly close its linked group. If Herdr
   requires group closure, Studio leaves it intact and directs you to the CLI:
   `herdr --session <name> workspace close <workspace_id> --group`. Review all

--- a/server/src/bridge/endpoint-client.test.ts
+++ b/server/src/bridge/endpoint-client.test.ts
@@ -220,6 +220,103 @@ async function startEndpointServer(
 }
 
 describe("EndpointClient (endpoint generation 1)", () => {
+  test.each([
+    Buffer.from("OSC52 \u4e2d\u6587").toString("base64"),
+    "A".repeat(256 * 1024),
+  ])(
+    "decodes tagged 0.9.0 Clipboard tag 5 as unchanged base64 (case %#)",
+    async (data) => {
+      const socketPath = await startEndpointServer((_hello, socket) => {
+        const w = new BinWriter();
+        w.variant(5);
+        w.string(data);
+        socket.write(encodeFrame(w.toBuffer()));
+      });
+      const client = new EndpointClient(socketPath);
+      const clipboard = new Promise((resolve) =>
+        client.once("clipboard", resolve),
+      );
+      try {
+        await client.connect(80, 24);
+        expect(await clipboard).toEqual({ data });
+      } finally {
+        client.close();
+      }
+    },
+  );
+
+  test.each([
+    "",
+    "?",
+    "not base64",
+    "YQ=",
+    "YQ==\n",
+    "A".repeat(256 * 1024 + 4),
+  ])("drops invalid or oversized Clipboard bodies (case %#)", async (data) => {
+    const socketPath = await startEndpointServer((_hello, socket) => {
+      const w = new BinWriter();
+      w.variant(5);
+      w.string(data);
+      socket.write(encodeFrame(w.toBuffer()));
+    });
+    const client = new EndpointClient(socketPath);
+    const received: unknown[] = [];
+    client.on("clipboard", (value) => received.push(value));
+    try {
+      await client.connect(80, 24);
+      await Bun.sleep(20);
+      expect(received).toEqual([]);
+      expect(client.isClosed).toBe(false);
+    } finally {
+      client.close();
+    }
+  });
+
+  test("drops trailing Clipboard fields and ignores buffered messages after close", async () => {
+    const socketPath = await startEndpointServer((_hello, socket) => {
+      const w = new BinWriter();
+      w.variant(5);
+      w.string("YQ==");
+      const valid = encodeFrame(w.toBuffer());
+      w.u8(0); // Clipboard has exactly one string field, no tail.
+      socket.write(Buffer.concat([encodeFrame(w.toBuffer()), valid, valid]));
+    });
+    const client = new EndpointClient(socketPath);
+    const received: unknown[] = [];
+    client.on("clipboard", (value) => {
+      received.push(value);
+      client.close();
+    });
+    try {
+      await client.connect(80, 24);
+      await Bun.sleep(20);
+      expect(received).toEqual([{ data: "YQ==" }]);
+      expect(client.isClosed).toBe(true);
+    } finally {
+      client.close();
+    }
+  });
+
+  test("rejects truncated Clipboard wire strings without delivering data", async () => {
+    const socketPath = await startEndpointServer((_hello, socket) => {
+      socket.write(encodeFrame(Buffer.from([5, 8, 65])));
+    });
+    const client = new EndpointClient(socketPath);
+    const received: unknown[] = [];
+    client.on("clipboard", (value) => received.push(value));
+    const error = new Promise<Error>((resolve) =>
+      client.once("error", resolve),
+    );
+    try {
+      await client.connect(80, 24);
+      expect((await error).message).toContain("short read");
+      expect(client.isClosed).toBe(true);
+      expect(received).toEqual([]);
+    } finally {
+      client.close();
+    }
+  });
+
   test("sends a generation-1 hello with the required codecs", async () => {
     const socketPath = await startEndpointServer(() => {});
     const client = new EndpointClient(socketPath);

--- a/server/src/bridge/endpoint-client.ts
+++ b/server/src/bridge/endpoint-client.ts
@@ -10,6 +10,7 @@ import {
 } from "./thin-client";
 
 import { type PaneInputEvent, encodePaneInput } from "./vt-input-classifier";
+import { isTerminalClipboardPayload } from "./terminal-clipboard";
 
 const HANDSHAKE_TIMEOUT_MS = 8_000;
 
@@ -26,6 +27,7 @@ const CM = {
 // ServerMessage tags (frozen for endpoint generation 1).
 const SM = {
   Welcome: 0,
+  Clipboard: 5,
   ClientShellSnapshot: 12,
   PaneSurface: 13,
   ClientShellError: 15,
@@ -279,11 +281,18 @@ export class EndpointClient extends EventEmitter {
   }
 
   private handlePayload(payload: Buffer) {
+    if (this.closed) return;
     try {
       const r = new BinReader(payload);
       const variant = r.variant();
       if (variant === SM.EndpointControl) {
         this.handleControl(r.string(), r.string());
+      } else if (variant === SM.Clipboard) {
+        // Tagged 0.9.0: one base64 String, with no producing pane identity.
+        const data = r.string();
+        if (r.remaining === 0 && isTerminalClipboardPayload(data)) {
+          this.emit("clipboard", { data });
+        }
       } else if (variant === SM.PaneSurface) {
         this.handleSurface(r);
       } else if (variant === SM.PaneSurfacePatch) {
@@ -327,7 +336,7 @@ export class EndpointClient extends EventEmitter {
         this.close();
         this.emit("error", error);
       }
-      // Terminal/Notify/Clipboard/graphics variants are not used by shells.
+      // Other optional server messages are ignored.
     } catch (e) {
       const error = e instanceof Error ? e : new Error(String(e));
       this.rejectWelcome(error);

--- a/server/src/bridge/endpoint-terminal-session.test.ts
+++ b/server/src/bridge/endpoint-terminal-session.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import * as net from "node:net";
 import * as path from "node:path";
 import { tmpdir } from "node:os";
@@ -10,6 +10,7 @@ import {
 import type { CellData, FrameData } from "./thin-client";
 import type { ServerWebSocket } from "bun";
 import { createTerminalBridge } from "./terminal-bridge";
+import { silentLogger } from "../utils/logger";
 
 const servers: net.Server[] = [];
 
@@ -144,6 +145,7 @@ async function startSessionServer(handlers: {
   onPaneInput?: (paneId: string, reader: BinReader) => void;
   panes?: TestPane[];
   onConnection?: (sendSurface: (panes: TestPane[]) => void) => void;
+  onClipboardConnection?: (send: (data: string) => void) => void;
 }) {
   const socketPath = path.join(
     tmpdir(),
@@ -160,6 +162,12 @@ async function startSessionServer(handlers: {
     hyperlinks: [],
   };
   const server = net.createServer((socket) => {
+    handlers.onClipboardConnection?.((data) => {
+      const w = new BinWriter();
+      w.variant(5);
+      w.string(data);
+      socket.write(encodeFrame(w.toBuffer()));
+    });
     let input = Buffer.alloc(0);
     let greeted = false;
     let revision = 1;
@@ -549,6 +557,184 @@ test("terminal bridge carries endpoint mouse state and targets each attached ter
     expect(inputs).toHaveLength(2);
   } finally {
     bridge.dispose();
+  }
+});
+
+test("endpoint clipboard follows foreground-recipient ownership, not producing PTY identity", async () => {
+  const peers: Array<(data: string) => void> = [];
+  const sessions: EndpointTerminalSession[] = [];
+  const originalConnect = EndpointTerminalSession.prototype.connect;
+  const connect = spyOn(
+    EndpointTerminalSession.prototype,
+    "connect",
+  ).mockImplementation(function (
+    this: EndpointTerminalSession,
+    cols: number,
+    rows: number,
+  ) {
+    sessions.push(this);
+    return originalConnect.call(this, cols, rows);
+  });
+  const socketPath = await startSessionServer({
+    panes: [
+      { paneId: "w1:p1", x: 0, mouseReporting: false },
+      { paneId: "w1:p2", x: 10, mouseReporting: false },
+    ],
+    onClipboardConnection: (send) => peers.push(send),
+  });
+  const ownerA = {} as ServerWebSocket<unknown>;
+  const ownerB = {} as ServerWebSocket<unknown>;
+  const passive = {} as ServerWebSocket<unknown>;
+  const received: Array<{ ws: ServerWebSocket<unknown>; message: any }> = [];
+  const warnings: string[] = [];
+  const errors: string[] = [];
+  const makeBridge = (connectionId: string, connectionGeneration = 1) =>
+    createTerminalBridge({
+      connectionId,
+      connectionGeneration,
+      clientSocketPath: socketPath,
+      herdrProtocol: async () => 22,
+      lookupPaneId: async (id) => (id === "left" ? "w1:p1" : "w1:p2"),
+      logger: { ...silentLogger, warn: (message) => warnings.push(message) },
+      safeSend: (ws, payload) => {
+        const message = JSON.parse(payload);
+        if (message.terminal_clipboard) received.push({ ws, message });
+        return true;
+      },
+      clientLabel: () => "test",
+      markRpcError: (_ws, _id, detail) => errors.push(detail ?? "error"),
+    });
+  const alpha = makeBridge("alpha");
+  const beta = makeBridge("beta");
+  const attach = (
+    bridge: typeof alpha,
+    ws: typeof ownerA,
+    terminal_id: string,
+  ) =>
+    bridge.handleTerminalRpc(ws, "attach", "terminal.attach", {
+      terminal_id,
+      cols: 20,
+      rows: 5,
+    });
+  const input = (
+    bridge: typeof alpha,
+    ws: typeof ownerA,
+    terminal_id: string,
+  ) =>
+    bridge.handleTerminalRpc(ws, "input", "terminal.input", {
+      terminal_id,
+      data: "eA==",
+    });
+  const deliver = async (peer: number, data = "Y29weQ==") => {
+    peers[peer](data);
+    await Bun.sleep(20);
+  };
+  try {
+    await attach(alpha, ownerA, "left");
+    await attach(alpha, passive, "left");
+    await attach(alpha, ownerB, "right");
+    await attach(beta, ownerA, "left"); // duplicate ids and same browser, separate connection
+    expect(warnings.some((message) => message.includes("unavailable"))).toBe(
+      false,
+    );
+    await deliver(0); // no recent input
+    expect(received).toEqual([]);
+    await input(alpha, ownerA, "left");
+    await deliver(0);
+    expect(received).toEqual([
+      {
+        ws: ownerA,
+        message: {
+          connection_id: "alpha",
+          connection_generation: 1,
+          terminal_clipboard: { terminal_id: "left", data: "Y29weQ==" },
+        },
+      },
+    ]);
+    received.length = 0;
+    await input(alpha, ownerB, "right");
+    await deliver(0); // receiving left session no longer matches global input owner
+    await deliver(2); // beta has no owner, despite same terminal/browser ids
+    expect(received).toEqual([]);
+    // Herdr may send a delayed/background LEFT PTY write to foreground RIGHT.
+    // The wire has no source id: approved semantics deliver to B, not A.
+    const delayedLeft = Buffer.from("delayed left PTY content").toString(
+      "base64",
+    );
+    await deliver(1, delayedLeft);
+    expect(received).toEqual([
+      {
+        ws: ownerB,
+        message: {
+          connection_id: "alpha",
+          connection_generation: 1,
+          terminal_clipboard: { terminal_id: "right", data: delayedLeft },
+        },
+      },
+    ]);
+    received.length = 0;
+    for (const data of ["?", "invalid", "A".repeat(256 * 1024 + 4)])
+      await deliver(1, data);
+    expect(received).toEqual([]);
+    const now = Date.now();
+    const clock = spyOn(Date, "now").mockReturnValue(now + 30_001);
+    try {
+      sessions[1].emit("clipboard", { data: "Y29weQ==" });
+    } finally {
+      clock.mockRestore();
+    }
+    expect(received).toEqual([]);
+    await input(beta, ownerA, "left");
+    await deliver(2);
+    expect(received[0].message.connection_id).toBe("beta");
+    received.length = 0;
+    // Detach one pane while this browser still views another; reattach must
+    // not resurrect its prior input owner, even with the same shared session.
+    await attach(alpha, ownerA, "right");
+    await input(alpha, ownerA, "left");
+    await alpha.handleTerminalRpc(ownerA, "detach", "terminal.detach", {
+      terminal_id: "left",
+    });
+    await attach(alpha, ownerA, "left");
+    await deliver(0);
+    expect(received).toEqual([]);
+    await input(alpha, ownerA, "left");
+    // A closed transport cannot pass a queued clipboard event to a replacement.
+    sessions[0].close();
+    await Bun.sleep(20);
+    await attach(alpha, ownerA, "left");
+    sessions[0].emit("clipboard", { data: "Y29weQ==" });
+    await deliver(3);
+    expect(received).toEqual([]);
+    await input(alpha, ownerA, "left");
+    sessions[0].emit("clipboard", { data: "Y29weQ==" });
+    expect(received).toEqual([]);
+    await deliver(3);
+    expect(received).toHaveLength(1);
+    expect(received[0].ws).toBe(ownerA);
+    received.length = 0;
+    alpha.cleanupWs(ownerA);
+    sessions[3].emit("clipboard", { data: "Y29weQ==" });
+    expect(received).toEqual([]);
+    alpha.dispose();
+    const replacement = makeBridge("alpha", 2);
+    try {
+      await attach(replacement, ownerA, "left");
+      await input(replacement, ownerA, "left");
+      sessions[3].emit("clipboard", { data: "Y29weQ==" });
+      expect(received).toEqual([]);
+      await deliver(4);
+      expect(received[0].message.connection_generation).toBe(2);
+      expect(received).toHaveLength(1);
+    } finally {
+      replacement.dispose();
+    }
+    expect(received.some(({ ws }) => ws === passive)).toBe(false);
+    expect(errors).toEqual([]);
+  } finally {
+    alpha.dispose();
+    beta.dispose();
+    connect.mockRestore();
   }
 });
 

--- a/server/src/bridge/endpoint-terminal-session.ts
+++ b/server/src/bridge/endpoint-terminal-session.ts
@@ -43,6 +43,9 @@ export class EndpointTerminalSession extends EventEmitter {
     super();
     this.client = new EndpointClient(socketPath);
     this.client.on("surface", (s) => this.onSurface(s));
+    this.client.on("clipboard", (clipboard) => {
+      if (!this.closed && this.paneId) this.emit("clipboard", clipboard);
+    });
     this.client.on("error", (e) => this.emit("error", e));
     this.client.on("close", () => {
       this.pressedMouseButtons.clear();

--- a/server/src/bridge/terminal-bridge.test.ts
+++ b/server/src/bridge/terminal-bridge.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { tmpdir } from "node:os";
 import { BinReader, BinWriter, encodeFrame } from "./bincode";
 import { createTerminalBridge } from "./terminal-bridge";
+import { silentLogger } from "../utils/logger";
 
 test("explicit half-page history retains legacy Wheel source and line count", async () => {
   const sources: number[] = [];
@@ -260,8 +261,10 @@ describe("terminal bridge sharing", () => {
       const socketPath = await startThinServer({ protocol, tracker });
       const browser = {} as ServerWebSocket<unknown>;
       const messages: string[] = [];
+      const warnings: string[] = [];
       const bridge = createTerminalBridge({
         clientSocketPath: socketPath,
+        logger: { ...silentLogger, warn: (message) => warnings.push(message) },
         herdrProtocol: async () => protocol,
         safeSend: (_ws, payload) => {
           messages.push(payload);
@@ -281,6 +284,11 @@ describe("terminal bridge sharing", () => {
           tracker.events.filter((event) => event === "attach"),
         ).toHaveLength(1);
         expect(tracker.appConnects).toBe(protocol === 22 ? 0 : 1);
+        expect(
+          warnings.filter((message) =>
+            message.includes("OSC 52 unavailable on the legacy fallback"),
+          ),
+        ).toHaveLength(protocol === 22 ? 1 : 0);
         const viewer = {} as ServerWebSocket<unknown>;
         await bridge.handleTerminalRpc(viewer, "second", "terminal.attach", {
           terminal_id: "term_1",

--- a/server/src/bridge/terminal-bridge.ts
+++ b/server/src/bridge/terminal-bridge.ts
@@ -8,6 +8,7 @@ import { NO_TERMINAL_ATTACHED_MESSAGE } from "../utils/rpc-logging";
 import { ThinClient } from "./thin-client";
 import { isTerminalHelloProtocol } from "./protocol-compat";
 import { EndpointTerminalSession } from "./endpoint-terminal-session";
+import { isTerminalClipboardPayload } from "./terminal-clipboard";
 
 type TerminalSession = {
   terminalId: string | null;
@@ -36,13 +37,12 @@ type ClipboardTarget = {
   ws: ServerWebSocket<unknown>;
   terminalId: string;
   inputAt: number;
+  session: SharedTerminalSession;
 };
 
 const CLIPBOARD_INPUT_WINDOW_MS = 30_000;
 const CLIPBOARD_RELAY_READY_WAIT_MS = 500;
 const TERMINAL_FIRST_FRAME_WAIT_MS = 20_000;
-// Herdr rejects OSC 52 bodies above 256 KiB before emitting Clipboard.
-const MAX_TERMINAL_CLIPBOARD_BASE64_CHARS = 256 * 1024;
 const STANDARD_BASE64_RE =
   /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
 
@@ -124,11 +124,7 @@ export function createTerminalBridge(args: {
 
   function forwardClipboard(data: string, terminalId?: string) {
     if (disposed) return;
-    if (
-      !data ||
-      data.length > MAX_TERMINAL_CLIPBOARD_BASE64_CHARS ||
-      !STANDARD_BASE64_RE.test(data)
-    ) {
+    if (!isTerminalClipboardPayload(data)) {
       logger.warn("dropped invalid terminal clipboard payload", {
         connection: args.connectionId ?? "legacy-default",
       });
@@ -139,6 +135,9 @@ export function createTerminalBridge(args: {
     const recentTarget =
       clipboardTarget &&
       now - clipboardTarget.inputAt <= CLIPBOARD_INPUT_WINDOW_MS &&
+      !clipboardTarget.session.thin.isClosed &&
+      sharedTerminals.get(clipboardTarget.terminalId) ===
+        clipboardTarget.session &&
       terminalViewers
         .get(clipboardTarget.ws)
         ?.has(clipboardTarget.terminalId) &&
@@ -253,23 +252,30 @@ export function createTerminalBridge(args: {
       // OSC 52 only to the foreground *shell* (endpoint-protocol) client;
       // direct terminal connections like this relay are never foreground and
       // can never receive ServerMessage::Clipboard there. Skip the relay and
-      // log the limitation instead of idling silently. Browser copy/paste
-      // remains available; terminal-program OSC 52 needs a shell endpoint.
+      // use the endpoint session's clipboard events instead. Only the explicit
+      // legacy fallback still lacks OSC 52; browser copy/paste is unaffected.
       const protocol = await args.herdrProtocol();
       if (disposed) return;
       if (isTerminalHelloProtocol(protocol)) {
         clipboardRelaySkipped = true;
-        logger.warn(
-          "terminal-program OSC 52 unavailable: Herdr protocol 22 routes clipboard only to endpoint shell clients; browser copy/paste is unaffected",
-          { connection: args.connectionId ?? "legacy-default" },
-        );
+        if (
+          !args.lookupPaneId ||
+          process.env.HERDR_GUI_DISABLE_ENDPOINT === "1"
+        ) {
+          logger.warn(
+            "terminal-program OSC 52 unavailable on the legacy fallback: Herdr protocol 22 routes clipboard only to endpoint shell clients; browser copy/paste is unaffected",
+            { connection: args.connectionId ?? "legacy-default" },
+          );
+        }
         return;
       }
 
       const relay = new ThinClient(args.clientSocketPath, args.herdrProtocol);
       clipboardRelay = relay;
       clipboardRelaySize = { cols, rows };
-      relay.on("clipboard", ({ data }) => forwardClipboard(data));
+      relay.on("clipboard", ({ data }) => {
+        if (clipboardRelay === relay && !relay.isClosed) forwardClipboard(data);
+      });
       relay.on("error", (error) =>
         logger.warn("clipboard relay error", {
           connection: args.connectionId ?? "legacy-default",
@@ -409,6 +415,9 @@ export function createTerminalBridge(args: {
       ? [terminalId]
       : Array.from(viewed ?? (current?.terminalId ? [current.terminalId] : []));
     for (const id of terminalIds) {
+      if (clipboardTarget?.ws === ws && clipboardTarget.terminalId === id) {
+        clipboardTarget = null;
+      }
       const shared = sharedTerminals.get(id);
       shared?.viewers.delete(ws);
       if (shared && shared.viewers.size === 0) {
@@ -530,9 +539,18 @@ export function createTerminalBridge(args: {
         args.safeSend(viewer, payload, "terminal-frame");
       }
     });
-    // Keep compatibility with a future Herdr version that may route clipboard
-    // side effects directly to the terminal attachment.
-    thin.on("clipboard", ({ data }) => forwardClipboard(data, terminalId));
+    // Bind to the receiving session, NOT the producing PTY: Herdr 0.9.0 sends
+    // clipboard to its foreground shell without source attribution. The global
+    // recent input owner must still match this session; never broadcast.
+    thin.on("clipboard", ({ data }) => {
+      if (
+        isCurrent(creationRevision) &&
+        !thin.isClosed &&
+        sharedTerminals.get(terminalId) === shared
+      ) {
+        forwardClipboard(data, terminalId);
+      }
+    });
     thin.on("welcome", (w) => {
       logger.debug("terminal stream welcome", {
         connection: args.connectionId ?? "legacy-default",
@@ -551,6 +569,7 @@ export function createTerminalBridge(args: {
       });
     });
     thin.on("close", () => {
+      if (clipboardTarget?.session === shared) clipboardTarget = null;
       const resolve = shared.resolveFirstFrame;
       if (resolve) {
         shared.resolveFirstFrame = null;
@@ -780,7 +799,7 @@ export function createTerminalBridge(args: {
         return reply({ ok: true });
       }
       if (method === "terminal.input") {
-        if (!thin || !requestedTerminalId) {
+        if (!thin || thin.isClosed || !shared || !requestedTerminalId) {
           return fail(NO_TERMINAL_ATTACHED_MESSAGE);
         }
         const b64 = String(params.data ?? "");
@@ -793,6 +812,7 @@ export function createTerminalBridge(args: {
           ws,
           terminalId: requestedTerminalId,
           inputAt: Date.now(),
+          session: shared,
         };
         thin.input(input);
         return reply({ ok: true });

--- a/server/src/bridge/terminal-clipboard.ts
+++ b/server/src/bridge/terminal-clipboard.ts
@@ -1,0 +1,13 @@
+// Herdr rejects OSC 52 bodies above 256 KiB before emitting Clipboard.
+const MAX_TERMINAL_CLIPBOARD_BASE64_CHARS = 256 * 1024;
+const STANDARD_BASE64_RE =
+  /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+/** Validate the transport body; the browser additionally enforces UTF-8/text limits. */
+export function isTerminalClipboardPayload(data: string): boolean {
+  return (
+    data.length > 0 &&
+    data.length <= MAX_TERMINAL_CLIPBOARD_BASE64_CHARS &&
+    STANDARD_BASE64_RE.test(data)
+  );
+}


### PR DESCRIPTION
## Summary

Closes #109 under the explicitly approved foreground-recipient semantics described below.

- Decode stable endpoint Clipboard messages and reuse existing authenticated, connection-scoped browser delivery, with shared base64/size validation.
- Deliver only to the current recent-input browser matching the live receiving endpoint session; reject stale, detached, replaced, disposed or mismatched session ownership and never broadcast to passive viewers.
- Preserve legacy relay behavior, clipboard-read refusal, browser UTF-8/text limits and permission fallback/retry. No frontend implementation changes or new dependencies.

## Approved scope clarification

Herdr 0.9.0's clipboard message contains no producing-pane or initiating-input identity. The owner explicitly chose its existing **foreground-recipient** behavior instead of waiting for an upstream attribution API. A delayed/background write from pane A can consequently arrive at B after B becomes foreground; this PR does not claim actual source-PTY or original initiating-browser isolation. The original issue's stronger attribution expectation is superseded by this approved scope. The limitation is documented in FEATURES.md, docs/DEPLOYMENT.md and CHANGELOG.md and positively exercised in the real Herdr smoke test. Clipboard reads remain disabled. No upstream change or Discussion was made.

## Verification

- Focused codec/session/legacy/frontend-permission tests: **57 passed**, 315 assertions.
- `bun run precommit`: **1118 passed, 1 existing live-SSH skip, 0 failed**; format, lint and typechecks passed.
- `bun run build:web`: passed; asset budget 118/160 files, 9.5/12 MiB.
- Changed TypeScript files: primary LSP diagnostics clean; `git diff --check` passed.
- Isolated real Herdr 0.9.0/protocol 22 plus three WebSocket recipients: A received its one write, B received its own write and the delayed A write after becoming foreground, passive viewer received zero. Only disposable test content used; no user's system clipboard/session touched.
- Independent review: **OK with notes**, no findings.

## Remaining verification gaps

Live SSH was skipped because no opt-in target is configured. Actual browser Clipboard API writes and permission prompts were not exercised; existing permission-denial/fallback/retry tests pass. The smoke tests verify real bridge-to-WebSocket delivery, not production login or an OS clipboard write.
