### PR TITLE
Gate endpoint actions on negotiated capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 ### Fixed
 
+- Respect each endpoint's advertised methods: disable unsupported creation and
+  history scrolling with a reason, while keeping supported terminal actions
+  usable. Missing required pane focus fails safely without legacy takeover.
+
 - Keep workspace and tab navigation local to each browser on Herdr 0.9.0
   endpoints, including reconnect and closed-pane fallback. Legacy navigation,
   native same-tab pane focus, topology and terminal sizes remain shared.

--- a/docs/endpoint-availability.md
+++ b/docs/endpoint-availability.md
@@ -1,0 +1,32 @@
+# Endpoint action availability
+
+For Herdr 0.9.0, Studio retains the methods and capabilities from each terminal
+socket's `endpoint.welcome.v1`. Advertisements are not shared across terminals
+or connection runtimes. Reattachment negotiates again; browser reconnect and
+connection switches clear cached availability until it is refreshed.
+
+- `pane.focus` is required to attach a cropped terminal safely. If absent,
+  attachment fails explicitly; Studio does not switch to legacy takeover.
+- `pane.scroll` gates terminal history scrolling. Application mouse wheels still
+  use semantic input, so a server without history scrolling can retain mouse,
+  keyboard, paste, resize, and rendering support.
+- `tab.create` and `workspace.create` are checked on the existing source terminal
+  before creation. Controls show a missing-method reason, or a loading reason
+  when that source has not negotiated. An empty session still uses the existing
+  serialized, validated control-API bootstrap; it opens no temporary endpoint.
+
+The bridge returns advertisements in terminal attach replies and in the
+connection-scoped `workspace.list` metadata. Every endpoint method is checked
+again at the socket dispatch boundary. Other operations using Herdr's control
+API are not restricted by the endpoint method list. Browser-local workspace/tab
+navigation, shared same-tab focus, cwd policy, topology, dimensions, and
+foreground-recipient clipboard behavior are unchanged.
+
+Only `health_check` enables optional endpoint ping/pong. `surface_interest` and
+`presentation_effects_fence` are retained but do not enable new behavior: Studio
+does not issue `client_shell.surface.set` or presentation fencing controls.
+These meanings follow tagged Herdr 0.9.0 `src/protocol/endpoint.rs` and
+`src/client/endpoint/registry.rs`. Input and resize are core codec operations,
+not advertised methods. Unknown capability names cannot enable unknown binary
+generations or codecs: Studio requires generation 1 and its four exact codecs,
+in addition to the existing private-protocol allowlist.

--- a/server/src/bridge/endpoint-client.test.ts
+++ b/server/src/bridge/endpoint-client.test.ts
@@ -162,6 +162,7 @@ async function startEndpointServer(
   onHello: (hello: any, socket: net.Socket) => void,
   onMessage?: (variant: number, reader: BinReader, socket: net.Socket) => void,
   sendSnapshot = true,
+  welcome: Record<string, unknown> = WELCOME,
 ) {
   const socketPath = path.join(
     tmpdir(),
@@ -191,7 +192,7 @@ async function startEndpointServer(
           expect(reader.remaining).toBe(0);
           socket.write(
             encodeFrame(
-              controlFrame("endpoint.welcome.v1", JSON.stringify(WELCOME)),
+              controlFrame("endpoint.welcome.v1", JSON.stringify(welcome)),
             ),
           );
           if (sendSnapshot) {
@@ -571,4 +572,78 @@ describe("EndpointClient (endpoint generation 1)", () => {
       "unsupported_generation",
     );
   });
+});
+
+test("method subset and absent health capability never send unsupported bytes", async () => {
+  const received: number[] = [];
+  const socketPath = await startEndpointServer(
+    () => {},
+    (variant, _reader, socket) => {
+      received.push(variant);
+      // Resize acts as an ordered wire fence after the rejected operations.
+      if (variant === 12) socket.end();
+    },
+    true,
+    { ...WELCOME, methods: [], capabilities: [] },
+  );
+  const client = new EndpointClient(socketPath);
+  client.on("error", () => {});
+  try {
+    expect(client.negotiation).toBeNull();
+    await client.connect(80, 24);
+    expect(client.negotiation?.methods).toEqual([]);
+    await expect(client.callEndpoint("pane.focus", {})).rejects.toThrow(
+      "does not advertise pane.focus",
+    );
+    client.ping();
+    const closed = new Promise<void>((resolve) =>
+      client.once("close", resolve),
+    );
+    client.resize(80, 24);
+    await closed;
+    expect(received).toEqual([12]);
+    expect(client.negotiation).toBeNull();
+  } finally {
+    client.close();
+  }
+});
+
+for (const invalid of [
+  { generation: 2 },
+  { snapshot_codec: "shell.snapshot.v2" },
+  { surface_codec: "shell.surface.v2" },
+  { input_codec: "shell.input.raw.v2" },
+  { blob_codec: "shell.blob.v2" },
+  { methods: "pane.focus" },
+  { capabilities: [123] },
+]) {
+  test(`rejects unverified negotiation ${JSON.stringify(invalid)}`, async () => {
+    const received: number[] = [];
+    const socketPath = await startEndpointServer(
+      () => {},
+      (variant) => {
+        received.push(variant);
+      },
+      true,
+      { ...WELCOME, ...invalid },
+    );
+    const client = new EndpointClient(socketPath);
+    client.on("error", () => {});
+    try {
+      await expect(client.connect(80, 24)).rejects.toThrow();
+      expect(client.negotiation).toBeNull();
+      expect(received).toEqual([]);
+    } finally {
+      client.close();
+    }
+  });
+}
+
+test("core resize and semantic input wait for verified codecs", () => {
+  const client = new EndpointClient("/unused-issue111.sock");
+  expect(() => client.resize(80, 24)).toThrow("not been negotiated");
+  expect(() =>
+    client.sendPaneInput("p1", [{ type: "paste", text: "blocked" }]),
+  ).toThrow("not been negotiated");
+  client.close();
 });

--- a/server/src/bridge/endpoint-client.ts
+++ b/server/src/bridge/endpoint-client.ts
@@ -96,6 +96,7 @@ export class EndpointClient extends EventEmitter {
   private buf = Buffer.alloc(0);
   private closed = false;
   private welcomed = false;
+  private welcome: EndpointWelcome | null = null;
   private pendingWelcome:
     | {
         resolve: () => void;
@@ -126,6 +127,25 @@ export class EndpointClient extends EventEmitter {
   /** Latest composed surface, for consumers that join mid-stream. */
   get currentSurface(): EndpointSurface | null {
     return this.surface;
+  }
+
+  /** Advertisement belongs to this socket only, never a server-wide cache. */
+  get negotiation(): EndpointWelcome | null {
+    return this.closed || !this.welcome
+      ? null
+      : {
+          ...this.welcome,
+          methods: [...this.welcome.methods],
+          capabilities: [...this.welcome.capabilities],
+        };
+  }
+
+  assertMethod(method: string): void {
+    if (this.closed) throw new Error("endpoint client closed");
+    if (!this.welcome)
+      throw new Error("Herdr endpoint availability is still loading");
+    if (!this.welcome.methods.includes(method))
+      throw new Error(`Herdr endpoint does not advertise ${method}`);
   }
 
   async connect(cols: number, rows: number): Promise<void> {
@@ -185,7 +205,14 @@ export class EndpointClient extends EventEmitter {
     this.write(w.toBuffer());
   }
 
+  private assertNegotiatedCodecs() {
+    if (this.closed) throw new Error("endpoint client closed");
+    if (!this.welcome)
+      throw new Error("Herdr endpoint codecs have not been negotiated");
+  }
+
   resize(cols: number, rows: number) {
+    this.assertNegotiatedCodecs();
     const w = new BinWriter();
     w.variant(CM.ClientShellResize);
     w.varint(0); // cell_width_px
@@ -198,12 +225,14 @@ export class EndpointClient extends EventEmitter {
 
   /** Probe the server; any inbound message (pong or otherwise) is liveness. */
   ping() {
-    this.sendControl(HEALTH_PING_KIND, "{}");
+    if (this.welcome?.capabilities.includes("health_check"))
+      this.sendControl(HEALTH_PING_KIND, "{}");
   }
 
   /** Deliver classified semantic input to one pane. */
   sendPaneInput(paneId: string, events: PaneInputEvent[]) {
     if (events.length === 0) return;
+    this.assertNegotiatedCodecs();
     this.write(encodePaneInput(paneId, events));
   }
 
@@ -217,6 +246,11 @@ export class EndpointClient extends EventEmitter {
     }
     if (!this.bootId) {
       return Promise.reject(new Error("endpoint snapshot has not arrived yet"));
+    }
+    try {
+      this.assertMethod(method);
+    } catch (error) {
+      return Promise.reject(error);
     }
     const requestId = `gui_${++this.requestSeq}`;
     const w = new BinWriter();
@@ -366,12 +400,30 @@ export class EndpointClient extends EventEmitter {
         this.emit("error", error);
         return;
       }
+      if (
+        parsed.generation !== ENDPOINT_GENERATION ||
+        parsed.snapshot_codec !== "shell.snapshot.v1" ||
+        parsed.surface_codec !== "shell.surface.v1" ||
+        parsed.input_codec !== "shell.input.semantic.v1" ||
+        parsed.blob_codec !== "shell.blob.v1"
+      ) {
+        throw new Error("Unsupported Herdr endpoint generation or codecs");
+      }
+      for (const field of ["methods", "capabilities"]) {
+        if (
+          parsed[field] !== undefined &&
+          (!Array.isArray(parsed[field]) ||
+            parsed[field].some((v: unknown) => typeof v !== "string"))
+        )
+          throw new Error(`Malformed Herdr endpoint ${field}`);
+      }
       const welcome: EndpointWelcome = {
         generation: parsed.generation,
         serverVersion: parsed.server_version,
         methods: parsed.methods ?? [],
         capabilities: parsed.capabilities ?? [],
       };
+      this.welcome = welcome;
       this.welcomed = true;
       this.emit("welcome", welcome);
       this.resolveWelcome();
@@ -394,7 +446,8 @@ export class EndpointClient extends EventEmitter {
       return;
     }
     if (kind === HEALTH_PING_KIND) {
-      this.sendControl(HEALTH_PONG_KIND, data);
+      if (this.welcome?.capabilities.includes("health_check"))
+        this.sendControl(HEALTH_PONG_KIND, data);
       return;
     }
     // Unknown named controls are optional and ignored per the contract.

--- a/server/src/bridge/endpoint-terminal-session.test.ts
+++ b/server/src/bridge/endpoint-terminal-session.test.ts
@@ -143,7 +143,8 @@ const WELCOME = {
  */
 async function startSessionServer(handlers: {
   onRequest?: (method: string, params: any, connection: number) => unknown;
-  methods?: string[];
+  methods?: string[] | ((connection: number) => string[]);
+  capabilities?: (connection: number) => string[];
   onPaneInput?: (paneId: string, reader: BinReader) => void;
   panes?: TestPane[];
   onConnection?: (sendSurface: (panes: TestPane[]) => void) => void;
@@ -202,7 +203,12 @@ async function startSessionServer(handlers: {
                 "endpoint.welcome.v1",
                 JSON.stringify({
                   ...WELCOME,
-                  methods: handlers.methods ?? WELCOME.methods,
+                  capabilities:
+                    handlers.capabilities?.(connection) ?? WELCOME.capabilities,
+                  methods:
+                    typeof handlers.methods === "function"
+                      ? handlers.methods(connection)
+                      : (handlers.methods ?? WELCOME.methods),
                 }),
               ),
             ),
@@ -1052,7 +1058,7 @@ describe("attached endpoint creation and input readiness", () => {
   });
 
   test("missing method advertisements and create rejection fail explicitly without control fallback", async () => {
-    for (const methods of [["pane.focus"], ["tab.create"], creationMethods]) {
+    for (const methods of [["pane.focus"], creationMethods]) {
       const requests: string[] = [];
       const socketPath = await startSessionServer({
         methods,
@@ -1614,3 +1620,131 @@ for (const invalidate of [
     }
   });
 }
+
+test("required pane.focus absent fails attach explicitly without legacy takeover", async () => {
+  const requests: string[] = [];
+  let lookups = 0;
+  const socketPath = await startSessionServer({
+    methods: [],
+    onRequest: (method) => {
+      requests.push(method);
+    },
+  });
+  const { bridge, replies, attach } = creationBridge(socketPath, {
+    lookup: async () => {
+      lookups++;
+      return "w1:p1";
+    },
+  });
+  try {
+    await attach();
+    expect(replies.find((r) => r.id === "attach").error.message).toContain(
+      "does not advertise pane.focus",
+    );
+    expect(requests).toEqual([]);
+    expect(lookups).toBe(0);
+    expect(bridge.statusTerminals()).toEqual([]);
+    expect(await bridge.navigationMode()).toBe("browser-local");
+  } finally {
+    bridge.dispose();
+  }
+});
+
+test("backend dispatch keeps subset input/create usable and rejects unsupported history before sending", async () => {
+  const requests: string[] = [];
+  const inputs: string[] = [];
+  const socketPath = await startSessionServer({
+    methods: ["pane.focus", "tab.create"],
+    onRequest: (method) => {
+      requests.push(method);
+    },
+    onPaneInput: (id) => {
+      inputs.push(id);
+    },
+  });
+  const { bridge, ws, replies, attach } = creationBridge(socketPath);
+  try {
+    await attach();
+    expect(
+      replies.find((r) => r.id === "attach").result.endpoint.methods,
+    ).toEqual(["pane.focus", "tab.create"]);
+    await bridge.handleTerminalRpc(ws, "scroll", "terminal.scroll", {
+      terminal_id: "term1",
+      direction: "up",
+      lines: 1,
+    });
+    expect(replies.find((r) => r.id === "scroll").error.message).toContain(
+      "pane.scroll",
+    );
+    await expect(
+      bridge.createFromTerminal(
+        ws,
+        "workspace.create",
+        { browser_source: creationSource },
+        () => true,
+      ),
+    ).rejects.toThrow("workspace.create");
+    await bridge.handleTerminalRpc(ws, "input", "terminal.input", {
+      terminal_id: "term1",
+      data: "WA==",
+    });
+    await bridge.createFromTerminal(
+      ws,
+      "tab.create",
+      { workspace_id: "w1", browser_source: creationSource },
+      () => true,
+    );
+    expect(inputs).toEqual(["w1:p1"]);
+    expect(requests).toEqual(["pane.focus", "tab.create"]);
+  } finally {
+    bridge.dispose();
+  }
+});
+
+test("reconnect replaces advertisements while other connection runtimes retain their own subset", async () => {
+  const socketPath = await startSessionServer({
+    methods: (connection) =>
+      connection === 1 ? creationMethods : ["pane.focus"],
+    capabilities: (connection) => (connection === 1 ? ["health_check"] : []),
+  });
+  const a = creationBridge(socketPath);
+  const b = creationBridge(socketPath);
+  try {
+    await a.attach();
+    await b.attach();
+    expect(a.bridge.endpointAvailability().term1?.capabilities).toEqual([
+      "health_check",
+    ]);
+    expect(b.bridge.endpointAvailability().term1?.capabilities).toEqual([]);
+    expect(a.bridge.endpointAvailability().term1?.methods).toEqual(
+      creationMethods,
+    );
+    expect(b.bridge.endpointAvailability().term1?.methods).toEqual([
+      "pane.focus",
+    ]);
+    await a.bridge.handleTerminalRpc(a.ws, "detach", "terminal.detach", {
+      terminal_id: "term1",
+    });
+    expect(a.bridge.endpointAvailability()).toEqual({});
+    await a.attach("reattach");
+    expect(a.bridge.endpointAvailability().term1?.capabilities).toEqual([]);
+    expect(b.bridge.endpointAvailability().term1?.capabilities).toEqual([]);
+    expect(a.bridge.endpointAvailability().term1?.methods).toEqual([
+      "pane.focus",
+    ]);
+    expect(b.bridge.endpointAvailability().term1?.methods).toEqual([
+      "pane.focus",
+    ]);
+    await expect(
+      a.bridge.createFromTerminal(
+        a.ws,
+        "tab.create",
+        { workspace_id: "w1", browser_source: creationSource },
+        () => true,
+      ),
+    ).rejects.toThrow("tab.create");
+  } finally {
+    a.bridge.dispose();
+    b.bridge.dispose();
+  }
+});

--- a/server/src/bridge/endpoint-terminal-session.ts
+++ b/server/src/bridge/endpoint-terminal-session.ts
@@ -33,7 +33,6 @@ export class EndpointTerminalSession extends EventEmitter {
   } | null = null;
   private closed = false;
   private seq = 0;
-  private advertisedMethods = new Set<string>();
   private commandChain: Promise<unknown> = Promise.resolve();
   connecting: Promise<void> | null = null;
 
@@ -56,9 +55,6 @@ export class EndpointTerminalSession extends EventEmitter {
       this.emit("close");
     });
     this.client.on("welcome", (w) => {
-      this.advertisedMethods = new Set(
-        Array.isArray(w.methods) ? w.methods : [],
-      );
       this.emit("welcome", {
         version: w.serverVersion,
         encoding: 1,
@@ -71,9 +67,14 @@ export class EndpointTerminalSession extends EventEmitter {
     return this.closed;
   }
 
+  get negotiation() {
+    return this.client.negotiation;
+  }
+
   connect(cols: number, rows: number): Promise<void> {
     const ready = (async () => {
       await this.client.connect(cols, rows);
+      this.client.assertMethod("pane.focus");
       const paneId = await this.lookupPaneId(this.terminalId);
       if (!paneId) {
         throw new Error(
@@ -153,10 +154,7 @@ export class EndpointTerminalSession extends EventEmitter {
             "Source terminal is not ready. Open its tab and retry creation.",
           );
         for (const requiredMethod of ["pane.focus", method]) {
-          if (!this.advertisedMethods.has(requiredMethod))
-            throw new Error(
-              `Herdr endpoint does not advertise ${requiredMethod}`,
-            );
+          this.client.assertMethod(requiredMethod);
         }
         await validateSource();
         if (!ready())
@@ -318,6 +316,7 @@ export class EndpointTerminalSession extends EventEmitter {
       ]);
       return;
     }
+    this.client.assertMethod("pane.scroll");
     if (!this.lastScroll) return;
     const delta = direction === "up" ? lines : -lines;
     const offset = Math.max(

--- a/server/src/bridge/terminal-bridge.ts
+++ b/server/src/bridge/terminal-bridge.ts
@@ -884,7 +884,12 @@ export function createTerminalBridge(args: {
           size: `${cols}x${rows}`,
           shared: sharedMode,
         });
-        return reply({ ok: true });
+        return reply({
+          ok: true,
+          ...(shared.thin instanceof EndpointTerminalSession
+            ? { endpoint: shared.thin.negotiation }
+            : {}),
+        });
       }
 
       if (method === "terminal.relay_resize") {
@@ -1021,6 +1026,17 @@ export function createTerminalBridge(args: {
     return Array.from(terminalViewers.get(ws) ?? []);
   }
 
+  function endpointAvailability() {
+    return Object.fromEntries(
+      Array.from(sharedTerminals, ([id, session]) => [
+        id,
+        session.thin instanceof EndpointTerminalSession
+          ? session.thin.negotiation
+          : null,
+      ]),
+    );
+  }
+
   function statusTerminals() {
     return Array.from(sharedTerminals.values()).map((session) => ({
       terminal_id: session.terminalId,
@@ -1043,6 +1059,7 @@ export function createTerminalBridge(args: {
   return {
     createFromTerminal,
     navigationMode,
+    endpointAvailability,
     handleTerminalRpc,
     cleanupWs,
     viewedTerminals,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1062,6 +1062,7 @@ async function handleRpc(ws: ServerWebSocket<unknown>, raw: string) {
       result = {
         ...result,
         navigation_mode: await terminalBridge.navigationMode(),
+        endpoint_availability: terminalBridge.endpointAvailability(),
       };
     }
     sendReply({ id, result }, method);

--- a/web/src/browserNavigation.test.ts
+++ b/web/src/browserNavigation.test.ts
@@ -7,6 +7,7 @@ import {
   selectBrowserTarget,
 } from "./browserNavigation";
 import type { Pane, PaneLayout, Tab, Workspace } from "./types";
+import type { EndpointAvailability } from "./endpointAvailability";
 
 function navigationTopology() {
   const workspaces: Workspace[] = ["a", "b"].map((id, i) => ({
@@ -167,6 +168,7 @@ import {
   __storeTesting,
   activateConnectionState,
   emptyServerSessionState,
+  endpointCreationReason,
   store,
   type State,
 } from "./store";
@@ -176,6 +178,20 @@ function browserState(): State {
   const session = {
     ...emptyServerSessionState(1),
     navigationMode: "browser-local" as const,
+    endpointAvailability: Object.fromEntries(
+      topology.panes.map((pane) => [
+        pane.terminal_id,
+        {
+          methods: [
+            "pane.focus",
+            "pane.scroll",
+            "tab.create",
+            "workspace.create",
+          ],
+          capabilities: [],
+        },
+      ]),
+    ),
     ...projectBrowserNavigation(
       emptyBrowserNavigation(),
       topology.workspaces,
@@ -212,6 +228,7 @@ async function withBrowserStore(
     topology: ReturnType<typeof navigationTopology>,
     control: {
       mode: string;
+      endpointAvailability?: EndpointAvailability;
       layoutWait?: Promise<void>;
       createWait?: Promise<void>;
       actionWait?: (method: string) => Promise<void>;
@@ -224,6 +241,7 @@ async function withBrowserStore(
   const calls: Array<{ method: string; params: Record<string, unknown> }> = [];
   const control: {
     mode: string;
+    endpointAvailability?: EndpointAvailability;
     layoutWait?: Promise<void>;
     createWait?: Promise<void>;
     actionWait?: (method: string) => Promise<void>;
@@ -244,6 +262,22 @@ async function withBrowserStore(
           return {
             workspaces: topology.workspaces,
             navigation_mode: control.mode,
+            endpoint_availability:
+              control.endpointAvailability ??
+              Object.fromEntries(
+                topology.panes.map((pane) => [
+                  pane.terminal_id,
+                  {
+                    methods: [
+                      "pane.focus",
+                      "tab.create",
+                      "workspace.create",
+                      "pane.scroll",
+                    ],
+                    capabilities: [],
+                  },
+                ]),
+              ),
           };
         if (method === "tab.list") return { tabs: topology.tabs };
         if (method === "pane.list") return { panes: topology.panes };
@@ -857,3 +891,185 @@ test("shared fallback retains shared focus, creation and split selection semanti
     expect(store.get().browserNavigation.revision).toBe(revision);
   });
 });
+
+test("frontend dispatch and availability track each terminal subset and refresh without borrowing another connection", async () => {
+  await withBrowserStore(async (calls) => {
+    const initial = store.get();
+    __storeTesting.replaceState({
+      ...initial,
+      endpointAvailability: {
+        "a1p-terminal": {
+          methods: ["pane.focus", "tab.create"],
+          capabilities: [],
+        },
+        "b1p-terminal": { methods: [], capabilities: [] },
+      },
+    });
+    expect(endpointCreationReason(store.get(), "tab.create", "a")).toBeNull();
+    expect(endpointCreationReason(store.get(), "workspace.create")).toContain(
+      "workspace.create",
+    );
+    expect(endpointCreationReason(store.get(), "tab.create", "b")).toContain(
+      "pane.focus",
+    );
+    const advertisementBeforeStaleReply = store.get().endpointAvailability;
+    store.setTerminalEndpoint(
+      { ...bridge.connection(), isCurrent: () => false },
+      "a1p-terminal",
+      { methods: ["pane.scroll"], capabilities: [] },
+    );
+    expect(store.get().endpointAvailability).toBe(
+      advertisementBeforeStaleReply,
+    );
+    expect(store.terminalScrollReason("a1p-terminal")).toContain("pane.scroll");
+    expect(store.terminalScrollReason("a1p-terminal", true)).toBeNull();
+    await store.createWorkspace("blocked");
+    await store.createTab("b");
+    expect(calls.some((call) => call.method.endsWith(".create"))).toBe(false);
+    await store.createTab("a");
+    expect(calls.filter((call) => call.method === "tab.create")).toHaveLength(
+      1,
+    );
+    const switched = activateConnectionState(store.get(), "other", 2);
+    expect(switched.endpointAvailability).toEqual({});
+    expect(
+      activateConnectionState(switched, "test", 3).endpointAvailability,
+    ).toEqual({});
+    __storeTesting.replaceState({ ...initial, endpointAvailability: {} });
+    expect(endpointCreationReason(store.get(), "tab.create", "a")).toContain(
+      "loading",
+    );
+    await store.refresh();
+    expect(endpointCreationReason(store.get(), "tab.create", "a")).toBeNull();
+  });
+});
+
+for (const transition of [
+  "complete-to-reduced",
+  "empty-to-attached",
+  "close-to-unknown",
+] as const) {
+  test.each(["pane.layout", "workspace.list"])(
+    `delayed %s preserves newer endpoint availability: ${transition}`,
+    async (updateDuring) => {
+      await withBrowserStore(async (calls, topology, control) => {
+        const terminalId = "a1p-terminal";
+        const complete = {
+          methods: [
+            "pane.focus",
+            "pane.scroll",
+            "tab.create",
+            "workspace.create",
+          ],
+          capabilities: [],
+        };
+        const newer =
+          transition === "close-to-unknown"
+            ? null
+            : transition === "complete-to-reduced"
+              ? { methods: ["pane.focus"], capabilities: [] }
+              : complete;
+        control.endpointAvailability =
+          transition === "empty-to-attached" ? {} : { [terminalId]: complete };
+        __storeTesting.replaceState({
+          ...store.get(),
+          layout: null,
+          endpointAvailability: control.endpointAvailability,
+        });
+        const navigation = store.get().browserNavigation;
+        topology.workspaces[0] = {
+          ...topology.workspaces[0],
+          label: "fresh topology",
+        };
+        const listEntered = Promise.withResolvers<void>();
+        const listRelease = Promise.withResolvers<void>();
+        const entered = Promise.withResolvers<void>();
+        const release = Promise.withResolvers<void>();
+        const queuedEntered = Promise.withResolvers<void>();
+        const queuedRelease = Promise.withResolvers<void>();
+        let layoutCalls = 0;
+        control.actionWait = async (method) => {
+          if (
+            method === "workspace.list" &&
+            updateDuring === method &&
+            layoutCalls === 0
+          ) {
+            listEntered.resolve();
+            await listRelease.promise;
+          }
+          if (method !== "pane.layout") return;
+          if (++layoutCalls === 1) {
+            entered.resolve();
+            await release.promise;
+          } else {
+            queuedEntered.resolve();
+            await queuedRelease.promise;
+          }
+        };
+        const refreshed = Promise.withResolvers<void>();
+        const freshAdvertisement = {
+          methods: ["pane.focus", "tab.create"],
+          capabilities: ["health_check"],
+        };
+        const unsubscribe = store.subscribe(() => {
+          if (
+            store
+              .get()
+              .endpointAvailability[terminalId]?.capabilities.includes(
+                "health_check",
+              )
+          )
+            refreshed.resolve();
+        });
+        try {
+          const pending = store.refresh();
+          await (updateDuring === "workspace.list"
+            ? listEntered.promise
+            : entered.promise);
+          store.setTerminalEndpoint(bridge.connection(), terminalId, newer);
+          const updated = store.get().endpointAvailability;
+          listRelease.resolve();
+          await entered.promise;
+          // Only the queued refresh should see this next server observation.
+          control.endpointAvailability = { [terminalId]: freshAdvertisement };
+          release.resolve();
+          await pending;
+          expect(store.get().endpointAvailability).toBe(updated);
+          expect(store.get().browserNavigation.revision).toBe(
+            navigation.revision,
+          );
+          expect(store.get().selectedPaneId).toBe("a1p");
+          expect(store.get().layout?.tab_id).toBe("a1");
+          expect(store.get().workspaces[0].label).toBe("fresh topology");
+          expect(endpointCreationReason(store.get(), "tab.create", "a")).toBe(
+            newer === null
+              ? "Endpoint availability is loading. Open the source terminal and wait for it to connect."
+              : transition === "complete-to-reduced"
+                ? "Herdr endpoint does not advertise tab.create"
+                : null,
+          );
+          await queuedEntered.promise;
+          expect(
+            calls.filter((call) => call.method === "workspace.list"),
+          ).toHaveLength(2);
+          queuedRelease.resolve();
+          await refreshed.promise;
+          expect(store.get().endpointAvailability[terminalId]).toEqual(
+            freshAdvertisement,
+          );
+          expect(
+            endpointCreationReason(store.get(), "tab.create", "a"),
+          ).toBeNull();
+          expect(
+            calls.filter((call) => call.method === "workspace.list"),
+          ).toHaveLength(2);
+        } finally {
+          unsubscribe();
+          listRelease.resolve();
+          release.resolve();
+          queuedRelease.resolve();
+        }
+      });
+    },
+  );
+}

--- a/web/src/components/CommandCombobox.tsx
+++ b/web/src/components/CommandCombobox.tsx
@@ -1,3 +1,4 @@
+import { endpointCreationReason } from "../store";
 import { useEffect, useMemo, useState } from "react";
 import {
   ArrowDown,
@@ -58,6 +59,7 @@ type ActionDefinition = {
   shortcut?: string;
   keywords?: string[];
   danger?: boolean;
+  disabledReason?: string | null;
   run: () => void;
 };
 
@@ -248,6 +250,7 @@ export function CommandCombobox({
       selectedPaneId: state.selectedPaneId,
       tabs: state.tabs,
       workspaces: state.workspaces,
+      endpointAvailability: state.endpointAvailability,
     }),
     shallowEqual,
   );
@@ -521,6 +524,11 @@ export function CommandCombobox({
       title: "Create tab",
       detail: workspaceName(focusedWorkspace),
       keywords: ["new tab", "add tab", "open tab"],
+      disabledReason: endpointCreationReason(
+        store.get(),
+        "tab.create",
+        focusedWorkspace.workspace_id,
+      ),
       run: () => store.createTab(focusedWorkspace.workspace_id),
     });
   }
@@ -696,6 +704,11 @@ export function CommandCombobox({
       title: "Create tab",
       detail: workspaceName(focusedWorkspace),
       keywords: ["new tab", "add tab", "open tab"],
+      disabledReason: endpointCreationReason(
+        store.get(),
+        "tab.create",
+        focusedWorkspace.workspace_id,
+      ),
       run: () => store.createTab(focusedWorkspace.workspace_id),
     });
     for (const workspace of otherWorkspaces) {
@@ -705,6 +718,11 @@ export function CommandCombobox({
         title: `Create tab: ${workspaceName(workspace)}`,
         detail: workspace.workspace_id,
         keywords: ["new tab", "add tab", "open tab", workspaceName(workspace)],
+        disabledReason: endpointCreationReason(
+          store.get(),
+          "tab.create",
+          workspace.workspace_id,
+        ),
         run: () => store.createTab(workspace.workspace_id),
       });
     }
@@ -979,8 +997,10 @@ export function CommandCombobox({
           className="command-popover"
           align="end"
           onKeyDownCapture={(event) => {
-            runCommandNumberShortcut(event, numberedActions, (action) =>
-              run(action.run),
+            runCommandNumberShortcut(
+              event,
+              numberedActions,
+              (action) => !action.disabledReason && run(action.run),
             );
           }}
         >
@@ -1015,7 +1035,10 @@ export function CommandCombobox({
                       )}
                       keywords={action.keywords}
                       danger={action.danger}
-                      onSelect={() => run(action.run)}
+                      disabledReason={action.disabledReason}
+                      onSelect={() => {
+                        if (!action.disabledReason) run(action.run);
+                      }}
                     />
                   ))}
                 </CommandGroup>
@@ -1161,6 +1184,7 @@ function ActionItem({
   keywords,
   danger,
   onSelect,
+  disabledReason,
 }: {
   value: string;
   icon: React.ReactNode;
@@ -1171,12 +1195,15 @@ function ActionItem({
   keywords?: string[];
   danger?: boolean;
   onSelect: () => void;
+  disabledReason?: string | null;
 }) {
   const numberShortcut =
     numberShortcutIndex === undefined ? null : `⌥${numberShortcutIndex + 1}`;
   return (
     <CommandItem
       value={value}
+      disabled={!!disabledReason}
+      title={disabledReason ?? undefined}
       keywords={keywords}
       onSelect={onSelect}
       className={danger ? "is-danger" : undefined}
@@ -1189,7 +1216,11 @@ function ActionItem({
       <span className="command-item-icon">{icon}</span>
       <span className="command-item-text">
         <span className="command-item-title">{title}</span>
-        {detail ? <span className="command-item-detail">{detail}</span> : null}
+        {disabledReason || detail ? (
+          <span className="command-item-detail">
+            {disabledReason ?? detail}
+          </span>
+        ) : null}
       </span>
       {numberShortcut || shortcut ? (
         <CommandShortcut>{numberShortcut ?? shortcut}</CommandShortcut>

--- a/web/src/components/CreateWorkspaceDialog.tsx
+++ b/web/src/components/CreateWorkspaceDialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { luckyWorkspaceName } from "../luckyName";
-import { store } from "../store";
+import { store, useEndpointCreationReason } from "../store";
 import { CloseButton } from "./CloseButton";
 import { focusDialogElement } from "./dialogFocus";
 
@@ -11,6 +11,7 @@ export function CreateWorkspaceDialog({
   open: boolean;
   onClose: () => void;
 }) {
+  const createReason = useEndpointCreationReason("workspace.create");
   const [label, setLabel] = useState("");
   const [cwd, setCwd] = useState("");
   const labelRef = useRef<HTMLInputElement>(null);
@@ -37,6 +38,7 @@ export function CreateWorkspaceDialog({
 
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (createReason) return;
     store.createWorkspace(label.trim() || undefined, cwd.trim() || undefined);
     onClose();
   };
@@ -75,11 +77,18 @@ export function CreateWorkspaceDialog({
           />
         </label>
 
+        {createReason ? <p role="status">{createReason}</p> : null}
         <div className="modal-actions">
           <button type="button" className="ghost" onClick={onClose}>
             Cancel
           </button>
-          <button type="submit">Create</button>
+          <button
+            type="submit"
+            disabled={!!createReason}
+            title={createReason ?? undefined}
+          >
+            Create
+          </button>
         </div>
       </form>
     </div>

--- a/web/src/components/MobileTabSheet.tsx
+++ b/web/src/components/MobileTabSheet.tsx
@@ -1,7 +1,12 @@
 import { Plus, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { shallowEqual, store, useStoreSelector } from "../store";
+import {
+  shallowEqual,
+  store,
+  useStoreSelector,
+  useEndpointCreationReason,
+} from "../store";
 import { AgentStatusIcon } from "./AgentStatusIcon";
 import { summarizeTabAgents } from "./agentSession";
 import { CloseButton } from "./CloseButton";
@@ -55,6 +60,10 @@ export function MobileTabSheet({
   };
 
   const focusedWs = s.workspaces.find((w) => w.focused);
+  const createReason = useEndpointCreationReason(
+    "tab.create",
+    focusedWs?.workspace_id,
+  );
   const tabs = focusedWs
     ? s.tabs
         .filter((t) => t.workspace_id === focusedWs.workspace_id)
@@ -162,13 +171,14 @@ export function MobileTabSheet({
         <button
           type="button"
           className="mobile-tab-sheet-new"
-          disabled={transitionPending}
+          title={createReason ?? undefined}
+          disabled={transitionPending || !!createReason}
           onClick={() =>
             void runTabTransition(() => store.createTab(focusedWs.workspace_id))
           }
         >
           <Plus size={15} />
-          <span>New Tab</span>
+          <span>{createReason ?? "New Tab"}</span>
         </button>
       </div>
     </div>,

--- a/web/src/components/TabBar.tsx
+++ b/web/src/components/TabBar.tsx
@@ -1,4 +1,9 @@
-import { shallowEqual, store, useStoreSelector } from "../store";
+import {
+  shallowEqual,
+  store,
+  useStoreSelector,
+  useEndpointCreationReason,
+} from "../store";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { PanelRight } from "lucide-react";
@@ -80,6 +85,10 @@ export function TabBar({
   const [pendingRenameTab, setPendingRenameTab] = useState<Tab | null>(null);
   const [menu, setMenu] = useState<TabMenuState | null>(null);
   const focusedWs = s.workspaces.find((w) => w.focused);
+  const createReason = useEndpointCreationReason(
+    "tab.create",
+    focusedWs?.workspace_id,
+  );
   const tabs = s.tabs
     .filter((t) => t.workspace_id === focusedWs?.workspace_id)
     .sort((a, b) => a.number - b.number);
@@ -144,6 +153,7 @@ export function TabBar({
         }}
         onRename={(tab) => setPendingRenameTab(tab)}
         onCloseTab={(tab) => setPendingCloseTabId(tab.tab_id)}
+        createReason={createReason}
         onCreateTab={() => {
           store.createTab(focusedWs.workspace_id);
         }}
@@ -275,7 +285,8 @@ export function TabBar({
             onClick={() => {
               store.createTab(focusedWs.workspace_id);
             }}
-            title="New tab"
+            disabled={!!createReason}
+            title={createReason ?? "New tab"}
           >
             +
           </button>
@@ -374,6 +385,7 @@ function TabContextMenu({
   onRename,
   onCloseTab,
   onCreateTab,
+  createReason,
 }: {
   state: TabMenuState | null;
   onClose: () => void;
@@ -381,6 +393,7 @@ function TabContextMenu({
   onRename: (tab: Tab) => void;
   onCloseTab: (tab: Tab) => void;
   onCreateTab: () => void;
+  createReason: string | null;
 }) {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -411,7 +424,7 @@ function TabContextMenu({
   const items = [
     { label: "Focus tab", action: () => onFocus(state.tab) },
     { label: "Rename tab...", action: () => onRename(state.tab) },
-    { label: "Create tab", action: onCreateTab },
+    { label: "Create tab", action: onCreateTab, reason: createReason },
     {
       label: "Close tab",
       danger: true,
@@ -438,6 +451,8 @@ function TabContextMenu({
       {items.map((item) => (
         <button
           key={item.label}
+          disabled={!!item.reason}
+          title={item.reason ?? undefined}
           className={`context-menu-item ${item.danger ? "is-danger" : ""}`}
           onClick={() => {
             onClose();

--- a/web/src/components/TerminalComposer.tsx
+++ b/web/src/components/TerminalComposer.tsx
@@ -57,6 +57,7 @@ export function TerminalComposer({
   draftKey,
   shortcutRows,
   onRunShortcut,
+  shortcutDisabledReason,
   onClose,
   onSubmit,
   onUploadImage,
@@ -65,6 +66,7 @@ export function TerminalComposer({
   draftKey: string;
   shortcutRows: (MobileTerminalShortcut | null)[][];
   onRunShortcut: (shortcut: MobileTerminalShortcut) => void;
+  shortcutDisabledReason?: (shortcut: MobileTerminalShortcut) => string | null;
   onClose: () => void;
   onSubmit: (text: string, submit: boolean) => Promise<void>;
   onUploadImage: (file: File) => Promise<string>;
@@ -259,9 +261,14 @@ export function TerminalComposer({
                   return (
                     <button
                       type="button"
-                      title={option?.label ?? shortcut.label}
                       aria-label={`Send ${option?.label ?? shortcut.label}`}
                       onPointerDown={keepTextareaFocus}
+                      disabled={!!shortcutDisabledReason?.(shortcut)}
+                      title={
+                        shortcutDisabledReason?.(shortcut) ??
+                        option?.label ??
+                        shortcut.label
+                      }
                       onClick={() => onRunShortcut(shortcut)}
                       key={shortcut.id}
                     >

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -440,6 +440,7 @@ export function TerminalView({
       selectedPaneId: state.selectedPaneId,
       status: state.status,
       terminalAttachEpoch: state.terminalAttachEpoch,
+      endpointAvailability: state.endpointAvailability,
     }),
     shallowEqual,
   );
@@ -706,7 +707,8 @@ export function TerminalView({
       if (shouldAvoidVirtualKeyboard()) blurTerminalInput();
       const targetTerminalId =
         desiredTerminalRef.current ?? paneTerminalIdRef.current;
-      if (!targetTerminalId) return;
+      if (!targetTerminalId || store.terminalScrollReason(targetTerminalId))
+        return;
       connectionClient
         .call("terminal.scroll", {
           terminal_id: targetTerminalId,
@@ -935,6 +937,7 @@ export function TerminalView({
       ) {
         return;
       }
+      store.setTerminalEndpoint(connectionClient, closed.terminal_id, null);
       // Herdr closes the direct attach when another client takes the
       // terminal over (or its stream dies). Re-attach, but bound takeover
       // wars between two clients so they cannot evict each other forever.
@@ -1785,7 +1788,15 @@ export function TerminalView({
       }
       const scroll = terminalWheelScroll(e.deltaY, e.deltaMode, term.rows);
       const terminalId = desiredTerminalRef.current;
-      if (!scroll || !terminalId) return;
+      if (
+        !scroll ||
+        !terminalId ||
+        store.terminalScrollReason(
+          terminalId,
+          endpointPresentation.mouseReporting,
+        )
+      )
+        return;
       connectionClient
         .call("terminal.scroll", {
           terminal_id: terminalId,
@@ -1829,7 +1840,13 @@ export function TerminalView({
       if (lines !== 0) {
         touchRemainder -= lines * 24;
         const terminalId = desiredTerminalRef.current;
-        if (terminalId) {
+        if (
+          terminalId &&
+          !store.terminalScrollReason(
+            terminalId,
+            endpointPresentation.mouseReporting,
+          )
+        ) {
           connectionClient
             .call("terminal.scroll", {
               terminal_id: terminalId,
@@ -2051,6 +2068,7 @@ export function TerminalView({
       renderedTerminalRef.current = terminalId;
     }
     resizeSyncRef.current?.markAttached({ cols, rows });
+    store.setTerminalEndpoint(connectionClient, terminalId, null);
     const attachStartedAt = performance.now();
     connectionClient
       .call("terminal.attach", {
@@ -2063,8 +2081,14 @@ export function TerminalView({
           : {}),
       })
       .then(
-        () => {
+        (result) => {
           if (!connectionClient.isCurrent()) return;
+          if (desiredTerminalRef.current === terminalId)
+            store.setTerminalEndpoint(
+              connectionClient,
+              terminalId,
+              result?.endpoint,
+            );
           if (attachingRef.current === terminalId) attachingRef.current = null;
           if (desiredTerminalRef.current === terminalId) {
             attachedRef.current = terminalId;
@@ -2217,6 +2241,11 @@ export function TerminalView({
       detail: message,
     });
   };
+  const mobileShortcutReason = (shortcut: MobileTerminalShortcut) =>
+    mobileTerminalShortcutExecution(shortcut.action)?.type === "scroll" &&
+    pane?.terminal_id
+      ? store.terminalScrollReason(pane.terminal_id)
+      : null;
   const runMobileShortcut = (shortcut: MobileTerminalShortcut) => {
     const execution = mobileTerminalShortcutExecution(shortcut.action);
     if (!execution) return;
@@ -2288,7 +2317,12 @@ export function TerminalView({
                 return (
                   <button
                     type="button"
-                    title={option?.label ?? shortcut.label}
+                    disabled={!!mobileShortcutReason(shortcut)}
+                    title={
+                      mobileShortcutReason(shortcut) ??
+                      option?.label ??
+                      shortcut.label
+                    }
                     aria-label={`Run ${option?.label ?? shortcut.label}`}
                     onPointerDown={preventShortcutFocus}
                     onClick={() => runMobileShortcut(shortcut)}
@@ -2352,7 +2386,12 @@ export function TerminalView({
                       return (
                         <button
                           type="button"
-                          title={option?.label ?? shortcut.label}
+                          disabled={!!mobileShortcutReason(shortcut)}
+                          title={
+                            mobileShortcutReason(shortcut) ??
+                            option?.label ??
+                            shortcut.label
+                          }
                           aria-label={`Send ${option?.label ?? shortcut.label}`}
                           onPointerDown={preventShortcutFocus}
                           onClick={() => runMobileShortcut(shortcut)}
@@ -2373,6 +2412,7 @@ export function TerminalView({
             draftKey={composerDraftKey}
             shortcutRows={mobileShortcuts}
             onRunShortcut={runMobileShortcut}
+            shortcutDisabledReason={mobileShortcutReason}
             onClose={() => setComposerOpen(false)}
             onSubmit={submitTerminalComposer}
             onUploadImage={uploadComposerImage}
@@ -2380,6 +2420,16 @@ export function TerminalView({
           />
         ) : null}
         <div className="terminal-pane-toolbar" aria-label="Pane actions">
+          {s.endpointAvailability[pane.terminal_id] &&
+          store.terminalScrollReason(pane.terminal_id) ? (
+            <span
+              className="muted"
+              role="status"
+              title={store.terminalScrollReason(pane.terminal_id) ?? undefined}
+            >
+              History unavailable: pane.scroll not advertised
+            </span>
+          ) : null}
           <button
             type="button"
             className="terminal-pane-action"

--- a/web/src/endpointAvailability.test.ts
+++ b/web/src/endpointAvailability.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test";
+import {
+  endpointMethodReason,
+  parseEndpointAdvertisement,
+  parseEndpointAvailability,
+} from "./endpointAvailability";
+
+test("unknown/loading is distinct from a known empty advertisement", () => {
+  expect(endpointMethodReason("browser-local", null, "tab.create")).toContain(
+    "loading",
+  );
+  const empty = parseEndpointAdvertisement({ methods: [], capabilities: [] });
+  expect(empty).toEqual({ methods: [], capabilities: [] });
+  expect(endpointMethodReason("browser-local", empty, "tab.create")).toBe(
+    "Herdr endpoint does not advertise tab.create",
+  );
+  expect(
+    parseEndpointAdvertisement({ methods: [42], capabilities: [] }),
+  ).toBeNull();
+  expect(parseEndpointAvailability({ t: null })).toEqual({ t: null });
+});
+
+test("subsets leave supported operations enabled; capabilities do not invent method support", () => {
+  const subset = {
+    methods: ["pane.focus", "tab.create"],
+    capabilities: ["health_check", "future_feature"],
+  };
+  expect(
+    endpointMethodReason("browser-local", subset, "tab.create"),
+  ).toBeNull();
+  expect(
+    endpointMethodReason("browser-local", subset, "workspace.create"),
+  ).toContain("workspace.create");
+  expect(
+    endpointMethodReason("browser-local", subset, "pane.scroll"),
+  ).toContain("pane.scroll");
+  expect(endpointMethodReason("shared", null, "tab.create")).toBeNull();
+});

--- a/web/src/endpointAvailability.ts
+++ b/web/src/endpointAvailability.ts
@@ -1,0 +1,50 @@
+export interface EndpointAdvertisement {
+  methods: string[];
+  capabilities: string[];
+}
+
+export type EndpointAvailability = Record<string, EndpointAdvertisement | null>;
+
+export function parseEndpointAdvertisement(
+  value: unknown,
+): EndpointAdvertisement | null {
+  if (!value || typeof value !== "object") return null;
+  const advertisement = value as EndpointAdvertisement;
+  if (
+    ![advertisement.methods, advertisement.capabilities].every(
+      (values) =>
+        Array.isArray(values) &&
+        values.every((value) => typeof value === "string"),
+    )
+  )
+    return null;
+  return {
+    methods: [...advertisement.methods],
+    capabilities: [...advertisement.capabilities],
+  };
+}
+
+export function parseEndpointAvailability(
+  value: unknown,
+): EndpointAvailability {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).map(([id, advertisement]) => [
+      id,
+      parseEndpointAdvertisement(advertisement),
+    ]),
+  );
+}
+
+export function endpointMethodReason(
+  mode: "browser-local" | "shared",
+  advertisement: EndpointAdvertisement | null | undefined,
+  method: string,
+): string | null {
+  if (mode === "shared") return null;
+  if (!advertisement)
+    return "Endpoint availability is loading. Open the source terminal and wait for it to connect.";
+  return advertisement.methods.includes(method)
+    ? null
+    : `Herdr endpoint does not advertise ${method}`;
+}

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -1,4 +1,10 @@
 import {
+  type EndpointAvailability,
+  parseEndpointAdvertisement,
+  parseEndpointAvailability,
+  endpointMethodReason,
+} from "./endpointAvailability";
+import {
   type BrowserNavigation,
   emptyBrowserNavigation,
   selectBrowserTarget,
@@ -41,6 +47,7 @@ export interface ServerSessionState {
   /** ConnectionManager generation that owns every server resource below. */
   serverRuntimeGeneration: number | null;
   navigationMode: "browser-local" | "shared";
+  endpointAvailability: EndpointAvailability;
   browserNavigation: BrowserNavigation;
   workspaces: Workspace[];
   tabs: Tab[];
@@ -154,6 +161,7 @@ export function emptyServerSessionState(
   return {
     serverRuntimeGeneration,
     navigationMode: "shared",
+    endpointAvailability: {},
     browserNavigation: emptyBrowserNavigation(),
     workspaces: [],
     tabs: [],
@@ -335,6 +343,7 @@ const initial: State = {
 const SERVER_SESSION_KEYS: Array<keyof ServerSessionState> = [
   "serverRuntimeGeneration",
   "navigationMode",
+  "endpointAvailability",
   "browserNavigation",
   "workspaces",
   "tabs",
@@ -354,6 +363,7 @@ function serverSessionFromState(snapshot: State): ServerSessionState {
   return {
     serverRuntimeGeneration: snapshot.serverRuntimeGeneration,
     navigationMode: snapshot.navigationMode,
+    endpointAvailability: snapshot.endpointAvailability,
     browserNavigation: snapshot.browserNavigation,
     workspaces: snapshot.workspaces,
     tabs: snapshot.tabs,
@@ -397,6 +407,7 @@ export function activateConnectionState(
       : emptyServerSessionState(runtimeGeneration);
   const newSession = {
     ...restored,
+    endpointAvailability: {},
     // A restored pending focus outlived its action, so treat it as settled:
     // the next fresh observation decides whether it still applies. Reuse the
     // snapshot timestamp as a stable non-null token; wall-clock time is unused.
@@ -983,6 +994,7 @@ const REFRESH_SLICE_KEYS = [
   "panes",
   "layout",
   "browserNavigation",
+  "endpointAvailability",
 ] as const;
 const REFRESH_SCALAR_KEYS = [
   "navigationMode",
@@ -1089,6 +1101,7 @@ async function refreshNow(lease = captureConnectionLease()) {
   // refresh that began after the focus action settled may declare the focus
   // lost, and only while the marker still belongs to that same attempt.
   const navigationAtEntry = state.browserNavigation;
+  const endpointAvailabilityAtEntry = state.endpointAvailability;
   const pendingFocusAtEntry = {
     seq: state.pendingFocusWorkspaceSeq,
     settledAt: state.pendingFocusWorkspaceSettledAt,
@@ -1114,6 +1127,9 @@ async function refreshNow(lease = captureConnectionLease()) {
       wsRes?.navigation_mode === "browser-local" ? "browser-local" : "shared";
     const next: Partial<State> = {
       navigationMode,
+      endpointAvailability: parseEndpointAvailability(
+        wsRes?.endpoint_availability,
+      ),
       workspaces,
       tabs,
       panes,
@@ -1228,6 +1244,12 @@ async function refreshNow(lease = captureConnectionLease()) {
     ) {
       delete next.pendingFocusWorkspaceId;
       delete next.pendingFocusWorkspaceSettledAt;
+    }
+    // Close/reattach can replace advertisements while either RPC is pending.
+    // Keep that newer slice without discarding useful topology/layout updates.
+    if (endpointAvailabilityAtEntry !== state.endpointAvailability) {
+      delete next.endpointAvailability;
+      queuedConnectionKeys.add(refreshKey);
     }
     const patch = stabilizeRefreshPatch(state, next);
     if (patch) {
@@ -1871,6 +1893,41 @@ function browserSelectionIsCurrent(navigation: BrowserNavigation) {
   );
 }
 
+export function endpointCreationReason(
+  snapshot: State,
+  method: "tab.create" | "workspace.create",
+  workspaceId = snapshot.browserNavigation.workspaceId,
+): string | null {
+  if (snapshot.navigationMode === "shared") return null;
+  // Empty bootstrap deliberately uses the validated control API, not an endpoint.
+  if (method === "workspace.create" && snapshot.workspaces.length === 0)
+    return null;
+  const tabId = workspaceId
+    ? snapshot.browserNavigation.tabIds[workspaceId]
+    : undefined;
+  const paneId = tabId ? snapshot.browserNavigation.paneIds[tabId] : undefined;
+  const pane = snapshot.panes.find((pane) => pane.pane_id === paneId);
+  const advertisement = pane
+    ? snapshot.endpointAvailability[pane.terminal_id]
+    : null;
+  return (
+    endpointMethodReason(
+      snapshot.navigationMode,
+      advertisement,
+      "pane.focus",
+    ) ?? endpointMethodReason(snapshot.navigationMode, advertisement, method)
+  );
+}
+
+export function useEndpointCreationReason(
+  method: "tab.create" | "workspace.create",
+  workspaceId?: string,
+) {
+  return useStoreSelector((snapshot) =>
+    endpointCreationReason(snapshot, method, workspaceId),
+  );
+}
+
 function browserCreationSource(workspaceId: string | null) {
   const tabId = workspaceId
     ? state.browserNavigation.tabIds[workspaceId]
@@ -1947,6 +2004,27 @@ function adoptBrowserTarget(lease: StoreConnectionLease, result: unknown) {
 }
 
 export const store = {
+  setTerminalEndpoint(
+    client: ConnectionClient,
+    terminalId: string,
+    advertisement: unknown,
+  ) {
+    if (!client.isCurrent()) return;
+    set({
+      endpointAvailability: {
+        ...state.endpointAvailability,
+        [terminalId]: parseEndpointAdvertisement(advertisement),
+      },
+    });
+  },
+  terminalScrollReason(terminalId: string, mouseReporting = false) {
+    if (mouseReporting) return null; // Wheel input uses the negotiated semantic codec.
+    return endpointMethodReason(
+      state.navigationMode,
+      state.endpointAvailability[terminalId],
+      "pane.scroll",
+    );
+  },
   get: () => state,
   subscribe(l: () => void) {
     listeners.add(l);
@@ -1971,6 +2049,7 @@ export const store = {
     });
     bridge.onStatus((s) => {
       if (s === "disconnected") {
+        set({ endpointAvailability: {} });
         catalogReadyForConnection = false;
         terminalReattachPending = true;
         bridge.setConnectionRuntimeGenerations([]);
@@ -2217,6 +2296,8 @@ export const store = {
     const navigation = state.browserNavigation;
     return action(
       async (lease) => {
+        const reason = endpointCreationReason(state, "tab.create", workspaceId);
+        if (reason) throw new Error(reason);
         const result: unknown = await lease.client.call("tab.create", {
           workspace_id: workspaceId,
           focus: state.navigationMode !== "browser-local",
@@ -2370,6 +2451,8 @@ export const store = {
     const navigation = state.browserNavigation;
     return action(
       async (lease) => {
+        const reason = endpointCreationReason(state, "workspace.create");
+        if (reason) throw new Error(reason);
         const result = await lease.client.call("workspace.create", {
           label,
           cwd,


### PR DESCRIPTION
## Summary

Closes #111.

- Retain negotiated endpoint methods/capabilities per terminal socket and expose connection-scoped availability through attach replies and workspace metadata. Clear/refresh browser availability on reconnect and connection switches.
- Check advertised support before endpoint dispatch. Disable unsupported creation/history controls on desktop/mobile with specific missing-method or loading reasons; preserve supported input, mouse, resize, rendering and other operations.
- Fail missing required `pane.focus` explicitly without unsafe legacy takeover. Require `health_check` for optional health controls and retain strict generation/codec/private-protocol validation.
- Preserve newer attach/close capability updates when an older refresh completes; refresh only the stale availability slice without losing useful topology/layout updates.

## Verification

- `bun run precommit`: **1210 passed, 1 optional live-SSH skip, 0 failed**; formatting, lint and frontend/server typechecks passed.
- Initial scoped suite: **130 passed**. Corrective focused suite: **50 passed**, including six deterministic refresh races across both RPC waits; three delayed-layout cases failed before the fix.
- `bun run build:web`: passed; asset budget 118/160 files, 9.6/12 MiB (existing chunk-size advisory).
- Reduced, complete and changed advertisements covered with endpoint fixtures: unsupported operations are not sent, supported operations remain usable, required attach failure is safe, reconnect refreshes metadata and connections remain isolated.
- Independent review and targeted re-review: **OK with notes**, stale-availability finding resolved. Final session diagnostics and `git diff --check` passed.

## Boundaries / remaining verification

No blanket compatibility with future binary/control interfaces. Other topology operations remain control-API operations, not endpoint-method-gated actions. Empty-session bootstrap, attached-source cwd policy, creation deadlines, browser-local workspace/tab navigation, input attachment checks and foreground clipboard semantics are preserved. Same-tab pane focus, topology and dimensions remain shared.

Interactive desktop/mobile visual verification and live SSH were not performed for this issue. No user terminal input, clipboard access or test-service restart was performed. Reviewers inspected source and saved evidence; they did not independently rerun the full suite.

See `docs/endpoint-availability.md` for negotiated availability behavior.
