### PR TITLE
Keep browser workspace and tab navigation independent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
 
 ### Fixed
 
+- Keep workspace and tab navigation local to each browser on Herdr 0.9.0
+  endpoints, including reconnect and closed-pane fallback. Legacy navigation,
+  native same-tab pane focus, topology and terminal sizes remain shared.
+  Preserve Herdr's cwd policy for client-scoped creation, and wait for terminal
+  attachment readiness instead of silently dropping early input.
+
 - Restore terminal-program OSC 52 clipboard writes on Herdr 0.9.0 endpoints,
   using its foreground recipient and Studio's recent-input filtering. Herdr
   does not identify the producing pane; delayed/background writes can reach

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -13,6 +13,18 @@ the [hands-on tutorial](./docs/TUTORIAL.md).
 
 - Browse all Herdr workspaces and their recognized agents from one sidebar.
 - Create, rename, focus, pin, and close workspaces.
+- On Herdr 0.9.0 endpoints, each browser remembers its workspace, tab and pane
+  selection per connection; workspace/tab navigation does not move other
+  browsers or native clients.
+  Reconnect preserves live selections; closing or moving a selected pane picks
+  a remaining pane in the selected tab, then a remaining tab/workspace if needed.
+  Reload starts from Herdr's current selection. The connection menu labels
+  **Local navigation** versus the legacy **Shared navigation** fallback.
+  Create/close/move operations and terminal sizes remain shared. Herdr's
+  same-tab pane focus remains shared, including the pane supplying `follow` cwd.
+  Creating tabs/workspaces preserves Herdr's cwd policy and requires the source
+  terminal tab to be open and connected; unavailable sources show an error.
+  An empty session can create its first workspace directly from Studio.
 - Group linked Git worktrees under their parent repository workspace. Groups can
   be collapsed, while individual workspaces or worktrees can be pinned to the
   top. Pin and collapse preferences are stored in the current browser.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -45,6 +45,35 @@ and mobile controls. WebSocket events keep multiple authenticated browsers in
 sync with server-side Herdr state, while each browser retains its own view and
 connection selection.
 
+With Herdr 0.9.0 endpoints, the store also owns workspace/tab/pane navigation
+per connection/runtime. `browserNavigation.ts` projects local choices into the
+existing focused fields, so desktop, mobile, inspectors and action targets use
+one selection. Shared snapshots supply topology, not subsequent navigation;
+stale in-flight layouts are discarded after local selection changes. Creation
+uses explicit context and `focus: false`, then adopts returned IDs locally only
+if the initiating selection and connection lease are still current. Delayed
+worktree/split/notification results cannot steal newer navigation.
+For tab/workspace creation, Studio-only `browser_source` identifies the caller's
+attached terminal, pane, tab and workspace. The bridge validates ownership and
+live topology, strips that field, and invokes the advertised create method on
+the existing endpoint, serialized with its focus/scroll command lane. No extra
+focus call or endpoint client is created. Omitting synthesized cwd preserves
+Herdr's policy; its same-tab pane focus (and `follow` cwd source) remains shared.
+Missing attachments fail explicitly rather than using shared control context.
+The sole exception is first-workspace bootstrap: each runtime serializes a valid
+empty `workspace.list` check and control creation, rechecking lease and deadline
+before dispatch. A competing request observes nonempty topology and must retry.
+Creation has a 20-second admission deadline spanning readiness, validation and
+queue residence, below the browser RPC timeout. Expired undispatched mutations
+never execute; dispatched timeouts warn about uncertain completion.
+Input waits for attachment readiness and revalidates its attachment token,
+session and routing lease before forwarding or assigning clipboard ownership;
+input is never replayed into a detached/replaced terminal.
+The bridge adds `workspace.list.navigation_mode` from the same verified backend
+choice used for terminal sessions. Legacy/endpoint-disabled paths remain shared.
+Endpoint terminal sessions still focus and send input to their explicit pane;
+no browser-session backend or upstream wire extension is needed.
+
 ## Connection isolation
 
 One bridge may manage multiple existing Herdr servers. Profiles are shared by

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -40,10 +40,25 @@ direct-terminal fallback:
   existing copy-retry UI. Ordinary browser selection copy and paste are unchanged.
   OSC 52 remains unavailable on the **0.9.0 legacy fallback** because only shell
   endpoints receive it. Legacy servers retain their existing clipboard relay.
-- Public JSON workspace/tab/pane focus remains session-wide; Studio does not
-  promise independent navigation alongside other Herdr clients. Enhanced Kitty
-  keyboard / modifyOtherKeys parity and pixel mouse are not supported. Legacy
-  keyboard-mode messages are decoded, not applied in-browser.
+- Endpoint navigation is browser-local, partitioned by connection. Studio
+  projects workspace/tab/pane selection locally and sends terminal input to
+  explicit pane targets; it does not issue public JSON focus calls for navigation.
+  Selection survives browser reconnect but not page reload or connection-runtime
+  replacement. Create/close/move are shared topology changes; creation selects
+  its result only in the initiating browser. Tab/workspace creation reuses the
+  source tab's attached endpoint, preserving `terminal.new_cwd` (`follow`,
+  `home`, `current`, or a fixed path); explicit cwd still wins. Herdr's focused
+  pane within a tab is shared, so `follow` is not browser-source-pane isolation.
+  Open the source terminal tab before creating; unattached/offscreen sources
+  fail explicitly. A server-verified empty session can create its first workspace
+  directly; competing first creations must retry against the resulting topology.
+  Terminal sizing remains shared and follows Herdr's last-interacting client
+  behavior.
+- Legacy servers and `HERDR_GUI_DISABLE_ENDPOINT=1` retain **Shared navigation**:
+  public JSON focus can move other clients. The connection menu shows the mode,
+  using the bridge's actual backend selection, not browser version guesses.
+  Enhanced Kitty keyboard / modifyOtherKeys parity and pixel mouse are not
+  supported. Legacy keyboard-mode messages are decoded, not applied in-browser.
 - Closing a workspace does not implicitly close its linked group. If Herdr
   requires group closure, Studio leaves it intact and directs you to the CLI:
   `herdr --session <name> workspace close <workspace_id> --group`. Review all

--- a/server/src/bridge/endpoint-creation.test.ts
+++ b/server/src/bridge/endpoint-creation.test.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "bun:test";
+import {
+  assertEndpointCreationSource,
+  createEmptyWorkspaceCreator,
+  EndpointCreationDeadline,
+  parseEndpointCreationSource,
+} from "./endpoint-creation";
+const source = {
+  workspace_id: "w1",
+  tab_id: "w1:t1",
+  pane_id: "w1:p1",
+  terminal_id: "term1",
+};
+test("creation source validates all explicit identities and rejects moved or missing panes", () => {
+  expect(parseEndpointCreationSource(source)).toEqual(source);
+  for (const value of [
+    null,
+    [],
+    {},
+    { ...source, pane_id: 42 },
+    { ...source, tab_id: "x".repeat(257) },
+    { ...source, terminal_id: "\n" },
+  ]) {
+    expect(() => parseEndpointCreationSource(value)).toThrow();
+  }
+  expect(() =>
+    assertEndpointCreationSource(source, { ...source, focused: false }),
+  ).not.toThrow();
+  for (const pane of [
+    null,
+    {},
+    { ...source, workspace_id: "w2" },
+    { ...source, tab_id: "w1:t2" },
+    { ...source, terminal_id: "replacement" },
+  ]) {
+    expect(() => assertEndpointCreationSource(source, pane)).toThrow(
+      "moved or closed",
+    );
+  }
+});
+
+for (const reason of ["lease", "deadline"] as const) {
+  test(`empty bootstrap rechecks ${reason} after topology validation`, async () => {
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let current = true;
+    const calls: string[] = [];
+    const create = createEmptyWorkspaceCreator(async (method) => {
+      calls.push(method);
+      if (method === "workspace.list") await held;
+      return { type: "workspace_list", workspaces: [] };
+    });
+    const deadline = new EndpointCreationDeadline(
+      reason === "deadline" ? 10 : 20000,
+    );
+    const task = create({ browser_source: null }, () => current, deadline);
+    const rejected = task.then(
+      () => null,
+      (error: Error) => error,
+    );
+    await Promise.resolve();
+    if (reason === "deadline")
+      await expect(deadline.wait(task)).rejects.toThrow(
+        "expired before dispatch",
+      );
+    else current = false;
+    release();
+    expect(await rejected).toBeInstanceOf(Error);
+    expect(calls).toEqual(["workspace.list"]);
+  });
+}
+
+test("empty bootstrap rejects malformed and nonempty topology without mutation", async () => {
+  for (const topology of [
+    null,
+    {},
+    [],
+    { type: "workspace_list", workspaces: null },
+    { type: "wrong", workspaces: [] },
+    { type: "workspace_list", workspaces: [{}] },
+  ]) {
+    const calls: string[] = [];
+    const create = createEmptyWorkspaceCreator(async (method) => {
+      calls.push(method);
+      return topology;
+    });
+    await expect(
+      create(
+        { browser_source: null },
+        () => true,
+        new EndpointCreationDeadline(),
+      ),
+    ).rejects.toThrow();
+    expect(calls).toEqual(["workspace.list"]);
+  }
+});

--- a/server/src/bridge/endpoint-creation.ts
+++ b/server/src/bridge/endpoint-creation.ts
@@ -1,0 +1,161 @@
+export interface EndpointCreationSource {
+  workspace_id: string;
+  tab_id: string;
+  pane_id: string;
+  terminal_id: string;
+}
+
+/** Studio-only creation context; never forward this field to Herdr. */
+export function parseEndpointCreationSource(
+  value: unknown,
+): EndpointCreationSource {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(
+      "Open the source workspace's terminal tab before creating a tab or workspace.",
+    );
+  }
+  const source = value as Record<string, unknown>;
+  for (const key of [
+    "workspace_id",
+    "tab_id",
+    "pane_id",
+    "terminal_id",
+  ] as const) {
+    const id = source[key];
+    if (
+      typeof id !== "string" ||
+      !id ||
+      id.length > 256 ||
+      /[\u0000-\u001f\u007f]/.test(id)
+    ) {
+      throw new Error(`Invalid browser creation source ${key}`);
+    }
+  }
+  return {
+    workspace_id: source.workspace_id as string,
+    tab_id: source.tab_id as string,
+    pane_id: source.pane_id as string,
+    terminal_id: source.terminal_id as string,
+  };
+}
+
+export function assertEndpointCreationSource(
+  source: EndpointCreationSource,
+  pane: unknown,
+): void {
+  if (
+    !pane ||
+    typeof pane !== "object" ||
+    Object.entries(source).some(
+      ([key, id]) => (pane as Record<string, unknown>)[key] !== id,
+    )
+  )
+    throw new Error(
+      "Source pane moved or closed. Open its current tab and retry creation.",
+    );
+}
+
+/** Admission-to-dispatch budget stays below the browser's 30-second RPC timeout. */
+export class EndpointCreationDeadline {
+  private readonly expiresAt: number;
+  private dispatched = false;
+
+  constructor(timeoutMs = 20_000) {
+    this.expiresAt = Date.now() + timeoutMs;
+  }
+
+  private error() {
+    return new Error(
+      this.dispatched
+        ? "Creation timed out after dispatch; check Herdr before retrying. Creation may have succeeded."
+        : "Creation expired before dispatch; nothing was created. Retry from the current terminal.",
+    );
+  }
+
+  assertBeforeDispatch() {
+    if (Date.now() >= this.expiresAt) throw this.error();
+  }
+
+  dispatch<T>(send: () => Promise<T>): Promise<T> {
+    this.assertBeforeDispatch();
+    this.dispatched = true;
+    return send();
+  }
+
+  async wait<T>(
+    pending: Promise<T>,
+    onDispatchedTimeout?: () => void,
+  ): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        pending,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () => {
+              reject(this.error());
+              if (this.dispatched) onDispatchedTimeout?.();
+            },
+            Math.max(0, this.expiresAt - Date.now()),
+          );
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+}
+
+/** One bootstrap lane per runtime: a second caller must recheck after the first. */
+export function createEmptyWorkspaceCreator(
+  call: (
+    method: string,
+    params: Record<string, unknown>,
+    timeoutMs: number,
+  ) => Promise<unknown>,
+) {
+  let tail: Promise<unknown> = Promise.resolve();
+  return (
+    params: Record<string, unknown>,
+    isCurrent: () => boolean,
+    deadline: EndpointCreationDeadline,
+  ) => {
+    const check = () => {
+      deadline.assertBeforeDispatch();
+      if (!isCurrent())
+        throw new Error("Creation connection changed. Reconnect and retry.");
+    };
+    const task = tail.then(async () => {
+      check();
+      const topology = await call("workspace.list", {}, 5000);
+      if (
+        !topology ||
+        typeof topology !== "object" ||
+        !("type" in topology) ||
+        topology.type !== "workspace_list" ||
+        !("workspaces" in topology) ||
+        !Array.isArray(topology.workspaces)
+      )
+        throw new Error(
+          "Cannot verify an empty session. Refresh and retry creation.",
+        );
+      if (topology.workspaces.length !== 0)
+        throw new Error(
+          "Session is no longer empty. Open a terminal in the desired workspace and retry creation.",
+        );
+      check();
+      const creationParams: Record<string, unknown> = {
+        ...params,
+        focus: false,
+      };
+      delete creationParams.browser_source;
+      delete creationParams.source_workspace_id;
+      return deadline.dispatch(() =>
+        call("workspace.create", creationParams, 20_000),
+      );
+    });
+    // Keep the lane until the actual control request settles, even if its caller expires.
+    tail = task.catch(() => undefined);
+    return task;
+  };
+}

--- a/server/src/bridge/endpoint-terminal-session.test.ts
+++ b/server/src/bridge/endpoint-terminal-session.test.ts
@@ -11,6 +11,7 @@ import type { CellData, FrameData } from "./thin-client";
 import type { ServerWebSocket } from "bun";
 import { createTerminalBridge } from "./terminal-bridge";
 import { silentLogger } from "../utils/logger";
+import { EndpointCreationDeadline } from "./endpoint-creation";
 
 const servers: net.Server[] = [];
 
@@ -141,7 +142,8 @@ const WELCOME = {
  * endpoint requests, and streams a two-pane surface.
  */
 async function startSessionServer(handlers: {
-  onRequest?: (method: string, params: any) => void;
+  onRequest?: (method: string, params: any, connection: number) => unknown;
+  methods?: string[];
   onPaneInput?: (paneId: string, reader: BinReader) => void;
   panes?: TestPane[];
   onConnection?: (sendSurface: (panes: TestPane[]) => void) => void;
@@ -161,7 +163,12 @@ async function startSessionServer(handlers: {
     cursor: { x: 2, y: 2, visible: true, shape: 1 },
     hyperlinks: [],
   };
+  let connectionSeq = 0;
   const server = net.createServer((socket) => {
+    socket.on("error", (error: NodeJS.ErrnoException) => {
+      expect(["EPIPE", "ECONNRESET"]).toContain(error.code ?? "");
+    });
+    const connection = ++connectionSeq;
     handlers.onClipboardConnection?.((data) => {
       const w = new BinWriter();
       w.variant(5);
@@ -191,7 +198,13 @@ async function startSessionServer(handlers: {
           reader.string(); // data
           socket.write(
             encodeFrame(
-              controlFrame("endpoint.welcome.v1", JSON.stringify(WELCOME)),
+              controlFrame(
+                "endpoint.welcome.v1",
+                JSON.stringify({
+                  ...WELCOME,
+                  methods: handlers.methods ?? WELCOME.methods,
+                }),
+              ),
             ),
           );
           socket.write(
@@ -209,14 +222,25 @@ async function startSessionServer(handlers: {
           // ClientShellEndpointRequest
           reader.string(); // boot_id
           const request = JSON.parse(reader.string());
-          handlers.onRequest?.(request.method, request.params);
-          const w = new BinWriter();
-          w.variant(18); // ClientShellEndpointResponseChunk
-          w.string("boot-1");
-          w.string(request.id);
-          w.bool(true);
-          w.bytes(Buffer.from(JSON.stringify({ id: request.id, result: {} })));
-          socket.write(encodeFrame(w.toBuffer()));
+          void Promise.resolve()
+            .then(() =>
+              handlers.onRequest?.(request.method, request.params, connection),
+            )
+            .then(
+              (result) => sendResponse({ result: result ?? {} }),
+              (error) => sendResponse({ error: { message: String(error) } }),
+            );
+          function sendResponse(response: object) {
+            const w = new BinWriter();
+            w.variant(18);
+            w.string("boot-1");
+            w.string(request.id);
+            w.bool(true);
+            w.bytes(
+              Buffer.from(JSON.stringify({ id: request.id, ...response })),
+            );
+            socket.write(encodeFrame(w.toBuffer()));
+          }
         } else if (variant === 13) {
           const paneId = reader.string();
           handlers.onPaneInput?.(paneId, reader);
@@ -769,3 +793,719 @@ describe("cropFrame", () => {
     expect(cropped.cursor).toBeNull();
   });
 });
+
+const creationSource = {
+  workspace_id: "w1",
+  tab_id: "w1:t1",
+  pane_id: "w1:p1",
+  terminal_id: "term1",
+};
+const creationMethods = [
+  "pane.focus",
+  "pane.scroll",
+  "tab.create",
+  "workspace.create",
+];
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+async function settleUntil(predicate: () => boolean) {
+  for (let i = 0; i < 200 && !predicate(); i++) await Bun.sleep(5);
+  expect(predicate()).toBe(true);
+}
+
+function creationBridge(
+  socketPath: string,
+  options: {
+    lookup?: (id: string) => Promise<string | null>;
+    validate?: (source: typeof creationSource) => Promise<void>;
+  } = {},
+) {
+  const replies: any[] = [];
+  const bridge = createTerminalBridge({
+    clientSocketPath: socketPath,
+    herdrProtocol: async () => 22,
+    lookupPaneId: options.lookup ?? (async () => "w1:p1"),
+    validateCreationSource: options.validate ?? (async () => {}),
+    safeSend: (_ws, message) => {
+      replies.push(JSON.parse(message));
+      return true;
+    },
+    clientLabel: () => "test",
+    markRpcError: () => {},
+  });
+  const ws = {} as ServerWebSocket<unknown>;
+  const attach = (id = "attach") =>
+    bridge.handleTerminalRpc(ws, id, "terminal.attach", {
+      terminal_id: "term1",
+      cols: 80,
+      rows: 24,
+      relay_active: false,
+    });
+  return { bridge, ws, replies, attach };
+}
+
+describe("attached endpoint creation and input readiness", () => {
+  test("waits for pane lookup/focus readiness before creating or forwarding input", async () => {
+    const lookup = deferred<string>();
+    let lookupStarted = false;
+    const inputs: string[] = [];
+    const requests: string[] = [];
+    const socketPath = await startSessionServer({
+      methods: creationMethods,
+      onRequest: (method) => {
+        requests.push(method);
+      },
+      onPaneInput: (paneId) => inputs.push(paneId),
+    });
+    const { bridge, ws, replies, attach } = creationBridge(socketPath, {
+      lookup: async () => {
+        lookupStarted = true;
+        return lookup.promise;
+      },
+    });
+    try {
+      const attaching = attach();
+      await settleUntil(() => lookupStarted);
+      const input = bridge.handleTerminalRpc(ws, "input", "terminal.input", {
+        terminal_id: "term1",
+        data: Buffer.from("X").toString("base64"),
+      });
+      const creation = bridge.createFromTerminal(
+        ws,
+        "tab.create",
+        { workspace_id: "w1", browser_source: creationSource },
+        () => true,
+      );
+      await Bun.sleep(10);
+      expect(replies.some((r) => r.id === "input")).toBe(false);
+      expect(inputs).toEqual([]);
+      lookup.resolve("w1:p1");
+      await Promise.all([attaching, input, creation]);
+      await settleUntil(() => inputs.length === 1);
+      expect(requests).toEqual(["pane.focus", "tab.create"]);
+      expect(inputs).toEqual(["w1:p1"]);
+      expect(replies.find((r) => r.id === "input")).toEqual({
+        id: "input",
+        result: { ok: true },
+      });
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  for (const invalidation of [
+    "detach",
+    "replace",
+    "lease",
+    "dispose",
+  ] as const) {
+    test(`does not replay pending input after ${invalidation}`, async () => {
+      const lookup = deferred<string>();
+      let lookupCount = 0;
+      let current = true;
+      const inputs: string[] = [];
+      const socketPath = await startSessionServer({
+        onPaneInput: (paneId) => inputs.push(paneId),
+      });
+      const { bridge, ws, replies, attach } = creationBridge(socketPath, {
+        lookup: async () => (++lookupCount === 1 ? lookup.promise : "w1:p1"),
+      });
+      try {
+        const attaching = attach();
+        await settleUntil(() => lookupCount === 1);
+        const input = bridge.handleTerminalRpc(
+          ws,
+          "input",
+          "terminal.input",
+          { terminal_id: "term1", data: "WA==" },
+          () => current,
+        );
+        await Bun.sleep(5);
+        if (invalidation === "lease") current = false;
+        else if (invalidation === "dispose") bridge.dispose();
+        else {
+          await bridge.handleTerminalRpc(ws, "detach", "terminal.detach", {
+            terminal_id: "term1",
+          });
+          if (invalidation === "replace") await attach("replacement");
+        }
+        lookup.resolve("w1:p1");
+        await Promise.all([attaching, input]);
+        expect(replies.find((r) => r.id === "input")?.error).toBeDefined();
+        expect(inputs).toEqual([]);
+      } finally {
+        bridge.dispose();
+      }
+    });
+  }
+
+  test("preserves defaults for every cwd policy and explicit cwd; no extra focus or browser fields", async () => {
+    const requests: Array<{ method: string; params: any }> = [];
+    let policy = "follow";
+    const policyCwd: Record<string, string> = {
+      follow: "/source-tab/shared-focused-pane",
+      home: "/home",
+      current: "/server-cwd",
+      path: "/configured",
+    };
+    const socketPath = await startSessionServer({
+      methods: creationMethods,
+      onRequest: (method, params) => {
+        requests.push({ method, params });
+        return { cwd: params.cwd ?? policyCwd[policy] };
+      },
+    });
+    const { bridge, ws, attach } = creationBridge(socketPath);
+    try {
+      await attach();
+      for (policy of Object.keys(policyCwd)) {
+        for (const method of ["tab.create", "workspace.create"] as const) {
+          const params = {
+            workspace_id: "w1",
+            browser_source: creationSource,
+            focus: true,
+          };
+          expect(
+            await bridge.createFromTerminal(ws, method, params, () => true),
+          ).toEqual({ cwd: policyCwd[policy] });
+          expect(
+            await bridge.createFromTerminal(
+              ws,
+              method,
+              { ...params, cwd: "/explicit" },
+              () => true,
+            ),
+          ).toEqual({ cwd: "/explicit" });
+        }
+      }
+      expect(requests.filter((r) => r.method === "pane.focus")).toHaveLength(1);
+      for (const request of requests.filter((r) =>
+        r.method.endsWith("create"),
+      )) {
+        expect(request.params.focus).toBe(false);
+        expect(request.params).not.toHaveProperty("browser_source");
+        if (request.params.cwd !== "/explicit")
+          expect(request.params).not.toHaveProperty("cwd");
+      }
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  test("rejects missing, mismatched, moved, and other-browser source attachments", async () => {
+    let moved = false;
+    const requests: string[] = [];
+    const socketPath = await startSessionServer({
+      methods: creationMethods,
+      onRequest: (method) => {
+        requests.push(method);
+      },
+    });
+    const { bridge, ws, attach } = creationBridge(socketPath, {
+      validate: async () => {
+        if (moved) throw new Error("source moved");
+      },
+    });
+    const params = { workspace_id: "w1", browser_source: creationSource };
+    try {
+      await expect(
+        bridge.createFromTerminal(ws, "tab.create", params, () => true),
+      ).rejects.toThrow("Open the source terminal");
+      await expect(
+        bridge.createFromTerminal(
+          ws,
+          "workspace.create",
+          { browser_source: null },
+          () => true,
+        ),
+      ).rejects.toThrow("Empty-session creation is unavailable");
+      await attach();
+      await expect(
+        bridge.createFromTerminal(
+          {} as ServerWebSocket<unknown>,
+          "tab.create",
+          params,
+          () => true,
+        ),
+      ).rejects.toThrow("attachment changed");
+      await expect(
+        bridge.createFromTerminal(
+          ws,
+          "tab.create",
+          { ...params, workspace_id: "other" },
+          () => true,
+        ),
+      ).rejects.toThrow("requested workspace");
+      moved = true;
+      await expect(
+        bridge.createFromTerminal(ws, "tab.create", params, () => true),
+      ).rejects.toThrow("source moved");
+      expect(requests).toEqual(["pane.focus"]);
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  test("missing method advertisements and create rejection fail explicitly without control fallback", async () => {
+    for (const methods of [["pane.focus"], ["tab.create"], creationMethods]) {
+      const requests: string[] = [];
+      const socketPath = await startSessionServer({
+        methods,
+        onRequest: (method) => {
+          requests.push(method);
+          if (method === "tab.create") throw new Error("creation rejected");
+        },
+      });
+      const { bridge, ws, attach } = creationBridge(socketPath);
+      try {
+        await attach();
+        await expect(
+          bridge.createFromTerminal(
+            ws,
+            "tab.create",
+            { workspace_id: "w1", browser_source: creationSource },
+            () => true,
+          ),
+        ).rejects.toThrow(
+          methods === creationMethods
+            ? "creation rejected"
+            : "does not advertise",
+        );
+        expect(
+          requests.filter((method) => method === "tab.create"),
+        ).toHaveLength(methods === creationMethods ? 1 : 0);
+      } finally {
+        bridge.dispose();
+      }
+    }
+  });
+
+  test("serializes concurrent creates/scroll on one attached shell while input keeps its pane target", async () => {
+    const heldCreate = deferred<void>();
+    const requests: string[] = [];
+    const inputs: string[] = [];
+    const socketPath = await startSessionServer({
+      methods: creationMethods,
+      onRequest: async (method) => {
+        requests.push(method);
+        if (
+          method === "tab.create" &&
+          requests.filter((m) => m === method).length === 1
+        )
+          await heldCreate.promise;
+        return { method };
+      },
+      onPaneInput: (paneId) => inputs.push(paneId),
+    });
+    const { bridge, ws, attach } = creationBridge(socketPath);
+    try {
+      await attach();
+      const params = { workspace_id: "w1", browser_source: creationSource };
+      const first = bridge.createFromTerminal(
+        ws,
+        "tab.create",
+        params,
+        () => true,
+      );
+      await settleUntil(() => requests.includes("tab.create"));
+      const second = bridge.createFromTerminal(
+        ws,
+        "workspace.create",
+        { browser_source: creationSource },
+        () => true,
+      );
+      await bridge.handleTerminalRpc(ws, "scroll", "terminal.scroll", {
+        terminal_id: "term1",
+        direction: "up",
+        lines: 1,
+      });
+      await bridge.handleTerminalRpc(ws, "input", "terminal.input", {
+        terminal_id: "term1",
+        data: "WA==",
+      });
+      await settleUntil(() => inputs.length === 1);
+      expect(requests).toEqual(["pane.focus", "tab.create"]);
+      heldCreate.resolve();
+      await Promise.all([first, second]);
+      await settleUntil(() => requests.includes("pane.scroll"));
+      expect(requests.filter((m) => m === "pane.focus")).toHaveLength(1);
+      expect(inputs).toEqual(["w1:p1"]);
+    } finally {
+      heldCreate.resolve();
+      bridge.dispose();
+    }
+  });
+});
+
+test("two browser source endpoints create concurrently without changing each other's shell target", async () => {
+  const sources = new Map<number, string>();
+  const creates: Array<{
+    connection: number;
+    pane: string;
+    workspace: string;
+  }> = [];
+  const socketPath = await startSessionServer({
+    methods: creationMethods,
+    panes: [
+      { paneId: "w1:p1", x: 0, mouseReporting: false },
+      { paneId: "w2:p1", x: 10, mouseReporting: false },
+    ],
+    onRequest: async (method, params, connection) => {
+      if (method === "pane.focus") sources.set(connection, params.pane_id);
+      if (method === "tab.create") {
+        creates.push({
+          connection,
+          pane: sources.get(connection)!,
+          workspace: params.workspace_id,
+        });
+        await Bun.sleep(10);
+        return { workspace_id: params.workspace_id };
+      }
+    },
+  });
+  const { bridge, ws, attach } = creationBridge(socketPath, {
+    lookup: async (id) => (id === "term1" ? "w1:p1" : "w2:p1"),
+  });
+  const other = {} as ServerWebSocket<unknown>;
+  const otherSource = {
+    workspace_id: "w2",
+    tab_id: "w2:t1",
+    pane_id: "w2:p1",
+    terminal_id: "term2",
+  };
+  try {
+    await Promise.all([
+      attach(),
+      bridge.handleTerminalRpc(other, "other-attach", "terminal.attach", {
+        terminal_id: "term2",
+        cols: 80,
+        rows: 24,
+        relay_active: false,
+      }),
+    ]);
+    expect(
+      await Promise.all([
+        bridge.createFromTerminal(
+          ws,
+          "tab.create",
+          { workspace_id: "w1", browser_source: creationSource },
+          () => true,
+        ),
+        bridge.createFromTerminal(
+          other,
+          "tab.create",
+          { workspace_id: "w2", browser_source: otherSource },
+          () => true,
+        ),
+      ]),
+    ).toEqual([{ workspace_id: "w1" }, { workspace_id: "w2" }]);
+    expect(
+      creates
+        .map(({ pane, workspace }) => ({ pane, workspace }))
+        .sort((a, b) => a.workspace.localeCompare(b.workspace)),
+    ).toEqual([
+      { pane: "w1:p1", workspace: "w1" },
+      { pane: "w2:p1", workspace: "w2" },
+    ]);
+    expect(sources.size).toBe(2);
+  } finally {
+    bridge.dispose();
+  }
+});
+
+test("creation queued behind readiness or validation cannot mutate a detached source", async () => {
+  const validation = deferred<void>();
+  let validating = false;
+  const requests: string[] = [];
+  const socketPath = await startSessionServer({
+    methods: creationMethods,
+    onRequest: (method) => {
+      requests.push(method);
+    },
+  });
+  const { bridge, ws, attach } = creationBridge(socketPath, {
+    validate: async () => {
+      validating = true;
+      await validation.promise;
+    },
+  });
+  try {
+    await attach();
+    const creation = bridge.createFromTerminal(
+      ws,
+      "tab.create",
+      { workspace_id: "w1", browser_source: creationSource },
+      () => true,
+    );
+    const rejected = creation.then(
+      () => null,
+      (error: Error) => error,
+    );
+    await settleUntil(() => validating);
+    await bridge.handleTerminalRpc(ws, "detach", "terminal.detach", {
+      terminal_id: "term1",
+    });
+    validation.resolve();
+    expect(await rejected).toBeInstanceOf(Error);
+    expect(requests).toEqual(["pane.focus"]);
+  } finally {
+    validation.resolve();
+    bridge.dispose();
+  }
+});
+
+test("input waits for the first source-pane surface, not only the endpoint welcome", async () => {
+  let sendSurface!: (panes: TestPane[]) => void;
+  let focused = false;
+  const inputs: string[] = [];
+  const socketPath = await startSessionServer({
+    panes: [{ paneId: "other-pane", x: 0, mouseReporting: false }],
+    onConnection: (send) => {
+      sendSurface = send;
+    },
+    onRequest: (method) => {
+      if (method === "pane.focus") focused = true;
+    },
+    onPaneInput: (paneId) => inputs.push(paneId),
+  });
+  const { bridge, ws, replies, attach } = creationBridge(socketPath);
+  try {
+    const attaching = attach();
+    await settleUntil(() => focused);
+    const input = bridge.handleTerminalRpc(ws, "early", "terminal.input", {
+      terminal_id: "term1",
+      data: "WA==",
+    });
+    await Bun.sleep(10);
+    expect(replies.some((reply) => reply.id === "early")).toBe(false);
+    expect(inputs).toEqual([]);
+    sendSurface(DEFAULT_PANES);
+    await Promise.all([attaching, input]);
+    await settleUntil(() => inputs.length === 1);
+    expect(inputs).toEqual(["w1:p1"]);
+  } finally {
+    bridge.dispose();
+  }
+});
+
+test("creation admission deadline prevents execution after queue residence", async () => {
+  const held = deferred<void>();
+  const creates: string[] = [];
+  const socketPath = await startSessionServer({
+    methods: creationMethods,
+    onRequest: async (method) => {
+      if (method === "tab.create") {
+        creates.push(method);
+        if (creates.length === 1) await held.promise;
+      }
+    },
+  });
+  const { bridge, ws, attach } = creationBridge(socketPath);
+  const clock = spyOn(Date, "now").mockReturnValue(Date.now());
+  try {
+    await attach();
+    const params = { workspace_id: "w1", browser_source: creationSource };
+    const first = bridge.createFromTerminal(
+      ws,
+      "tab.create",
+      params,
+      () => true,
+    );
+    await settleUntil(() => creates.length === 1);
+    const second = bridge
+      .createFromTerminal(ws, "tab.create", params, () => true)
+      .then(
+        () => null,
+        (error: Error) => error,
+      );
+    await Bun.sleep(5);
+    clock.mockReturnValue(Date.now() + 30_001);
+    held.resolve();
+    await first;
+    expect(await second).toBeInstanceOf(Error);
+    expect(creates).toHaveLength(1);
+  } finally {
+    held.resolve();
+    clock.mockRestore();
+    bridge.dispose();
+  }
+});
+
+for (const stage of ["readiness", "validation"] as const) {
+  test(`creation deadline includes ${stage} before the mutation queue`, async () => {
+    const held = deferred<void>();
+    let waiting = false;
+    const creates: string[] = [];
+    const socketPath = await startSessionServer({
+      methods: creationMethods,
+      onRequest: (method) => {
+        if (method === "tab.create") creates.push(method);
+      },
+    });
+    const { bridge, ws, attach } = creationBridge(socketPath, {
+      lookup: async () => {
+        if (stage === "readiness") {
+          waiting = true;
+          await held.promise;
+        }
+        return "w1:p1";
+      },
+      validate: async () => {
+        if (stage === "validation") {
+          waiting = true;
+          await held.promise;
+        }
+      },
+    });
+    const clock = spyOn(Date, "now").mockReturnValue(Date.now());
+    try {
+      const attaching = attach();
+      if (stage === "validation") await attaching;
+      else await settleUntil(() => waiting);
+      const pending = bridge
+        .createFromTerminal(
+          ws,
+          "tab.create",
+          { workspace_id: "w1", browser_source: creationSource },
+          () => true,
+        )
+        .then(
+          () => null,
+          (error: Error) => error,
+        );
+      if (stage === "validation") await settleUntil(() => waiting);
+      else await Bun.sleep(5);
+      clock.mockReturnValue(Date.now() + 30_001);
+      held.resolve();
+      await attaching;
+      expect((await pending)?.message).toContain("expired before dispatch");
+      expect(creates).toEqual([]);
+    } finally {
+      held.resolve();
+      clock.mockRestore();
+      bridge.dispose();
+    }
+  });
+}
+
+test("undispatched queue deadline rejects promptly without closing or mutating; later create still works", async () => {
+  const held = deferred<void>();
+  const creates: string[] = [];
+  const socketPath = await startSessionServer({
+    methods: creationMethods,
+    onRequest: async (method) => {
+      if (method === "tab.create") {
+        creates.push(method);
+        if (creates.length === 1) await held.promise;
+      }
+    },
+  });
+  const session = new EndpointTerminalSession(
+    socketPath,
+    "term1",
+    async () => "w1:p1",
+  );
+  try {
+    await session.connect(80, 24);
+    const create = (deadline?: EndpointCreationDeadline) =>
+      session.create("tab.create", {}, "w1:p1", async () => {}, deadline);
+    const first = create();
+    await settleUntil(() => creates.length === 1);
+    await expect(create(new EndpointCreationDeadline(20))).rejects.toThrow(
+      "expired before dispatch",
+    );
+    expect(session.isClosed).toBe(false);
+    held.resolve();
+    await first;
+    await create();
+    expect(creates).toHaveLength(2);
+  } finally {
+    held.resolve();
+    session.close();
+  }
+});
+
+test("dispatched deadline warns about uncertainty and closes only the affected endpoint", async () => {
+  const held = deferred<void>();
+  let dispatched = false;
+  const socketPath = await startSessionServer({
+    methods: creationMethods,
+    onRequest: async (method) => {
+      if (method === "tab.create") {
+        dispatched = true;
+        await held.promise;
+      }
+    },
+  });
+  const session = new EndpointTerminalSession(
+    socketPath,
+    "term1",
+    async () => "w1:p1",
+  );
+  try {
+    await session.connect(80, 24);
+    await expect(
+      session.create(
+        "tab.create",
+        {},
+        "w1:p1",
+        async () => {},
+        new EndpointCreationDeadline(30),
+      ),
+    ).rejects.toThrow("may have succeeded");
+    expect(dispatched).toBe(true);
+    expect(session.isClosed).toBe(true);
+  } finally {
+    held.resolve();
+    session.close();
+  }
+});
+
+for (const invalidate of ["lease", "dispose"] as const) {
+  test(`creation validation rechecks ${invalidate} before dispatch`, async () => {
+    const held = deferred<void>();
+    let waiting = false,
+      current = true;
+    const creates: string[] = [];
+    const socketPath = await startSessionServer({
+      methods: creationMethods,
+      onRequest: (method) => {
+        if (method === "tab.create") creates.push(method);
+      },
+    });
+    const { bridge, ws, attach } = creationBridge(socketPath, {
+      validate: async () => {
+        waiting = true;
+        await held.promise;
+      },
+    });
+    try {
+      await attach();
+      const pending = bridge
+        .createFromTerminal(
+          ws,
+          "tab.create",
+          { workspace_id: "w1", browser_source: creationSource },
+          () => current,
+        )
+        .then(
+          () => null,
+          (error: Error) => error,
+        );
+      await settleUntil(() => waiting);
+      if (invalidate === "lease") current = false;
+      else bridge.dispose();
+      held.resolve();
+      expect(await pending).toBeInstanceOf(Error);
+      expect(creates).toEqual([]);
+    } finally {
+      held.resolve();
+      bridge.dispose();
+    }
+  });
+}

--- a/server/src/bridge/endpoint-terminal-session.test.ts
+++ b/server/src/bridge/endpoint-terminal-session.test.ts
@@ -1509,3 +1509,108 @@ for (const invalidate of ["lease", "dispose"] as const) {
     }
   });
 }
+
+for (const invalidate of [
+  "detach",
+  "reattach",
+  "lease",
+  "dispose",
+  "replace",
+] as const) {
+  test(`ready shared input revalidates ${invalidate} after its await before input or clipboard ownership`, async () => {
+    const socketPath = await startSessionServer({ methods: creationMethods });
+    const a = {} as ServerWebSocket<unknown>,
+      b = {} as ServerWebSocket<unknown>;
+    const replies: Array<{ ws: ServerWebSocket<unknown>; message: any }> = [];
+    const bridge = createTerminalBridge({
+      clientSocketPath: socketPath,
+      herdrProtocol: async () => 22,
+      lookupPaneId: async () => "w1:p1",
+      safeSend: (ws, payload) => {
+        replies.push({ ws, message: JSON.parse(payload) });
+        return true;
+      },
+      clientLabel: () => "ready-input-race",
+      markRpcError: () => {},
+    });
+    const forwarded: string[] = [];
+    const sessions: EndpointTerminalSession[] = [];
+    const original = EndpointTerminalSession.prototype.input;
+    const inputSpy = spyOn(
+      EndpointTerminalSession.prototype,
+      "input",
+    ).mockImplementation(function (
+      this: EndpointTerminalSession,
+      data: Buffer,
+    ) {
+      sessions.push(this);
+      forwarded.push(data.toString());
+      original.call(this, data);
+    });
+    const attach = (ws: typeof a) =>
+      bridge.handleTerminalRpc(ws, "attach", "terminal.attach", {
+        terminal_id: "term1",
+        cols: 80,
+        rows: 24,
+        relay_active: false,
+      });
+    let current = true;
+    try {
+      await attach(a);
+      await attach(b);
+      await bridge.handleTerminalRpc(b, "owner", "terminal.input", {
+        terminal_id: "term1",
+        data: "Qg==",
+      });
+      const session = sessions[0];
+      expect(session.connecting).toBeNull();
+      expect(session.isClosed).toBe(false);
+      expect(bridge.viewedTerminals(a)).toEqual(["term1"]);
+      expect(bridge.viewedTerminals(b)).toEqual(["term1"]);
+      forwarded.length = 0;
+      // No sleep or await between starting ready input and invalidating its lease/token.
+      const input = bridge.handleTerminalRpc(
+        a,
+        "stale-input",
+        "terminal.input",
+        { terminal_id: "term1", data: "WA==" },
+        () => current,
+      );
+      let invalidating: unknown;
+      if (invalidate === "detach")
+        invalidating = bridge.handleTerminalRpc(
+          a,
+          "detach",
+          "terminal.detach",
+          { terminal_id: "term1" },
+        );
+      else if (invalidate === "reattach") invalidating = attach(a);
+      else if (invalidate === "lease") current = false;
+      else if (invalidate === "dispose") bridge.dispose();
+      else {
+        session.close();
+        invalidating = attach(a);
+      }
+      await Promise.all([input, invalidating]);
+      if (invalidate === "detach")
+        expect(bridge.viewedTerminals(a)).toEqual([]);
+      expect(forwarded).toEqual([]);
+      expect(
+        replies.find(({ message }) => message.id === "stale-input")?.message
+          .error,
+      ).toBeDefined();
+      if (invalidate !== "dispose" && invalidate !== "replace") {
+        expect(bridge.viewedTerminals(b)).toEqual(["term1"]);
+        session.emit("clipboard", { data: "Y29weQ==" });
+        expect(
+          replies
+            .filter(({ message }) => message.terminal_clipboard)
+            .map(({ ws }) => ws),
+        ).toEqual([b]);
+      }
+    } finally {
+      inputSpy.mockRestore();
+      bridge.dispose();
+    }
+  });
+}

--- a/server/src/bridge/endpoint-terminal-session.ts
+++ b/server/src/bridge/endpoint-terminal-session.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import { EndpointClient, type EndpointSurface } from "./endpoint-client";
+import { EndpointCreationDeadline } from "./endpoint-creation";
 import { frameToAnsi } from "./frame-to-ansi";
 import type { FrameData } from "./thin-client";
 import type { Logger } from "../utils/logger";
@@ -32,6 +33,8 @@ export class EndpointTerminalSession extends EventEmitter {
   } | null = null;
   private closed = false;
   private seq = 0;
+  private advertisedMethods = new Set<string>();
+  private commandChain: Promise<unknown> = Promise.resolve();
   connecting: Promise<void> | null = null;
 
   constructor(
@@ -52,13 +55,16 @@ export class EndpointTerminalSession extends EventEmitter {
       this.closed = true;
       this.emit("close");
     });
-    this.client.on("welcome", (w) =>
+    this.client.on("welcome", (w) => {
+      this.advertisedMethods = new Set(
+        Array.isArray(w.methods) ? w.methods : [],
+      );
       this.emit("welcome", {
         version: w.serverVersion,
         encoding: 1,
         error: null,
-      }),
-    );
+      });
+    });
   }
 
   get isClosed() {
@@ -77,7 +83,9 @@ export class EndpointTerminalSession extends EventEmitter {
       this.paneId = paneId;
       // Focus scopes this shell's surface to the pane's tab; per-client
       // focus in Herdr 0.9.0 keeps this from moving other clients.
-      await this.client.callEndpoint("pane.focus", { pane_id: paneId });
+      await this.enqueueCommand(() =>
+        this.client.callEndpoint("pane.focus", { pane_id: paneId }),
+      );
       // A surface may have arrived before the lookup resolved; process it
       // now if it already contains the pane.
       const current = this.client.currentSurface;
@@ -95,6 +103,72 @@ export class EndpointTerminalSession extends EventEmitter {
         this.connecting = null;
       });
     return this.connecting;
+  }
+
+  private enqueueCommand<T>(run: () => Promise<T>): Promise<T> {
+    const bounded = async () => {
+      if (this.closed) throw new Error("Endpoint terminal is closed");
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        return await Promise.race([
+          run(),
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(() => {
+              reject(
+                new Error(
+                  "Endpoint command timed out; check Herdr before retrying. Creation may have succeeded.",
+                ),
+              );
+              this.close();
+            }, 10_000);
+          }),
+        ]);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    };
+    const task = this.commandChain.then(bounded, bounded);
+    this.commandChain = task.catch(() => undefined);
+    return task;
+  }
+
+  /** Reuse the attached shell/clipboard lane; never refocus it for creation. */
+  create(
+    method: "tab.create" | "workspace.create",
+    params: Record<string, unknown>,
+    sourcePaneId: string,
+    validateSource: () => Promise<void>,
+    deadline = new EndpointCreationDeadline(),
+  ): Promise<unknown> {
+    return deadline.wait(
+      this.enqueueCommand(async () => {
+        deadline.assertBeforeDispatch();
+        const ready = () =>
+          !this.closed &&
+          !this.connecting &&
+          this.paneId === sourcePaneId &&
+          this.hasPane(this.latestSurface(), sourcePaneId);
+        if (!ready())
+          throw new Error(
+            "Source terminal is not ready. Open its tab and retry creation.",
+          );
+        for (const requiredMethod of ["pane.focus", method]) {
+          if (!this.advertisedMethods.has(requiredMethod))
+            throw new Error(
+              `Herdr endpoint does not advertise ${requiredMethod}`,
+            );
+        }
+        await validateSource();
+        if (!ready())
+          throw new Error(
+            "Source terminal changed before creation. Open its tab and retry.",
+          );
+        return deadline.dispatch(() =>
+          this.client.callEndpoint(method, { ...params, focus: false }),
+        );
+      }),
+      () => this.close(),
+    );
   }
 
   private waitForSurface(paneId: string): Promise<void> {
@@ -255,16 +329,17 @@ export class EndpointTerminalSession extends EventEmitter {
     );
     if (offset === this.lastScroll.offsetFromBottom) return;
     this.lastScroll.offsetFromBottom = offset;
-    this.client
-      .callEndpoint("pane.scroll", {
-        pane_id: this.paneId,
+    const paneId = this.paneId;
+    this.enqueueCommand(() =>
+      this.client.callEndpoint("pane.scroll", {
+        pane_id: paneId,
         offset_from_bottom: offset,
-      })
-      .catch((e) =>
-        this.logger.debug("endpoint pane.scroll failed", {
-          error: e instanceof Error ? e.message : String(e),
-        }),
-      );
+      }),
+    ).catch((e) =>
+      this.logger.debug("endpoint pane.scroll failed", {
+        error: e instanceof Error ? e.message : String(e),
+      }),
+    );
   }
 
   close() {

--- a/server/src/bridge/terminal-bridge.test.ts
+++ b/server/src/bridge/terminal-bridge.test.ts
@@ -1212,3 +1212,31 @@ describe("terminal bridge sharing", () => {
     bridge.dispose();
   });
 });
+
+test("navigation mode uses exactly the terminal backend decision", async () => {
+  const disabled = process.env.HERDR_GUI_DISABLE_ENDPOINT;
+  try {
+    for (const [protocol, lookup, disable, expected] of [
+      [22, true, false, "browser-local"],
+      [22, true, true, "shared"],
+      [22, false, false, "shared"],
+      [20, true, false, "shared"],
+    ] as const) {
+      if (disable) process.env.HERDR_GUI_DISABLE_ENDPOINT = "1";
+      else delete process.env.HERDR_GUI_DISABLE_ENDPOINT;
+      const bridge = createTerminalBridge({
+        clientSocketPath: "/unused",
+        herdrProtocol: async () => protocol,
+        lookupPaneId: lookup ? async () => "pane" : undefined,
+        safeSend: () => true,
+        clientLabel: () => "test",
+        markRpcError: () => {},
+      });
+      expect(await bridge.navigationMode()).toBe(expected);
+      bridge.dispose();
+    }
+  } finally {
+    if (disabled === undefined) delete process.env.HERDR_GUI_DISABLE_ENDPOINT;
+    else process.env.HERDR_GUI_DISABLE_ENDPOINT = disabled;
+  }
+});

--- a/server/src/bridge/terminal-bridge.ts
+++ b/server/src/bridge/terminal-bridge.ts
@@ -1,3 +1,8 @@
+import {
+  EndpointCreationDeadline,
+  parseEndpointCreationSource,
+  type EndpointCreationSource,
+} from "./endpoint-creation";
 import type { ServerWebSocket } from "bun";
 import {
   CONNECTION_CHANGED_DURING_REQUEST,
@@ -55,6 +60,12 @@ export function createTerminalBridge(args: {
   herdrProtocol: () => Promise<number>;
   /** Resolve a terminal id to its owning pane id (control-socket pane.list). */
   lookupPaneId?: (terminalId: string) => Promise<string | null>;
+  validateCreationSource?: (source: EndpointCreationSource) => Promise<void>;
+  createEmptyWorkspace?: (
+    params: Record<string, unknown>,
+    isCurrent: () => boolean,
+    deadline: EndpointCreationDeadline,
+  ) => Promise<unknown>;
   safeSend: (
     ws: ServerWebSocket<unknown>,
     payload: string,
@@ -76,6 +87,10 @@ export function createTerminalBridge(args: {
   const terminals = new Map<ServerWebSocket<unknown>, TerminalSession>();
   const terminalViewers = new Map<ServerWebSocket<unknown>, Set<string>>();
   const sharedTerminals = new Map<string, SharedTerminalSession>();
+  const attachmentTokens = new Map<
+    ServerWebSocket<unknown>,
+    Map<string, object>
+  >();
   let clipboardRelay: ThinClient | null = null;
   let clipboardRelayConnecting: Promise<void> | null = null;
   let clipboardTarget: ClipboardTarget | null = null;
@@ -94,6 +109,15 @@ export function createTerminalBridge(args: {
       resolvedProtocol = await args.herdrProtocol();
     }
     return resolvedProtocol;
+  }
+
+  // Use the same verified backend decision for browser navigation and rendering.
+  async function navigationMode(): Promise<"browser-local" | "shared"> {
+    return isTerminalHelloProtocol(await bridgeProtocol()) &&
+      args.lookupPaneId &&
+      process.env.HERDR_GUI_DISABLE_ENDPOINT !== "1"
+      ? "browser-local"
+      : "shared";
   }
 
   const serialize = (message: Record<string, unknown>) =>
@@ -415,6 +439,7 @@ export function createTerminalBridge(args: {
       ? [terminalId]
       : Array.from(viewed ?? (current?.terminalId ? [current.terminalId] : []));
     for (const id of terminalIds) {
+      attachmentTokens.get(ws)?.delete(id);
       if (clipboardTarget?.ws === ws && clipboardTarget.terminalId === id) {
         clipboardTarget = null;
       }
@@ -428,6 +453,7 @@ export function createTerminalBridge(args: {
     }
     if (!viewed || viewed.size === 0) {
       terminalViewers.delete(ws);
+      attachmentTokens.delete(ws);
       terminals.delete(ws);
       if (clipboardTarget?.ws === ws) clipboardTarget = null;
       return;
@@ -450,7 +476,7 @@ export function createTerminalBridge(args: {
     const creationRevision = lifecycleRevision;
     // Resolve before checking the map so concurrent attaches for the same
     // terminal cannot double-create while the first resolution is in flight.
-    const protocol = await bridgeProtocol();
+    const mode = await navigationMode();
     const existing = sharedTerminals.get(terminalId);
     if (existing && !existing.thin.isClosed) return existing;
     if (existing) {
@@ -459,9 +485,7 @@ export function createTerminalBridge(args: {
     }
 
     const thin =
-      isTerminalHelloProtocol(protocol) &&
-      args.lookupPaneId &&
-      process.env.HERDR_GUI_DISABLE_ENDPOINT !== "1"
+      mode === "browser-local" && args.lookupPaneId
         ? new EndpointTerminalSession(
             args.clientSocketPath,
             terminalId,
@@ -640,6 +664,123 @@ export function createTerminalBridge(args: {
     return shared;
   }
 
+  async function waitForOwnedTerminal(
+    ws: ServerWebSocket<unknown>,
+    terminalId: string,
+    shared: SharedTerminalSession,
+    requestIsCurrent: () => boolean,
+  ): Promise<() => void> {
+    const token = attachmentTokens.get(ws)?.get(terminalId);
+    const revision = lifecycleRevision;
+    const validate = () => {
+      if (
+        !requestIsCurrent() ||
+        !isCurrent(revision) ||
+        !token ||
+        attachmentTokens.get(ws)?.get(terminalId) !== token ||
+        !terminalViewers.get(ws)?.has(terminalId) ||
+        sharedTerminals.get(terminalId) !== shared ||
+        shared.thin.isClosed
+      ) {
+        throw new Error(
+          "Source terminal attachment changed; retry after it reconnects.",
+        );
+      }
+    };
+    validate();
+    if (shared.connecting) {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await Promise.race([
+          shared.connecting,
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(
+              () =>
+                reject(
+                  new Error(
+                    "Source terminal is still connecting; retry when ready.",
+                  ),
+                ),
+              20_000,
+            );
+          }),
+        ]);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    }
+    validate();
+    return validate;
+  }
+
+  async function createFromTerminal(
+    ws: ServerWebSocket<unknown>,
+    method: "tab.create" | "workspace.create",
+    params: Record<string, unknown>,
+    requestIsCurrent: () => boolean,
+  ) {
+    const deadline = new EndpointCreationDeadline();
+    return deadline.wait(
+      (async () => {
+        if ((await navigationMode()) !== "browser-local")
+          throw new Error("Client-scoped creation requires Herdr endpoints.");
+        deadline.assertBeforeDispatch();
+        if (method === "workspace.create" && params.browser_source === null) {
+          if (!args.createEmptyWorkspace)
+            throw new Error("Empty-session creation is unavailable.");
+          return args.createEmptyWorkspace(
+            params,
+            () => !disposed && requestIsCurrent(),
+            deadline,
+          );
+        }
+        const source = parseEndpointCreationSource(params.browser_source);
+        if (
+          method === "tab.create" &&
+          params.workspace_id !== source.workspace_id
+        ) {
+          throw new Error(
+            "Creation source does not belong to the requested workspace.",
+          );
+        }
+        const shared = sharedTerminals.get(source.terminal_id);
+        if (!shared || !(shared.thin instanceof EndpointTerminalSession)) {
+          throw new Error(
+            "Open the source terminal tab and wait for it to connect before creating.",
+          );
+        }
+        const validateAttachment = await waitForOwnedTerminal(
+          ws,
+          source.terminal_id,
+          shared,
+          requestIsCurrent,
+        );
+        const creationParams = { ...params };
+        delete creationParams.browser_source;
+        const result = await shared.thin.create(
+          method,
+          {
+            ...creationParams,
+            ...(method === "workspace.create"
+              ? { source_workspace_id: source.workspace_id }
+              : {}),
+            focus: false,
+          },
+          source.pane_id,
+          async () => {
+            validateAttachment();
+            if (!args.validateCreationSource)
+              throw new Error("Creation source validation is unavailable.");
+            await args.validateCreationSource(source);
+            validateAttachment();
+          },
+          deadline,
+        );
+        return result;
+      })(),
+    );
+  }
+
   async function handleTerminalRpc(
     ws: ServerWebSocket<unknown>,
     id: string,
@@ -687,6 +828,9 @@ export function createTerminalBridge(args: {
         terminals.set(ws, { terminalId, cols, rows });
         viewed.add(terminalId);
         terminalViewers.set(ws, viewed);
+        const tokens = attachmentTokens.get(ws) ?? new Map<string, object>();
+        tokens.set(terminalId, {});
+        attachmentTokens.set(ws, tokens);
         const shared = await getSharedTerminal(terminalId, cols, rows);
         shared.viewers.add(ws);
         try {
@@ -808,6 +952,12 @@ export function createTerminalBridge(args: {
         }
         const input = Buffer.from(b64, "base64");
         if (input.length === 0) return fail("terminal input required");
+        await waitForOwnedTerminal(
+          ws,
+          requestedTerminalId,
+          shared,
+          requestIsCurrent,
+        );
         clipboardTarget = {
           ws,
           terminalId: requestedTerminalId,
@@ -884,10 +1034,13 @@ export function createTerminalBridge(args: {
     for (const shared of sharedTerminals.values()) shared.thin.close();
     sharedTerminals.clear();
     terminalViewers.clear();
+    attachmentTokens.clear();
     terminals.clear();
   }
 
   return {
+    createFromTerminal,
+    navigationMode,
     handleTerminalRpc,
     cleanupWs,
     viewedTerminals,

--- a/server/src/bridge/terminal-bridge.ts
+++ b/server/src/bridge/terminal-bridge.ts
@@ -952,12 +952,14 @@ export function createTerminalBridge(args: {
         }
         const input = Buffer.from(b64, "base64");
         if (input.length === 0) return fail("terminal input required");
-        await waitForOwnedTerminal(
+        const validateAttachment = await waitForOwnedTerminal(
           ws,
           requestedTerminalId,
           shared,
           requestIsCurrent,
         );
+        // Even a ready terminal yields above; recheck at the side-effect boundary.
+        validateAttachment();
         clipboardTarget = {
           ws,
           terminalId: requestedTerminalId,

--- a/server/src/connections/profile-process.test.ts
+++ b/server/src/connections/profile-process.test.ts
@@ -41,6 +41,10 @@ async function fakeHerdr(
   id: string,
   protocol: unknown = 14,
   welcomeProtocol?: number,
+  respond?: (request: {
+    method: string;
+    params?: Record<string, unknown>;
+  }) => unknown,
 ): Promise<LocalConnectionProfile> {
   const controlPath = join(root, `${id}-control.sock`);
   const renderPath = join(root, `${id}-render.sock`);
@@ -49,7 +53,7 @@ async function fakeHerdr(
       sockets.add(socket);
       socket.on("close", () => sockets.delete(socket));
       let input = "";
-      socket.on("data", (chunk) => {
+      socket.on("data", async (chunk) => {
         input += chunk.toString();
         const newline = input.indexOf("\n");
         if (newline < 0) return;
@@ -58,7 +62,8 @@ async function fakeHerdr(
         calls.push(request.method);
         controlCalls.set(id, calls);
         const result =
-          request.method === "ping"
+          (await respond?.(request)) ??
+          (request.method === "ping"
             ? { version: `fake-${id}`, protocol }
             : request.method === "workspace.list"
               ? {
@@ -69,7 +74,7 @@ async function fakeHerdr(
                     },
                   ],
                 }
-              : {};
+              : {});
         socket.write(`${JSON.stringify({ id: request.id, result })}\n`);
         if (request.method !== "events.subscribe") socket.end();
       });
@@ -368,9 +373,11 @@ test("production dispatcher isolates two local profiles and profile CRUD", async
 
     // Explicitly retain old-client compatibility for both RPC and HTTP while
     // proving generation-bound current requests reach only the replacement.
-    expect(
-      (await browserA.rpc("workspace.list", {}, "alpha")).workspaces[0].name,
-    ).toBe("from-beta");
+    const legacySnapshot = await browserA.rpc("workspace.list", {}, "alpha");
+    expect(legacySnapshot.workspaces[0].name).toBe("from-beta");
+    expect(legacySnapshot.navigation_mode).toBe("shared");
+    // The first snapshot also resolves the replacement terminal backend.
+    const beforeLegacyHttp = betaPingCalls();
     const legacyHttp = await fetch(
       `http://127.0.0.1:${port}/api/connections/alpha/herdr-info`,
     );
@@ -379,7 +386,7 @@ test("production dispatcher isolates two local profiles and profile CRUD", async
       String(newAlphaGeneration),
     );
     expect(await legacyHttp.json()).toMatchObject({ version: "fake-beta" });
-    expect(betaPingCalls()).toBe(beforeStaleHttp + 1);
+    expect(betaPingCalls()).toBe(beforeLegacyHttp + 1);
     const currentAlpha = await browserB.raw(
       "workspace.list",
       {},
@@ -493,3 +500,146 @@ for (const { protocol, welcomeProtocol, accepted } of [
     }
   }, 10_000);
 }
+
+test("production routing bootstraps only a verified empty session and serializes competing browsers", async () => {
+  if (process.platform === "win32") return;
+  const root = join(tmpdir(), `h110-bootstrap-${crypto.randomUUID()}`);
+  roots.push(root);
+  mkdirSync(root, { recursive: true, mode: 0o700 });
+  let valid = false;
+  let workspaces: Array<{ workspace_id: string }> = [];
+  const mutations: Record<string, unknown>[] = [];
+  const profile = await fakeHerdr(
+    root,
+    "empty",
+    22,
+    undefined,
+    async (request) => {
+      if (request.method === "workspace.list")
+        return valid
+          ? { type: "workspace_list", workspaces }
+          : { workspaces: [] };
+      if (request.method === "workspace.create") {
+        mutations.push(request.params ?? {});
+        await Bun.sleep(20);
+        workspaces = [{ workspace_id: "w1" }];
+        return {
+          type: "workspace_created",
+          workspace: workspaces[0],
+          tab: { workspace_id: "w1", tab_id: "w1:t1" },
+          root_pane: { workspace_id: "w1", tab_id: "w1:t1", pane_id: "w1:p1" },
+        };
+      }
+    },
+  );
+  const registryPath = join(root, "connections.json");
+  writeFileSync(
+    registryPath,
+    JSON.stringify({
+      version: 1,
+      default_connection_id: "empty",
+      profiles: [profile],
+    }),
+    { mode: 0o600 },
+  );
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    HOST: "127.0.0.1",
+    PORT: "0",
+    HERDR_GUI_CONNECTIONS_PATH: registryPath,
+  };
+  for (const key of [
+    "HERDR_SOCKET_PATH",
+    "HERDR_CLIENT_SOCKET_PATH",
+    "HERDR_SSH_HOST",
+    "HERDR_SESSION",
+  ])
+    delete env[key];
+  const child = Bun.spawn([process.execPath, "server/src/index.ts"], {
+    cwd: join(import.meta.dir, "../../.."),
+    env,
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  const browsers: WebSocket[] = [];
+  try {
+    const port = await bridgeListeningPort(child.stdout);
+    await waitForHealth(port);
+    for (let i = 0; i < 2; i++) {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+      browsers.push(ws);
+      await new Promise<void>((resolve, reject) => {
+        ws.onopen = () => resolve();
+        ws.onerror = () => reject(new Error("socket failed"));
+      });
+    }
+    let seq = 0;
+    const rpc = (
+      ws: WebSocket,
+      params: Record<string, unknown>,
+      generation?: number,
+    ) =>
+      new Promise<any>((resolve, reject) => {
+        const id = `bootstrap-${++seq}`;
+        const timer = setTimeout(() => {
+          ws.removeEventListener("message", receive);
+          reject(new Error("bootstrap RPC timed out"));
+        }, 4000);
+        const receive = (event: MessageEvent) => {
+          const result = JSON.parse(String(event.data));
+          if (result.id !== id) return;
+          clearTimeout(timer);
+          ws.removeEventListener("message", receive);
+          resolve(result);
+        };
+        ws.addEventListener("message", receive);
+        ws.send(
+          JSON.stringify({
+            id,
+            method: "workspace.create",
+            connection_id: "empty",
+            ...(generation === undefined
+              ? {}
+              : { connection_generation: generation }),
+            params,
+          }),
+        );
+      });
+    expect(
+      (await rpc(browsers[0], { browser_source: null })).error,
+    ).toBeDefined();
+    expect(mutations).toHaveLength(0);
+    valid = true;
+    const results = await Promise.all(
+      browsers.map((ws) => rpc(ws, { browser_source: null, focus: true })),
+    );
+    expect(
+      results.filter((result) => result.result?.type === "workspace_created"),
+    ).toHaveLength(1);
+    expect(results.filter((result) => result.error)).toHaveLength(1);
+    expect(mutations).toEqual([{ focus: false }]);
+    expect(
+      (await rpc(browsers[0], { browser_source: null, cwd: "/wrong" })).error,
+    ).toBeDefined();
+    workspaces = [];
+    expect(
+      (
+        await rpc(browsers[0], {
+          browser_source: null,
+          cwd: "/explicit",
+          focus: true,
+        })
+      ).result.type,
+    ).toBe("workspace_created");
+    expect(mutations[1]).toEqual({ cwd: "/explicit", focus: false });
+    workspaces = [];
+    expect(
+      (await rpc(browsers[0], { browser_source: null }, 99999)).error,
+    ).toBeDefined();
+    expect(mutations).toHaveLength(2);
+  } finally {
+    for (const ws of browsers) ws.close();
+    child.kill("SIGTERM");
+    await child.exited;
+  }
+}, 15000);

--- a/server/src/connections/runtime.ts
+++ b/server/src/connections/runtime.ts
@@ -1,3 +1,7 @@
+import {
+  assertEndpointCreationSource,
+  createEmptyWorkspaceCreator,
+} from "../bridge/endpoint-creation";
 import type { ServerWebSocket } from "bun";
 import { createAgentSessionHandlers } from "../agent/agent-sessions";
 import { createAgentSessionFileAccess } from "../agent/session-file-access";
@@ -197,6 +201,17 @@ export function createLegacyConnectionRuntime(args: {
       const protocol: unknown = (await herdr.ping()).protocol;
       assertSupportedHerdrProtocol(protocol);
       return protocol;
+    },
+    createEmptyWorkspace: createEmptyWorkspaceCreator(
+      (method, params, timeoutMs) => herdr.call(method, params, timeoutMs),
+    ),
+    validateCreationSource: async (source) => {
+      const result = await herdr.call(
+        "pane.get",
+        { pane_id: source.pane_id },
+        5000,
+      );
+      assertEndpointCreationSource(source, result?.pane);
     },
     lookupPaneId: async (terminalId) => {
       try {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -758,6 +758,25 @@ async function handleRpc(ws: ServerWebSocket<unknown>, raw: string) {
     readEntry: readAgentHistoryEntry,
   } = connection.agentSessions;
 
+  if (
+    (method === "tab.create" || method === "workspace.create") &&
+    params &&
+    Object.hasOwn(params, "browser_source")
+  ) {
+    try {
+      const result = await terminalBridge.createFromTerminal(
+        ws,
+        method,
+        params,
+        requestIsCurrent,
+      );
+      sendReply({ id, result }, method);
+    } catch (error) {
+      sendError(`${method}-error`, error);
+    }
+    return;
+  }
+
   if (method === "agent_history.get") {
     try {
       const result = await readAgentMessageHistory(params ?? {});
@@ -1040,6 +1059,10 @@ async function handleRpc(ws: ServerWebSocket<unknown>, raw: string) {
     if (method === "workspace.list") {
       result = await worktreeParents.enrichWorkspaceList(result);
       result = await enrichWorkspacesWithGitStatus(result);
+      result = {
+        ...result,
+        navigation_mode: await terminalBridge.navigationMode(),
+      };
     }
     sendReply({ id, result }, method);
   } catch (e) {

--- a/web/src/browserNavigation.test.ts
+++ b/web/src/browserNavigation.test.ts
@@ -1,0 +1,655 @@
+import { describe, expect, test } from "bun:test";
+import {
+  browserPaneInDirection,
+  emptyBrowserNavigation,
+  projectBrowserLayout,
+  projectBrowserNavigation,
+  selectBrowserTarget,
+} from "./browserNavigation";
+import type { Pane, PaneLayout, Tab, Workspace } from "./types";
+
+function navigationTopology() {
+  const workspaces: Workspace[] = ["a", "b"].map((id, i) => ({
+    workspace_id: id,
+    number: i + 1,
+    label: id,
+    focused: id === "a",
+    pane_count: 3,
+    tab_count: 2,
+    active_tab_id: `${id}1`,
+    agent_status: "idle",
+    cwd: `/tmp/${id}`,
+  }));
+  const tabs: Tab[] = ["a1", "a2", "b1"].map((id, i) => ({
+    tab_id: id,
+    workspace_id: id[0],
+    number: i + 1,
+    label: id,
+    focused: id === "a1",
+    pane_count: 2,
+    agent_status: "idle",
+  }));
+  const panes: Pane[] = ["a1p", "a1q", "a2p", "b1p"].map((id) => ({
+    pane_id: id,
+    terminal_id: `${id}-terminal`,
+    workspace_id: id[0],
+    tab_id: id.slice(0, 2),
+    focused: id === "a1p",
+    agent_status: "idle",
+    revision: 1,
+    cwd: `/tmp/${id}`,
+    foreground_cwd: `/tmp/${id}-foreground`,
+  }));
+  return { workspaces, tabs, panes };
+}
+
+function navigationLayout(pane: Pane, panes: Pane[]): PaneLayout {
+  return {
+    workspace_id: pane.workspace_id,
+    tab_id: pane.tab_id,
+    zoomed: false,
+    area: { x: 0, y: 0, width: 100, height: 30 },
+    focused_pane_id: pane.pane_id,
+    panes: panes
+      .filter((p) => p.tab_id === pane.tab_id)
+      .map((p, i) => ({
+        pane_id: p.pane_id,
+        focused: i === 0,
+        rect: { x: i * 50, y: 0, width: 50, height: 30 },
+      })),
+    splits: [],
+  };
+}
+
+describe("browser navigation projection", () => {
+  test("reproduces shared snapshot clobber but isolates two browser selections", () => {
+    const { workspaces, tabs, panes } = navigationTopology();
+    const a = selectBrowserTarget(emptyBrowserNavigation(), "a", "a2", "a2p");
+    const b = selectBrowserTarget(emptyBrowserNavigation(), "b", "b1", "b1p");
+    const native = JSON.stringify({ workspaces, tabs, panes });
+    // The old refresh published shared focus a/a1 for both browsers.
+    expect(workspaces.find((w) => w.focused)?.active_tab_id).toBe("a1");
+    const projectedA = projectBrowserNavigation(a, workspaces, tabs, panes);
+    const projectedB = projectBrowserNavigation(b, workspaces, tabs, panes);
+    expect(projectedA.selectedPaneId).toBe("a2p");
+    expect(projectedB.selectedPaneId).toBe("b1p");
+    expect(JSON.stringify({ workspaces, tabs, panes })).toBe(native);
+    workspaces[0].focused = false;
+    workspaces[1].focused = true;
+    expect(
+      projectBrowserNavigation(
+        projectedA.browserNavigation,
+        workspaces,
+        tabs,
+        panes,
+      ).selectedPaneId,
+    ).toBe("a2p");
+  });
+
+  test("closed and moved panes stay within the selected tab; missing tabs/workspaces fall back", () => {
+    const { workspaces, tabs, panes } = navigationTopology();
+    const selected = selectBrowserTarget(
+      emptyBrowserNavigation(),
+      "a",
+      "a1",
+      "a1q",
+    );
+    const moved = panes.map((p) =>
+      p.pane_id === "a1q" ? { ...p, workspace_id: "b", tab_id: "b1" } : p,
+    );
+    const projection = projectBrowserNavigation(
+      selected,
+      workspaces,
+      tabs,
+      moved,
+    );
+    expect(projection.selectedPaneId).toBe("a1p");
+    expect(projection.browserNavigation.paneIds.a1).toBe("a1p");
+    expect(
+      projectBrowserNavigation(
+        selected,
+        workspaces,
+        tabs,
+        panes.filter((p) => p.pane_id !== "a1q"),
+      ).selectedPaneId,
+    ).toBe("a1p");
+    expect(
+      projectBrowserNavigation(
+        selected,
+        workspaces,
+        tabs.filter((t) => t.tab_id !== "a1"),
+        moved,
+      ).selectedPaneId,
+    ).toBe("a2p");
+    expect(
+      projectBrowserNavigation(
+        selected,
+        workspaces.slice(1),
+        tabs.slice(2),
+        moved,
+      ).selectedPaneId,
+    ).toBe("a1q");
+    expect(
+      projectBrowserNavigation(selected, [], [], []).browserNavigation,
+    ).toEqual(emptyBrowserNavigation());
+  });
+
+  test("remembers per-workspace tabs and per-tab panes without adopting later focus", () => {
+    const topology = navigationTopology();
+    let selection = selectBrowserTarget(
+      emptyBrowserNavigation(),
+      "a",
+      "a1",
+      "a1q",
+    );
+    selection = selectBrowserTarget(selection, "b", "b1", "b1p");
+    selection = selectBrowserTarget(selection, "a");
+    const projected = projectBrowserNavigation(
+      selection,
+      topology.workspaces,
+      topology.tabs,
+      topology.panes,
+    );
+    expect(projected.selectedPaneId).toBe("a1q");
+    const layout = navigationLayout(topology.panes[0], topology.panes);
+    expect(
+      projectBrowserLayout(layout, projected.selectedPaneId)?.focused_pane_id,
+    ).toBe("a1q");
+    expect(layout.focused_pane_id).toBe("a1p");
+    expect(browserPaneInDirection(layout, "a1p", "right")).toBe("a1q");
+    expect(browserPaneInDirection(layout, "a1q", "left")).toBe("a1p");
+    expect(browserPaneInDirection(layout, "a1p", "up")).toBeNull();
+  });
+});
+
+import { bridge, type ConnectionClient } from "./api";
+import {
+  __storeTesting,
+  activateConnectionState,
+  emptyServerSessionState,
+  store,
+  type State,
+} from "./store";
+
+function browserState(): State {
+  const topology = navigationTopology();
+  const session = {
+    ...emptyServerSessionState(1),
+    navigationMode: "browser-local" as const,
+    ...projectBrowserNavigation(
+      emptyBrowserNavigation(),
+      topology.workspaces,
+      topology.tabs,
+      topology.panes,
+    ),
+    layout: navigationLayout(topology.panes[0], topology.panes),
+  };
+  return {
+    ...store.get(),
+    ...session,
+    status: "connected",
+    connectionPaused: false,
+    activeConnectionId: "test",
+    connectionGeneration: 1,
+    connections: ["test", "other"].map((id) => ({
+      id,
+      label: id,
+      source: "test",
+      is_default: id === "test",
+      state: "ready" as const,
+      generation: 1,
+    })),
+    sessionsByConnectionId: {
+      test: session,
+      other: emptyServerSessionState(1),
+    },
+  };
+}
+
+async function withBrowserStore(
+  run: (
+    calls: Array<{ method: string; params: Record<string, unknown> }>,
+    topology: ReturnType<typeof navigationTopology>,
+    control: {
+      mode: string;
+      layoutWait?: Promise<void>;
+      createWait?: Promise<void>;
+      actionWait?: (method: string) => Promise<void>;
+    },
+  ) => Promise<void>,
+) {
+  const previous = store.get();
+  const original = bridge.connection;
+  const topology = navigationTopology();
+  const calls: Array<{ method: string; params: Record<string, unknown> }> = [];
+  const control: {
+    mode: string;
+    layoutWait?: Promise<void>;
+    createWait?: Promise<void>;
+    actionWait?: (method: string) => Promise<void>;
+  } = {
+    mode: "browser-local",
+  };
+  bridge.connection = ((connectionId = "test") =>
+    ({
+      connectionId,
+      generation: 1,
+      serverRuntimeGeneration: 1,
+      isCurrent: () => true,
+      acceptsServerGeneration: () => true,
+      call: async (method: string, params: Record<string, unknown> = {}) => {
+        calls.push({ method, params });
+        await control.actionWait?.(method);
+        if (method === "workspace.list")
+          return {
+            workspaces: topology.workspaces,
+            navigation_mode: control.mode,
+          };
+        if (method === "tab.list") return { tabs: topology.tabs };
+        if (method === "pane.list") return { panes: topology.panes };
+        if (method === "pane.layout") {
+          const pane = topology.panes.find(
+            (p) => p.pane_id === params.pane_id,
+          )!;
+          await control.layoutWait;
+          return { layout: navigationLayout(pane, topology.panes) };
+        }
+        if (method === "pane.get")
+          return {
+            pane: topology.panes.find((p) => p.pane_id === params.pane_id),
+          };
+        if (method === "tab.create" || method === "workspace.create")
+          await control.createWait;
+        if (method === "tab.create")
+          return {
+            type: "tab_created",
+            tab: topology.tabs[1],
+            root_pane: topology.panes[2],
+          };
+        if (
+          method === "workspace.create" ||
+          method === "worktree.create" ||
+          method === "worktree.open"
+        )
+          return {
+            workspace: topology.workspaces[1],
+            tab: topology.tabs[2],
+            root_pane: topology.panes[3],
+          };
+        if (method === "pane.split") return { pane: topology.panes[1] };
+        return {};
+      },
+    }) satisfies ConnectionClient) as typeof bridge.connection;
+  __storeTesting.replaceState(browserState());
+  try {
+    await run(calls, topology, control);
+  } finally {
+    __storeTesting.replaceState(previous);
+    bridge.connection = original;
+  }
+}
+
+describe("store browser-local navigation", () => {
+  test("all navigation routes avoid shared focus and target input explicitly", async () => {
+    await withBrowserStore(async (calls) => {
+      await store.focusWorkspace("b");
+      expect(store.get().selectedPaneId).toBe("b1p");
+      await store.focusTab("a2");
+      expect(store.get().selectedPaneId).toBe("a2p");
+      await store.focusPane("a1p");
+      await store.focusPaneDirection("a1p", "right");
+      expect(store.get().selectedPaneId).toBe("a1q");
+      await store.selectPane("a1p");
+      await store.focusTaskNotificationTarget({
+        connectionId: "test",
+        runtimeGeneration: 1,
+        workspaceId: "b",
+        paneId: "b1p",
+      });
+      expect(store.get().selectedPaneId).toBe("b1p");
+      await store.sendText(store.get().selectedPaneId!, "targeted");
+      await store.sendKeys(store.get().selectedPaneId!, "Enter");
+      expect(calls.filter((call) => /focus/.test(call.method))).toEqual([]);
+      expect(
+        calls.filter((call) => call.method.startsWith("pane.send")),
+      ).toEqual([
+        {
+          method: "pane.send_text",
+          params: { pane_id: "b1p", text: "targeted" },
+        },
+        {
+          method: "pane.send_keys",
+          params: { pane_id: "b1p", keys: ["Enter"] },
+        },
+      ]);
+    });
+  });
+
+  test("event/resync snapshots and reconnect preserve selection; connection switches restore it", async () => {
+    await withBrowserStore(async (_calls, topology) => {
+      await store.focusTab("a2");
+      topology.workspaces[0].focused = false;
+      topology.workspaces[1].focused = true;
+      __storeTesting.handleHerdrEvent({
+        connection_id: "test",
+        connection_generation: 1,
+        event: "session.resync_required",
+        data: {},
+      });
+      await Bun.sleep(120);
+      expect(store.get().selectedPaneId).toBe("a2p");
+      const before = store.get();
+      __storeTesting.markTerminalReattachPending();
+      __storeTesting.applyCatalog(before.connections, "test");
+      __storeTesting.rearmTerminalAttachmentsAfterCatalog(true);
+      await store.refresh();
+      expect(store.get().selectedPaneId).toBe("a2p");
+      const other = activateConnectionState(store.get(), "other", 2);
+      const restored = activateConnectionState(other, "test", 3);
+      expect(restored.browserNavigation).toEqual(store.get().browserNavigation);
+      expect(restored.selectedPaneId).toBe("a2p");
+    });
+  });
+
+  test("a deferred layout cannot overwrite a newer local click", async () => {
+    await withBrowserStore(async (_calls, _topology, control) => {
+      let resolve!: () => void;
+      control.layoutWait = new Promise<void>((r) => {
+        resolve = r;
+      });
+      const refresh = store.refresh();
+      await Bun.sleep(1);
+      await store.focusTab("b1");
+      expect(store.get().layout).toBeNull();
+      resolve();
+      await refresh;
+      await Bun.sleep(5);
+      expect(store.get().selectedPaneId).toBe("b1p");
+      expect(store.get().layout?.tab_id).toBe("b1");
+    });
+  });
+
+  test("closed/moved snapshots reconcile action targets without following remote focus", async () => {
+    await withBrowserStore(async (calls, topology) => {
+      await store.focusPane("a1q");
+      Object.assign(topology.panes[1], { workspace_id: "b", tab_id: "b1" });
+      await store.refresh();
+      expect(store.get().selectedPaneId).toBe("a1p");
+      await store.closePane(store.get().selectedPaneId!);
+      expect(calls[calls.length - 1]).toEqual({
+        method: "pane.close",
+        params: { pane_id: "a1p" },
+      });
+      topology.panes = topology.panes.filter((pane) => pane.pane_id !== "a1p");
+      topology.tabs = topology.tabs.filter((tab) => tab.tab_id !== "a1");
+      await store.refresh();
+      expect(store.get().selectedPaneId).toBe("a2p");
+    });
+  });
+
+  test("notification activation follows an explicitly moved pane and falls back when closed", async () => {
+    await withBrowserStore(async (calls, topology) => {
+      Object.assign(topology.panes[1], { workspace_id: "b", tab_id: "b1" });
+      const target = {
+        connectionId: "test",
+        runtimeGeneration: 1,
+        workspaceId: "a",
+        paneId: "a1q",
+      };
+      await store.focusTaskNotificationTarget(target);
+      expect(store.get().browserNavigation.workspaceId).toBe("b");
+      expect(store.get().selectedPaneId).toBe("a1q");
+      topology.panes = topology.panes.filter((pane) => pane.pane_id !== "a1q");
+      await store.focusTaskNotificationTarget(target);
+      expect(store.get().browserNavigation.workspaceId).toBe("a");
+      expect(store.get().selectedPaneId).toBe("a1p");
+      expect(calls.filter((call) => /focus/.test(call.method))).toEqual([]);
+    });
+  });
+
+  test("a pane moved while its layout is in flight never publishes the destination tab", async () => {
+    await withBrowserStore(async (_calls, topology, control) => {
+      let resolve!: () => void;
+      control.layoutWait = new Promise<void>((r) => {
+        resolve = r;
+      });
+      const refresh = store.refresh();
+      await Bun.sleep(1);
+      Object.assign(topology.panes[0], { workspace_id: "b", tab_id: "b1" });
+      const publishedTabs: Array<string | undefined> = [];
+      const unsubscribe = store.subscribe(() =>
+        publishedTabs.push(store.get().layout?.tab_id),
+      );
+      resolve();
+      await refresh;
+      await Bun.sleep(5);
+      unsubscribe();
+      expect(publishedTabs).not.toContain("b1");
+      expect(store.get().selectedPaneId).toBe("a1q");
+      expect(store.get().layout?.tab_id).toBe("a1");
+    });
+  });
+
+  test("creation suppresses shared focus, inherits local context and selects returned objects", async () => {
+    await withBrowserStore(async (calls) => {
+      await store.focusPane("a1q");
+      await store.createTab("a");
+      expect(
+        calls.find((call) => call.method === "tab.create")?.params,
+      ).toEqual({
+        workspace_id: "a",
+        focus: false,
+        browser_source: {
+          workspace_id: "a",
+          tab_id: "a1",
+          pane_id: "a1q",
+          terminal_id: "a1q-terminal",
+        },
+      });
+      await store.refresh();
+      expect(store.get().selectedPaneId).toBe("a2p");
+      await store.createWorkspace("new");
+      expect(
+        calls.find((call) => call.method === "workspace.create")?.params,
+      ).toMatchObject({
+        browser_source: {
+          workspace_id: "a",
+          tab_id: "a2",
+          pane_id: "a2p",
+          terminal_id: "a2p-terminal",
+        },
+        focus: false,
+      });
+      expect(
+        calls.find((call) => call.method === "workspace.create")?.params.cwd,
+      ).toBeUndefined();
+      await store.refresh();
+      expect(store.get().selectedPaneId).toBe("b1p");
+      await store.splitPane("a1p", "right");
+      await store.refresh();
+      expect(store.get().selectedPaneId).toBe("a1q");
+      expect(
+        calls.find((call) => call.method === "pane.split")?.params,
+      ).toEqual({ target_pane_id: "a1p", direction: "right", focus: false });
+      await store.openWorktree("a", "topic");
+      await store.refresh();
+      expect(store.get().selectedPaneId).toBe("b1p");
+      expect(
+        calls.find((call) => call.method === "worktree.open")?.params.focus,
+      ).toBe(false);
+    });
+  });
+
+  test("creation never synthesizes cwd and carries nonactive workspace context", async () => {
+    await withBrowserStore(async (calls) => {
+      await store.createTab("b");
+      const tabCreate = calls.find((call) => call.method === "tab.create")!;
+      expect(tabCreate.params).not.toHaveProperty("cwd");
+      expect(tabCreate.params.browser_source).toEqual({
+        workspace_id: "b",
+        tab_id: "b1",
+        pane_id: "b1p",
+        terminal_id: "b1p-terminal",
+      });
+      await store.createWorkspace("explicit", "/chosen");
+      expect(
+        calls.find((call) => call.method === "workspace.create")?.params.cwd,
+      ).toBe("/chosen");
+    });
+  });
+
+  test("a delayed create response does not navigate away from a newer local choice", async () => {
+    await withBrowserStore(async (_calls, _topology, control) => {
+      let resolve!: () => void;
+      control.createWait = new Promise<void>((r) => {
+        resolve = r;
+      });
+      const creation = store.createTab("a");
+      await store.focusWorkspace("b");
+      resolve();
+      await creation;
+      await store.refresh();
+      expect(store.get().selectedPaneId).toBe("b1p");
+    });
+  });
+
+  for (const kind of [
+    "worktree-create",
+    "worktree-open",
+    "worktree-cwd",
+    "split",
+    "notification",
+    "notification-fallback",
+  ] as const) {
+    test(`delayed ${kind} preserves a newer browser selection`, async () => {
+      await withBrowserStore(async (_calls, topology, control) => {
+        let release!: () => void;
+        const waiting = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        const worktree = kind.startsWith("worktree");
+        const method =
+          kind === "worktree-create"
+            ? "worktree.create"
+            : worktree
+              ? "worktree.open"
+              : kind === "split"
+                ? "pane.split"
+                : "pane.get";
+        control.actionWait = (call) =>
+          call === method ? waiting : Promise.resolve();
+        if (worktree) await store.focusWorkspace("b");
+        if (kind === "notification-fallback")
+          topology.panes = topology.panes.filter(
+            (pane) => pane.pane_id !== "a1q",
+          );
+        const pending =
+          kind === "worktree-create"
+            ? store.createWorktree("b", "topic")
+            : kind === "worktree-open"
+              ? store.openWorktree("b", "topic")
+              : kind === "worktree-cwd"
+                ? store.openWorktreeFromCwd("/tmp/b", "main")
+                : kind === "split"
+                  ? store.splitPane("a1p", "right")
+                  : store.focusTaskNotificationTarget({
+                      connectionId: "test",
+                      runtimeGeneration: 1,
+                      workspaceId: "a",
+                      paneId: "a1q",
+                    });
+        await store.focusWorkspace(worktree ? "a" : "b");
+        release();
+        await pending;
+        await store.refresh();
+        expect(store.get().selectedPaneId).toBe(worktree ? "a1p" : "b1p");
+      });
+    });
+  }
+
+  test("reverse mutation completion cannot let an older split steal selection", async () => {
+    await withBrowserStore(async (_calls, _topology, control) => {
+      let release!: () => void;
+      const waiting = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      control.actionWait = (method) =>
+        method === "pane.split" ? waiting : Promise.resolve();
+      const split = store.splitPane("a1p", "right");
+      await store.openWorktree("a", "topic");
+      await store.refresh();
+      expect(store.get().selectedPaneId).toBe("b1p");
+      release();
+      await split;
+      expect(store.get().selectedPaneId).toBe("b1p");
+    });
+  });
+
+  test("legacy or endpoint-disabled metadata explicitly restores shared behavior", async () => {
+    await withBrowserStore(async (calls, _topology, control) => {
+      await store.focusWorkspace("b");
+      control.mode = "shared";
+      await store.refresh();
+      expect(store.get().navigationMode).toBe("shared");
+      expect(store.get().workspaces.find((w) => w.focused)?.workspace_id).toBe(
+        "a",
+      );
+      await store.focusTab("b1");
+      expect(
+        calls
+          .filter((call) => /focus/.test(call.method))
+          .map((call) => call.method),
+      ).toEqual(["workspace.focus", "tab.focus"]);
+    });
+  });
+});
+
+for (const kind of [
+  "worktree-create",
+  "worktree-open",
+  "worktree-cwd",
+  "split",
+  "notification",
+] as const) {
+  test(`delayed ${kind} cannot adopt into a replacement runtime on the same connection`, async () => {
+    await withBrowserStore(async (_calls, _topology, control) => {
+      let release!: () => void;
+      const waiting = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const method =
+        kind === "worktree-create"
+          ? "worktree.create"
+          : kind.startsWith("worktree")
+            ? "worktree.open"
+            : kind === "split"
+              ? "pane.split"
+              : "pane.get";
+      control.actionWait = (call) =>
+        call === method ? waiting : Promise.resolve();
+      const pending =
+        kind === "worktree-create"
+          ? store.createWorktree("a", "topic")
+          : kind === "worktree-open"
+            ? store.openWorktree("a", "topic")
+            : kind === "worktree-cwd"
+              ? store.openWorktreeFromCwd("/tmp/a", "main")
+              : kind === "split"
+                ? store.splitPane("a1p", "right")
+                : store.focusTaskNotificationTarget({
+                    connectionId: "test",
+                    runtimeGeneration: 1,
+                    workspaceId: "a",
+                    paneId: "a1q",
+                  });
+      __storeTesting.replaceState({
+        ...activateConnectionState(store.get(), "test", 2),
+        serverRuntimeGeneration: 2,
+      });
+      release();
+      await pending;
+      expect(store.get().selectedPaneId).toBe("a1p");
+      expect(store.get().browserNavigation.workspaceId).toBe("a");
+    });
+  });
+}

--- a/web/src/browserNavigation.test.ts
+++ b/web/src/browserNavigation.test.ts
@@ -131,7 +131,7 @@ describe("browser navigation projection", () => {
     ).toBe("a1q");
     expect(
       projectBrowserNavigation(selected, [], [], []).browserNavigation,
-    ).toEqual(emptyBrowserNavigation());
+    ).toEqual({ ...emptyBrowserNavigation(), revision: selected.revision + 1 });
   });
 
   test("remembers per-workspace tabs and per-tab panes without adopting later focus", () => {
@@ -653,3 +653,207 @@ for (const kind of [
     });
   });
 }
+
+for (const kind of [
+  "tab",
+  "workspace",
+  "worktree-create",
+  "worktree-open",
+  "worktree-cwd",
+  "split",
+  "notification",
+  "notification-fallback",
+] as const) {
+  test(`delayed ${kind} cannot adopt after workspace A-B-A navigation`, async () => {
+    await withBrowserStore(async (_calls, _topology, control) => {
+      let release!: () => void;
+      const held = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const method =
+        kind === "tab"
+          ? "tab.create"
+          : kind === "workspace"
+            ? "workspace.create"
+            : kind === "worktree-create"
+              ? "worktree.create"
+              : kind.startsWith("worktree")
+                ? "worktree.open"
+                : kind === "split"
+                  ? "pane.split"
+                  : "pane.get";
+      control.actionWait = (call) =>
+        call === method ? held : Promise.resolve();
+      const pending =
+        kind === "tab"
+          ? store.createTab("a")
+          : kind === "workspace"
+            ? store.createWorkspace("new")
+            : kind === "worktree-create"
+              ? store.createWorktree("a", "topic")
+              : kind === "worktree-open"
+                ? store.openWorktree("a", "topic")
+                : kind === "worktree-cwd"
+                  ? store.openWorktreeFromCwd("/tmp/a", "main")
+                  : kind === "split"
+                    ? store.splitPane("a1p", "right")
+                    : store.focusTaskNotificationTarget({
+                        connectionId: "test",
+                        runtimeGeneration: 1,
+                        workspaceId:
+                          kind === "notification-fallback" ? "b" : "a",
+                        paneId:
+                          kind === "notification-fallback" ? "closed" : "a1q",
+                      });
+      await store.focusWorkspace("b");
+      await store.focusWorkspace("a");
+      release();
+      await pending;
+      await store.refresh();
+      expect(store.get().selectedPaneId).toBe("a1p");
+    });
+  });
+}
+
+for (const scope of ["tab", "pane"] as const) {
+  test(`delayed tab creation cannot adopt after same-workspace ${scope} ABA`, async () => {
+    await withBrowserStore(async (_calls, _topology, control) => {
+      let release!: () => void;
+      control.createWait = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const pending = store.createTab("a");
+      if (scope === "tab") {
+        await store.focusTab("a2");
+        await store.focusTab("a1");
+      } else {
+        await store.focusPane("a1q");
+        await store.focusPane("a1p");
+      }
+      release();
+      await pending;
+      await store.refresh();
+      expect(store.get().selectedPaneId).toBe("a1p");
+    });
+  });
+}
+
+test("ordinary snapshots do not invalidate pending adoption, including copied navigation maps", async () => {
+  await withBrowserStore(async (_calls, topology, control) => {
+    let release!: () => void;
+    control.createWait = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const pending = store.createTab("a");
+    const initialNavigation = store.get().browserNavigation;
+    topology.workspaces[0] = { ...topology.workspaces[0], label: "renamed" };
+    topology.tabs.push({ ...topology.tabs[2], tab_id: "b2" });
+    topology.panes.push({ ...topology.panes[3], tab_id: "b2", pane_id: "b2p" });
+    await store.refresh();
+    await store.refresh();
+    expect(initialNavigation.workspaceId).toBe("a");
+    expect(store.get().browserNavigation).not.toBe(initialNavigation);
+    expect(store.get().browserNavigation.revision).toBe(
+      initialNavigation.revision,
+    );
+    release();
+    await pending;
+    await store.refresh();
+    expect(store.get().selectedPaneId).toBe("a2p");
+  });
+});
+
+for (const paneId of ["a1p", "closed"]) {
+  test(`successful same-target notification ${paneId} adoption invalidates an older competing creation`, async () => {
+    await withBrowserStore(async (_calls, _topology, control) => {
+      let release!: () => void;
+      control.createWait = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const pending = store.createTab("a");
+      await store.focusTaskNotificationTarget({
+        connectionId: "test",
+        runtimeGeneration: 1,
+        workspaceId: "a",
+        paneId,
+      });
+      release();
+      await pending;
+      await store.refresh();
+      expect(store.get().selectedPaneId).toBe("a1p");
+    });
+  });
+}
+
+test("revision snapshots are immutable; reconciliation changes revision only for a different active target", () => {
+  const topology = navigationTopology();
+  const initial = projectBrowserNavigation(
+    emptyBrowserNavigation(),
+    topology.workspaces,
+    topology.tabs,
+    topology.panes,
+  ).browserNavigation;
+  Object.freeze(initial);
+  Object.freeze(initial.tabIds);
+  Object.freeze(initial.paneIds);
+  const selected = selectBrowserTarget(initial, "a", "a1", "a1q");
+  expect(selected.revision).toBe(initial.revision + 1);
+  expect(initial.paneIds.a1).toBe("a1p");
+  const stable = projectBrowserNavigation(
+    selected,
+    topology.workspaces,
+    topology.tabs,
+    topology.panes,
+  ).browserNavigation;
+  expect(stable).not.toBe(selected);
+  expect(stable.revision).toBe(selected.revision);
+  const removed = projectBrowserNavigation(
+    stable,
+    topology.workspaces,
+    topology.tabs,
+    topology.panes.filter((pane) => pane.pane_id !== "a1q"),
+  ).browserNavigation;
+  expect(removed.revision).toBe(stable.revision + 1);
+  expect(removed.paneIds.a1).toBe("a1p");
+});
+
+test("navigation revisions remain partitioned by connection and reset with runtime session state", async () => {
+  await withBrowserStore(async () => {
+    await store.focusWorkspace("b");
+    const original = store.get().browserNavigation;
+    __storeTesting.replaceState(
+      activateConnectionState(store.get(), "other", 2),
+    );
+    expect(store.get().browserNavigation.revision).toBe(0);
+    await store.refresh();
+    await store.focusPane("a1q");
+    __storeTesting.replaceState(
+      activateConnectionState(store.get(), "test", 3),
+    );
+    expect(store.get().browserNavigation).toEqual(original);
+    expect(emptyServerSessionState(2).browserNavigation.revision).toBe(0);
+  });
+});
+
+test("shared fallback retains shared focus, creation and split selection semantics", async () => {
+  await withBrowserStore(async (calls, _topology, control) => {
+    control.mode = "shared";
+    await store.refresh();
+    const revision = store.get().browserNavigation.revision;
+    await store.createTab("a");
+    expect(calls.find((call) => call.method === "tab.create")?.params).toEqual({
+      workspace_id: "a",
+      focus: true,
+    });
+    await store.focusWorkspace("b");
+    expect(
+      calls.some(
+        (call) =>
+          call.method === "workspace.focus" && call.params.workspace_id === "b",
+      ),
+    ).toBe(true);
+    await store.splitPane("a1p", "right");
+    expect(store.get().selectedPaneId).toBe("a1q");
+    expect(store.get().browserNavigation.revision).toBe(revision);
+  });
+});

--- a/web/src/browserNavigation.ts
+++ b/web/src/browserNavigation.ts
@@ -1,0 +1,158 @@
+import type { Pane, PaneLayout, Tab, Workspace } from "./types";
+
+/** Browser-memory selection, partitioned by the store's connection/runtime lease. */
+export interface BrowserNavigation {
+  workspaceId: string | null;
+  tabIds: Record<string, string>;
+  paneIds: Record<string, string>;
+}
+
+export function emptyBrowserNavigation(): BrowserNavigation {
+  return { workspaceId: null, tabIds: {}, paneIds: {} };
+}
+
+export function selectBrowserTarget(
+  navigation: BrowserNavigation,
+  workspaceId: string,
+  tabId?: string,
+  paneId?: string,
+): BrowserNavigation {
+  return {
+    workspaceId,
+    tabIds: tabId
+      ? { ...navigation.tabIds, [workspaceId]: tabId }
+      : navigation.tabIds,
+    paneIds:
+      tabId && paneId
+        ? { ...navigation.paneIds, [tabId]: paneId }
+        : navigation.paneIds,
+  };
+}
+
+/** Adopt shared focus only at first observation; later snapshots cannot navigate. */
+export function projectBrowserNavigation(
+  navigation: BrowserNavigation,
+  workspaces: Workspace[],
+  tabs: Tab[],
+  panes: Pane[],
+): {
+  browserNavigation: BrowserNavigation;
+  workspaces: Workspace[];
+  tabs: Tab[];
+  panes: Pane[];
+  selectedPaneId: string | null;
+} {
+  const workspaceId =
+    workspaces.find((w) => w.workspace_id === navigation.workspaceId)
+      ?.workspace_id ??
+    (navigation.workspaceId === null
+      ? workspaces.find((w) => w.focused)?.workspace_id
+      : undefined) ??
+    workspaces[0]?.workspace_id ??
+    null;
+  const tabIds: Record<string, string> = {};
+  const paneIds: Record<string, string> = {};
+  for (const workspace of workspaces) {
+    const candidates = tabs.filter(
+      (tab) => tab.workspace_id === workspace.workspace_id,
+    );
+    const remembered = navigation.tabIds[workspace.workspace_id];
+    const tab =
+      candidates.find((tab) => tab.tab_id === remembered) ??
+      (!remembered
+        ? candidates.find((tab) => tab.tab_id === workspace.active_tab_id)
+        : undefined) ??
+      candidates[0];
+    if (tab) tabIds[workspace.workspace_id] = tab.tab_id;
+  }
+  for (const tab of tabs) {
+    const candidates = panes.filter(
+      (pane) =>
+        pane.tab_id === tab.tab_id && pane.workspace_id === tab.workspace_id,
+    );
+    const remembered = navigation.paneIds[tab.tab_id];
+    const pane =
+      candidates.find((pane) => pane.pane_id === remembered) ??
+      (!remembered ? candidates.find((pane) => pane.focused) : undefined) ??
+      candidates[0];
+    if (pane) paneIds[tab.tab_id] = pane.pane_id;
+  }
+  const selectedTabId = workspaceId ? tabIds[workspaceId] : undefined;
+  const selectedPaneId = selectedTabId
+    ? (paneIds[selectedTabId] ?? null)
+    : null;
+  return {
+    browserNavigation: { workspaceId, tabIds, paneIds },
+    workspaces: workspaces.map((w) => ({
+      ...w,
+      focused: w.workspace_id === workspaceId,
+      active_tab_id: tabIds[w.workspace_id],
+    })),
+    tabs: tabs.map((t) => ({ ...t, focused: t.tab_id === selectedTabId })),
+    panes: panes.map((p) => ({ ...p, focused: p.pane_id === selectedPaneId })),
+    selectedPaneId,
+  };
+}
+
+export function projectBrowserLayout(
+  layout: PaneLayout | null,
+  paneId: string | null,
+): PaneLayout | null {
+  if (
+    !layout ||
+    !paneId ||
+    !layout.panes.some((pane) => pane.pane_id === paneId)
+  )
+    return layout;
+  return {
+    ...layout,
+    focused_pane_id: paneId,
+    panes: layout.panes.map((pane) => ({
+      ...pane,
+      focused: pane.pane_id === paneId,
+    })),
+  };
+}
+
+/** Directional navigation uses visible pane geometry, never a shared focus RPC. */
+export function browserPaneInDirection(
+  layout: PaneLayout | null,
+  paneId: string,
+  direction: "left" | "right" | "up" | "down",
+): string | null {
+  const source = layout?.panes.find((pane) => pane.pane_id === paneId);
+  if (!source || !layout) return null;
+  const horizontal = direction === "left" || direction === "right";
+  const reverse = direction === "left" || direction === "up";
+  const a = source.rect;
+  const start = horizontal ? a.x : a.y;
+  const end = start + (horizontal ? a.width : a.height);
+  const crossStart = horizontal ? a.y : a.x;
+  const crossEnd = crossStart + (horizontal ? a.height : a.width);
+  // Same edge/overlap/center ordering as tagged Herdr 0.9 layout::find_in_direction.
+  return (
+    layout.panes
+      .filter((pane) => pane.pane_id !== paneId)
+      .map((pane) => {
+        const b = pane.rect;
+        const bStart = horizontal ? b.x : b.y;
+        const bEnd = bStart + (horizontal ? b.width : b.height);
+        const bCrossStart = horizontal ? b.y : b.x;
+        const bCrossEnd = bCrossStart + (horizontal ? b.height : b.width);
+        return {
+          pane,
+          distance: reverse ? start - bEnd : bStart - end,
+          overlap:
+            Math.min(crossEnd, bCrossEnd) - Math.max(crossStart, bCrossStart),
+          center: Math.abs(crossStart + crossEnd - bCrossStart - bCrossEnd),
+        };
+      })
+      .filter((candidate) => candidate.distance >= 0 && candidate.overlap > 0)
+      .sort(
+        (a, b) =>
+          a.distance - b.distance ||
+          b.overlap - a.overlap ||
+          a.center - b.center,
+      )[0]?.pane.pane_id ?? null
+  );
+}

--- a/web/src/browserNavigation.ts
+++ b/web/src/browserNavigation.ts
@@ -2,13 +2,15 @@ import type { Pane, PaneLayout, Tab, Workspace } from "./types";
 
 /** Browser-memory selection, partitioned by the store's connection/runtime lease. */
 export interface BrowserNavigation {
+  /** Explicit navigation/adoption invalidates pending results, including ABA. */
+  revision: number;
   workspaceId: string | null;
   tabIds: Record<string, string>;
   paneIds: Record<string, string>;
 }
 
 export function emptyBrowserNavigation(): BrowserNavigation {
-  return { workspaceId: null, tabIds: {}, paneIds: {} };
+  return { revision: 0, workspaceId: null, tabIds: {}, paneIds: {} };
 }
 
 export function selectBrowserTarget(
@@ -18,6 +20,7 @@ export function selectBrowserTarget(
   paneId?: string,
 ): BrowserNavigation {
   return {
+    revision: navigation.revision + 1,
     workspaceId,
     tabIds: tabId
       ? { ...navigation.tabIds, [workspaceId]: tabId }
@@ -81,8 +84,23 @@ export function projectBrowserNavigation(
   const selectedPaneId = selectedTabId
     ? (paneIds[selectedTabId] ?? null)
     : null;
+  const previousTabId = navigation.workspaceId
+    ? navigation.tabIds[navigation.workspaceId]
+    : undefined;
+  const previousPaneId = previousTabId
+    ? (navigation.paneIds[previousTabId] ?? null)
+    : null;
+  const selectionChanged =
+    workspaceId !== navigation.workspaceId ||
+    selectedTabId !== previousTabId ||
+    selectedPaneId !== previousPaneId;
   return {
-    browserNavigation: { workspaceId, tabIds, paneIds },
+    browserNavigation: {
+      revision: navigation.revision + (selectionChanged ? 1 : 0),
+      workspaceId,
+      tabIds,
+      paneIds,
+    },
     workspaces: workspaces.map((w) => ({
       ...w,
       focused: w.workspace_id === workspaceId,

--- a/web/src/components/ConnectionSwitcher.tsx
+++ b/web/src/components/ConnectionSwitcher.tsx
@@ -159,6 +159,7 @@ function BrowserTransportStatus({ onAction }: { onAction?: () => void }) {
       bridgeStatus: snapshot.bridgeStatus,
       connectionPaused: snapshot.connectionPaused,
       status: snapshot.status,
+      navigationMode: snapshot.navigationMode,
     }),
     shallowEqual,
   );
@@ -190,6 +191,17 @@ function BrowserTransportStatus({ onAction }: { onAction?: () => void }) {
           }`}
         />
         <span>{statusLabel}</span>
+        <span
+          title={
+            state.navigationMode === "browser-local"
+              ? "Workspace, tab and pane selection stays in this browser. Topology and sizes are shared."
+              : "Legacy navigation follows shared Herdr focus and can move other clients."
+          }
+        >
+          {state.navigationMode === "browser-local"
+            ? "Local navigation"
+            : "Shared navigation"}
+        </span>
       </div>
       {onAction ? (
         <div className="connection-browser-actions">

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -1,3 +1,11 @@
+import {
+  type BrowserNavigation,
+  emptyBrowserNavigation,
+  selectBrowserTarget,
+  projectBrowserNavigation,
+  projectBrowserLayout,
+  browserPaneInDirection,
+} from "./browserNavigation";
 import { useRef, useSyncExternalStore } from "react";
 import {
   bridge,
@@ -32,6 +40,8 @@ import {
 export interface ServerSessionState {
   /** ConnectionManager generation that owns every server resource below. */
   serverRuntimeGeneration: number | null;
+  navigationMode: "browser-local" | "shared";
+  browserNavigation: BrowserNavigation;
   workspaces: Workspace[];
   tabs: Tab[];
   panes: Pane[];
@@ -143,6 +153,8 @@ export function emptyServerSessionState(
 ): ServerSessionState {
   return {
     serverRuntimeGeneration,
+    navigationMode: "shared",
+    browserNavigation: emptyBrowserNavigation(),
     workspaces: [],
     tabs: [],
     panes: [],
@@ -322,6 +334,8 @@ const initial: State = {
 
 const SERVER_SESSION_KEYS: Array<keyof ServerSessionState> = [
   "serverRuntimeGeneration",
+  "navigationMode",
+  "browserNavigation",
   "workspaces",
   "tabs",
   "panes",
@@ -339,6 +353,8 @@ const SERVER_SESSION_KEYS: Array<keyof ServerSessionState> = [
 function serverSessionFromState(snapshot: State): ServerSessionState {
   return {
     serverRuntimeGeneration: snapshot.serverRuntimeGeneration,
+    navigationMode: snapshot.navigationMode,
+    browserNavigation: snapshot.browserNavigation,
     workspaces: snapshot.workspaces,
     tabs: snapshot.tabs,
     panes: snapshot.panes,
@@ -961,8 +977,15 @@ function serverSessionEqual(
   return true;
 }
 
-const REFRESH_SLICE_KEYS = ["workspaces", "tabs", "panes", "layout"] as const;
+const REFRESH_SLICE_KEYS = [
+  "workspaces",
+  "tabs",
+  "panes",
+  "layout",
+  "browserNavigation",
+] as const;
 const REFRESH_SCALAR_KEYS = [
+  "navigationMode",
   "error",
   "pendingFocusWorkspaceId",
   "pendingFocusWorkspaceSettledAt",
@@ -1065,6 +1088,7 @@ async function refreshNow(lease = captureConnectionLease()) {
   // Snapshot the pending-focus marker when the fetch actually starts. Only a
   // refresh that began after the focus action settled may declare the focus
   // lost, and only while the marker still belongs to that same attempt.
+  const navigationAtEntry = state.browserNavigation;
   const pendingFocusAtEntry = {
     seq: state.pendingFocusWorkspaceSeq,
     settledAt: state.pendingFocusWorkspaceSettledAt,
@@ -1086,13 +1110,27 @@ async function refreshNow(lease = captureConnectionLease()) {
     );
     const completedPanes = trackTaskCompletions(lease.connectionId, panes);
 
+    const navigationMode =
+      wsRes?.navigation_mode === "browser-local" ? "browser-local" : "shared";
     const next: Partial<State> = {
+      navigationMode,
       workspaces,
       tabs,
       panes,
       error: null,
       lastRefresh: Date.now(),
     };
+    if (navigationMode === "browser-local") {
+      Object.assign(
+        next,
+        projectBrowserNavigation(
+          state.browserNavigation,
+          workspaces,
+          tabs,
+          panes,
+        ),
+      );
+    }
     const pendingFocusAtObservation = {
       seq: state.pendingFocusWorkspaceSeq,
       settledAt: state.pendingFocusWorkspaceSettledAt,
@@ -1122,6 +1160,7 @@ async function refreshNow(lease = captureConnectionLease()) {
     // active tab layout is fetched below, because a pane can exist while no
     // longer belonging to the visible terminal.
     if (
+      navigationMode === "shared" &&
       state.selectedPaneId &&
       !panes.some((p) => p.pane_id === state.selectedPaneId)
     ) {
@@ -1140,9 +1179,26 @@ async function refreshNow(lease = captureConnectionLease()) {
           pane_id: aPane.pane_id,
         });
         if (!leaseIsCurrent(lease)) return;
-        const layout = (lr?.layout ?? null) as PaneLayout | null;
-        next.layout = layout;
+        const observedLayout = (lr?.layout ?? null) as PaneLayout | null;
+        // Panes can move or close between pane.list and pane.layout. Never
+        // substitute shared layout focus for a missing browser-selected pane.
+        const staleLayout =
+          navigationMode === "browser-local" &&
+          observedLayout &&
+          (observedLayout.tab_id !== activeTabId ||
+            observedLayout.workspace_id !== aPane.workspace_id ||
+            (next.selectedPaneId &&
+              !observedLayout.panes.some(
+                (pane) => pane.pane_id === next.selectedPaneId,
+              )));
+        const layout = staleLayout ? null : observedLayout;
+        if (staleLayout) queuedConnectionKeys.add(refreshKey);
+        next.layout =
+          navigationMode === "browser-local"
+            ? projectBrowserLayout(layout, next.selectedPaneId ?? null)
+            : layout;
         if (
+          navigationMode === "shared" &&
           layout &&
           state.selectedPaneId &&
           !layout.panes.some((p) => p.pane_id === state.selectedPaneId)
@@ -1154,6 +1210,12 @@ async function refreshNow(lease = captureConnectionLease()) {
       }
     } else {
       next.layout = null;
+    }
+
+    // Never publish a layout fetched for an older browser navigation target.
+    if (navigationAtEntry !== state.browserNavigation) {
+      queuedConnectionKeys.add(refreshKey);
+      return;
     }
 
     // Layout fetching can overlap another focus attempt or its settlement.
@@ -1797,6 +1859,92 @@ function handleHerdrEvent(event: HerdrEventMsg) {
   }
 }
 
+function browserSelectionIsCurrent(navigation: BrowserNavigation) {
+  const current = state.browserNavigation;
+  const workspaceId = navigation.workspaceId;
+  const tabId = workspaceId ? navigation.tabIds[workspaceId] : undefined;
+  return (
+    current.workspaceId === workspaceId &&
+    (!workspaceId || current.tabIds[workspaceId] === tabId) &&
+    (!tabId || current.paneIds[tabId] === navigation.paneIds[tabId])
+  );
+}
+
+function browserCreationSource(workspaceId: string | null) {
+  const tabId = workspaceId
+    ? state.browserNavigation.tabIds[workspaceId]
+    : undefined;
+  const paneId = tabId ? state.browserNavigation.paneIds[tabId] : undefined;
+  const pane = state.panes.find((pane) => pane.pane_id === paneId);
+  return pane
+    ? {
+        workspace_id: pane.workspace_id,
+        tab_id: pane.tab_id,
+        pane_id: pane.pane_id,
+        terminal_id: pane.terminal_id,
+      }
+    : null;
+}
+
+function navigateBrowser(workspaceId: string, tabId?: string, paneId?: string) {
+  const navigation = selectBrowserTarget(
+    state.browserNavigation,
+    workspaceId,
+    tabId,
+    paneId,
+  );
+  const projected = projectBrowserNavigation(
+    navigation,
+    state.workspaces,
+    state.tabs,
+    state.panes,
+  );
+  const activeTabId = projected.browserNavigation.tabIds[workspaceId];
+  set({
+    ...projected,
+    layout:
+      state.layout?.tab_id === activeTabId
+        ? projectBrowserLayout(state.layout, projected.selectedPaneId)
+        : null,
+    pendingFocusWorkspaceId: null,
+    pendingFocusWorkspaceSettledAt: null,
+    error: null,
+  });
+  return refreshNow();
+}
+
+/** Adopt an explicit RPC result without requiring it in an older list snapshot. */
+function adoptBrowserTarget(lease: StoreConnectionLease, result: unknown) {
+  if (
+    !leaseIsCurrent(lease) ||
+    state.navigationMode !== "browser-local" ||
+    !result ||
+    typeof result !== "object"
+  )
+    return;
+  const target = result as {
+    root_pane?: Partial<Pane>;
+    pane?: Partial<Pane>;
+    tab?: Partial<Tab>;
+    workspace?: Partial<Workspace>;
+  };
+  const pane = target.root_pane ?? target.pane;
+  const tabId = pane?.tab_id ?? target.tab?.tab_id;
+  const workspaceId =
+    pane?.workspace_id ??
+    target.tab?.workspace_id ??
+    target.workspace?.workspace_id;
+  if (typeof workspaceId !== "string") return;
+  setForConnection(lease, {
+    browserNavigation: selectBrowserTarget(
+      state.browserNavigation,
+      workspaceId,
+      typeof tabId === "string" ? tabId : undefined,
+      typeof pane?.pane_id === "string" ? pane.pane_id : undefined,
+    ),
+  });
+}
+
 export const store = {
   get: () => state,
   subscribe(l: () => void) {
@@ -2006,6 +2154,8 @@ export const store = {
   },
 
   selectPane(paneId: string) {
+    if (state.navigationMode === "browser-local")
+      return store.focusPane(paneId);
     set({
       selectedPaneId: paneId,
       error: null,
@@ -2013,6 +2163,10 @@ export const store = {
   },
 
   focusTab(tabId: string) {
+    if (state.navigationMode === "browser-local") {
+      const tab = state.tabs.find((tab) => tab.tab_id === tabId);
+      return tab ? navigateBrowser(tab.workspace_id, tabId) : Promise.resolve();
+    }
     const workspaceId = state.tabs.find(
       (t) => t.tab_id === tabId,
     )?.workspace_id;
@@ -2059,33 +2213,50 @@ export const store = {
   },
 
   createTab(workspaceId: string, options: { numberedLabel?: boolean } = {}) {
-    return action(async (lease) => {
-      const result: unknown = await lease.client.call("tab.create", {
-        workspace_id: workspaceId,
-        focus: true,
-      });
-      if (!options.numberedLabel) return result;
+    const navigation = state.browserNavigation;
+    return action(
+      async (lease) => {
+        const result: unknown = await lease.client.call("tab.create", {
+          workspace_id: workspaceId,
+          focus: state.navigationMode !== "browser-local",
+          ...(state.navigationMode === "browser-local"
+            ? {
+                browser_source: browserCreationSource(workspaceId),
+              }
+            : {}),
+        });
+        if (browserSelectionIsCurrent(navigation))
+          adoptBrowserTarget(lease, result);
+        if (!options.numberedLabel) return result;
 
-      const rename = numberedCreatedTabRename(result);
-      if (!rename) return result;
-      try {
-        await lease.client.call("tab.rename", {
-          tab_id: rename.tabId,
-          label: rename.label,
-        });
-      } catch (error) {
-        // The tab already exists, so keep the successful create visible while
-        // surfacing the non-fatal naming failure to the user.
-        setForConnection(lease, {
-          notice: {
-            kind: "error",
-            message: "Tab created, but naming failed",
-            detail: (error as Error).message,
-          },
-        });
-      }
-      return result;
-    });
+        const rename = numberedCreatedTabRename(result);
+        if (!rename) return result;
+        try {
+          await lease.client.call("tab.rename", {
+            tab_id: rename.tabId,
+            label: rename.label,
+          });
+        } catch (error) {
+          // The tab already exists, so keep the successful create visible while
+          // surfacing the non-fatal naming failure to the user.
+          setForConnection(lease, {
+            notice: {
+              kind: "error",
+              message: "Tab created, but naming failed",
+              detail: (error as Error).message,
+            },
+          });
+        }
+        return result;
+      },
+      {
+        failureNotice: (error) => ({
+          kind: "error",
+          message: "Tab creation failed",
+          detail: error.message,
+        }),
+      },
+    );
   },
 
   closeTab(tabId: string) {
@@ -2099,6 +2270,13 @@ export const store = {
   },
 
   focusWorkspace(workspaceId: string) {
+    if (state.navigationMode === "browser-local") {
+      return state.workspaces.some(
+        (workspace) => workspace.workspace_id === workspaceId,
+      )
+        ? navigateBrowser(workspaceId)
+        : Promise.resolve();
+    }
     const pendingFocusSeq = stampPendingFocusWorkspace(workspaceId);
     return action(
       (lease) =>
@@ -2128,6 +2306,28 @@ export const store = {
       state.serverRuntimeGeneration !== target.runtimeGeneration
     ) {
       return Promise.resolve(undefined);
+    }
+    if (state.navigationMode === "browser-local") {
+      const navigation = state.browserNavigation;
+      return action(
+        async (lease) => {
+          const result = await lease.client
+            .call("pane.get", { pane_id: target.paneId })
+            .catch(() => null);
+          if (!leaseIsCurrent(lease)) return;
+          if (!browserSelectionIsCurrent(navigation)) return refreshNow(lease);
+          if (result?.pane) adoptBrowserTarget(lease, result);
+          else
+            setForConnection(lease, {
+              browserNavigation: selectBrowserTarget(
+                state.browserNavigation,
+                target.workspaceId,
+              ),
+            });
+          return refreshNow(lease);
+        },
+        { refresh: "none" },
+      );
     }
     const pendingFocusSeq = stampPendingFocusWorkspace(target.workspaceId);
     return action(
@@ -2166,8 +2366,32 @@ export const store = {
   },
 
   createWorkspace(label?: string, cwd?: string) {
-    return action((lease) =>
-      lease.client.call("workspace.create", { label, cwd, focus: true }),
+    const navigation = state.browserNavigation;
+    return action(
+      async (lease) => {
+        const result = await lease.client.call("workspace.create", {
+          label,
+          cwd,
+          focus: state.navigationMode !== "browser-local",
+          ...(state.navigationMode === "browser-local"
+            ? {
+                browser_source: browserCreationSource(
+                  state.browserNavigation.workspaceId,
+                ),
+              }
+            : {}),
+        });
+        if (browserSelectionIsCurrent(navigation))
+          adoptBrowserTarget(lease, result);
+        return result;
+      },
+      {
+        failureNotice: (error) => ({
+          kind: "error",
+          message: "Workspace creation failed",
+          detail: error.message,
+        }),
+      },
     );
   },
 
@@ -2328,6 +2552,7 @@ export const store = {
   },
 
   createWorktree(workspaceId: string, branch: string) {
+    const navigation = state.browserNavigation;
     return action(
       async (lease) => {
         setForConnection(lease, {
@@ -2343,8 +2568,10 @@ export const store = {
         const result = await lease.client.call("worktree.create", {
           workspace_id: workspaceId,
           branch,
-          focus: true,
+          focus: state.navigationMode !== "browser-local",
         });
+        if (browserSelectionIsCurrent(navigation))
+          adoptBrowserTarget(lease, result);
         const setupHook = result?.setup_hook as
           | WorktreeHookRunResult
           | undefined;
@@ -2379,6 +2606,7 @@ export const store = {
   },
 
   openWorktree(workspaceId: string, target: string, focus = true) {
+    const navigation = state.browserNavigation;
     const trimmed = target.trim();
     const locator = trimmed.startsWith("/")
       ? { path: trimmed }
@@ -2387,8 +2615,10 @@ export const store = {
       const result = await lease.client.call("worktree.open", {
         workspace_id: workspaceId,
         ...locator,
-        focus,
+        focus: focus && state.navigationMode !== "browser-local",
       });
+      if (focus && browserSelectionIsCurrent(navigation))
+        adoptBrowserTarget(lease, result);
       const openedHook = result?.opened_hook as
         | WorktreeHookRunResult
         | undefined;
@@ -2404,6 +2634,7 @@ export const store = {
   // Herdr accepts the repository root as the source in that state, allowing
   // the GUI to reopen main without inventing or guessing a workspace ID.
   openWorktreeFromCwd(cwd: string, target: string, focus = true) {
+    const navigation = state.browserNavigation;
     const trimmed = target.trim();
     const locator = trimmed.startsWith("/")
       ? { path: trimmed }
@@ -2412,8 +2643,10 @@ export const store = {
       const result = await lease.client.call("worktree.open", {
         cwd,
         ...locator,
-        focus,
+        focus: focus && state.navigationMode !== "browser-local",
       });
+      if (focus && browserSelectionIsCurrent(navigation))
+        adoptBrowserTarget(lease, result);
       const openedHook = result?.opened_hook as
         | WorktreeHookRunResult
         | undefined;
@@ -2802,6 +3035,11 @@ export const store = {
 
   focusPane(paneId: string) {
     const pane = state.panes.find((p) => p.pane_id === paneId);
+    if (state.navigationMode === "browser-local") {
+      return pane
+        ? navigateBrowser(pane.workspace_id, pane.tab_id, paneId)
+        : Promise.resolve();
+    }
     const pendingFocusSeq = pane?.workspace_id
       ? stampPendingFocusWorkspace(pane.workspace_id)
       : undefined;
@@ -2823,15 +3061,19 @@ export const store = {
   },
 
   splitPane(paneId: string, direction: "right" | "down") {
+    const navigation = state.browserNavigation;
     return action(async (lease) => {
       const result = await lease.client.call("pane.split", {
         target_pane_id: paneId,
         direction,
-        focus: true,
+        focus: state.navigationMode !== "browser-local",
       });
+      const selectionIsCurrent = browserSelectionIsCurrent(navigation);
+      if (selectionIsCurrent) adoptBrowserTarget(lease, result);
       const nextPaneId =
         typeof result?.pane?.pane_id === "string" ? result.pane.pane_id : null;
-      if (nextPaneId) setForConnection(lease, { selectedPaneId: nextPaneId });
+      if (nextPaneId && selectionIsCurrent)
+        setForConnection(lease, { selectedPaneId: nextPaneId });
       return result;
     });
   },
@@ -2854,7 +3096,13 @@ export const store = {
         amount,
       });
       const layout = result?.resize?.layout;
-      if (layout) setForConnection(lease, { layout });
+      if (layout && state.layout?.tab_id === layout.tab_id)
+        setForConnection(lease, {
+          layout:
+            state.navigationMode === "browser-local"
+              ? projectBrowserLayout(layout, state.selectedPaneId)
+              : layout,
+        });
       return result;
     });
   },
@@ -2863,6 +3111,10 @@ export const store = {
     paneId: string,
     direction: "left" | "right" | "up" | "down",
   ) {
+    if (state.navigationMode === "browser-local") {
+      const target = browserPaneInDirection(state.layout, paneId, direction);
+      return target ? store.focusPane(target) : Promise.resolve();
+    }
     return action(async (lease) => {
       const result = await lease.client.call("pane.focus_direction", {
         pane_id: paneId,

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -1864,6 +1864,7 @@ function browserSelectionIsCurrent(navigation: BrowserNavigation) {
   const workspaceId = navigation.workspaceId;
   const tabId = workspaceId ? navigation.tabIds[workspaceId] : undefined;
   return (
+    current.revision === navigation.revision &&
     current.workspaceId === workspaceId &&
     (!workspaceId || current.tabIds[workspaceId] === tabId) &&
     (!tabId || current.paneIds[tabId] === navigation.paneIds[tabId])

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -207,6 +207,8 @@ export interface GitDiffFile {
 // Raw list responses
 export interface WorkspaceList {
   type: "workspace_list";
+  /** Studio bridge metadata, absent on older bridges (shared navigation). */
+  navigation_mode?: "browser-local" | "shared";
   workspaces: Workspace[];
 }
 export interface TabList {


### PR DESCRIPTION
## Summary

Closes #110.

- Keep browser workspace/tab navigation per connection/runtime instead of writing shared control focus or re-adopting it on refresh. Reconcile reconnects and closed/moved targets; preserve explicit terminal input targeting and label legacy/shared fallback.
- Preserve Herdr's configured creation cwd policy through the existing attached endpoint, without extra focus calls or an ephemeral clipboard recipient. Validate source identity, force `focus:false`, and ignore late selection adoption after newer navigation.
- Restore true-empty-session bootstrap through server-validated, serialized control creation. Bound creation admission/readiness/queue time and never dispatch expired queued mutations.
- Wait for terminal attachment readiness and revalidate session/attachment/routing identity before forwarding early input, fixing silent input loss during fallback.

## Verification

- `bun run precommit`: **1168 passed, 1 existing optional live-SSH skip, 0 failed**; formatting, lint and frontend/server typechecks passed.
- Focused corrective suite: **83 passed**. All three review findings reproduced before fixes and passed afterward.
- `bun run build:web`: passed; asset budget 118/160 files, 9.5/12 MiB.
- Changed-file primary LSP checks and `git diff --check` passed. Final wording-only changelog clarification followed by `bun run format:check` passed.
- Genuine native Herdr 0.9.0 TUI plus two separate Chromium contexts: independent navigation/input, reconnect and closed-tab immediate input passed. The fallback test sent input before attach ACK and confirmed delivery without adding a harness wait.
- **24 real cwd assertions** covered follow/home/current/fixed-path and explicit overrides across both browsers. Native/browser workspace/tab selections remained unchanged.
- Corrective real-browser smoke bootstrapped an actually empty session through Studio UI, preserving home policy and immediate input; held a real split response while the browser navigated elsewhere and confirmed it did not steal selection/input. No shared browser workspace/tab/pane focus RPCs appeared in smoke logs.
- Independent review and targeted re-review: **OK with notes**, all findings resolved.

## Boundaries

Workspace/tab navigation is independent; Herdr's same-tab pane focus (including the pane used for `follow` cwd), topology and terminal sizing remain shared. The #109 foreground-recipient clipboard contract is unchanged.

Local selection survives reconnect, not page reload or connection-runtime replacement. Nonempty-session creation needs a valid source terminal attached to the requesting browser; missing/offscreen-unattached/stale sources fail visibly. Empty sessions can create their first workspace from Studio. A dispatched creation timeout warns it may have succeeded; mutations are never silently retried.

Bootstrap serialization is per Studio connection runtime, not an atomic upstream transaction against independent native/separate-runtime mutations. Live SSH remains unrun; queue-expiry and worktree-delay scenarios have deterministic tests, while actual split-delay handling was exercised live. Disposable test processes were cleaned up without changing user sessions, clipboard or services.

See FEATURES.md, docs/DEPLOYMENT.md and docs/ARCHITECTURE.md for behavior and design details.
