### PR TITLE
Fix modified keys in endpoint terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
   a new recipient. The 0.9.0 legacy fallback remains unsupported.
 - Restore endpoint app clicks, drags, and wheels; preserve browser selection/copy with
   output paused during selection. Fix Unicode text alignment and stale repaint text.
-- Wait for terminal readiness before input and reject pending endpoint requests on
+- Preserve modified keys including Ctrl+J, Shift/Alt+Enter, function keys, and
+  Alt-prefixed controls; wait for terminal readiness and reject pending requests on
   disconnect.
 
 ## 0.5.3 - 2026-09-08

--- a/server/src/bridge/vt-input-classifier.test.ts
+++ b/server/src/bridge/vt-input-classifier.test.ts
@@ -68,6 +68,39 @@ describe("VtInputClassifier", () => {
     ]);
   });
 
+  test("preserves Ctrl+J and modified Enter variants", () => {
+    expect(feed("\n")).toEqual([
+      {
+        type: "key",
+        code: KEY.Char,
+        char: 0x6a,
+        fn: undefined,
+        modifiers: MOD_CONTROL,
+        generatedText: undefined,
+      },
+    ]);
+    expect(feed("\x1b[13;2u")).toEqual([
+      {
+        type: "key",
+        code: KEY.Enter,
+        char: undefined,
+        fn: undefined,
+        modifiers: MOD_SHIFT,
+        generatedText: undefined,
+      },
+    ]);
+    expect(feed("\x1b[13;3u")).toEqual([
+      {
+        type: "key",
+        code: KEY.Enter,
+        char: undefined,
+        fn: undefined,
+        modifiers: MOD_ALT,
+        generatedText: undefined,
+      },
+    ]);
+  });
+
   test("ctrl+letter maps to Char with CONTROL", () => {
     expect(feed([0x03])).toEqual([
       {
@@ -114,6 +147,26 @@ describe("VtInputClassifier", () => {
     ]);
   });
 
+  test("preserves every modified CSI key family emitted by xterm", () => {
+    for (const [sequence, expected] of [
+      ["\x1b[1;2A", { code: KEY.Up, modifiers: MOD_SHIFT }],
+      ["\x1b[1;3H", { code: KEY.Home, modifiers: MOD_ALT }],
+      ["\x1b[1;5F", { code: KEY.End, modifiers: MOD_CONTROL }],
+      ["\x1b[3;2~", { code: KEY.Delete, modifiers: MOD_SHIFT }],
+      ["\x1b[5;5~", { code: KEY.PageUp, modifiers: MOD_CONTROL }],
+      ["\x1b[1;2P", { code: KEY.F, fn: 1, modifiers: MOD_SHIFT }],
+      ["\x1b[1;3S", { code: KEY.F, fn: 4, modifiers: MOD_ALT }],
+      ["\x1b[15;2~", { code: KEY.F, fn: 5, modifiers: MOD_SHIFT }],
+      ["\x1b[24;3~", { code: KEY.F, fn: 12, modifiers: MOD_ALT }],
+    ] as const) {
+      expect(feed(sequence)).toHaveLength(1);
+      expect(feed(sequence)[0]).toMatchObject({
+        type: "key",
+        ...expected,
+      });
+    }
+  });
+
   test("tilde keys: delete, home, end, page up/down", () => {
     const codeAt = (input: string) => {
       const e = feed(input)[0];
@@ -141,6 +194,29 @@ describe("VtInputClassifier", () => {
         char: 0x78,
         fn: undefined,
         modifiers: MOD_ALT,
+        generatedText: undefined,
+      },
+    ]);
+  });
+
+  test("alt-prefixed control bytes remain one modified key", () => {
+    expect(feed("\x1b\x7f")).toEqual([
+      {
+        type: "key",
+        code: KEY.Backspace,
+        char: undefined,
+        fn: undefined,
+        modifiers: MOD_ALT,
+        generatedText: undefined,
+      },
+    ]);
+    expect(feed("\x1b\x03")).toEqual([
+      {
+        type: "key",
+        code: KEY.Char,
+        char: 0x63,
+        fn: undefined,
+        modifiers: MOD_CONTROL | MOD_ALT,
         generatedText: undefined,
       },
     ]);

--- a/server/src/bridge/vt-input-classifier.ts
+++ b/server/src/bridge/vt-input-classifier.ts
@@ -150,6 +150,13 @@ const CSI_FINALS: Record<string, number> = {
   Z: KEY.BackTab,
 };
 
+const CSI_FN_FINALS: Record<string, number> = {
+  P: 1,
+  Q: 2,
+  R: 3,
+  S: 4,
+};
+
 const CSI_TILDE_KEYS: Record<number, number> = {
   1: KEY.Home,
   2: KEY.Insert,
@@ -202,7 +209,7 @@ function xtermModifiers(param: number): number {
 
 /** Control byte 0x00-0x1f → key event, or null when handled elsewhere. */
 function controlByteKey(b: number): PaneInputEvent | null {
-  if (b === 0x0d || b === 0x0a) return key(KEY.Enter);
+  if (b === 0x0d) return key(KEY.Enter);
   if (b === 0x09) return key(KEY.Tab);
   if (b === 0x7f) return key(KEY.Backspace);
   if (b === 0x08) return key(KEY.Char, { char: 0x68, modifiers: MOD_CONTROL }); // ctrl+h
@@ -371,6 +378,37 @@ export class VtInputClassifier {
         const mods = xtermModifiers(params[1] ?? 1);
         return { events: [key(CSI_FINALS[final], { modifiers: mods })], next };
       }
+      if (final in CSI_FN_FINALS && params[0] === 1) {
+        const mods = xtermModifiers(params[1] ?? 1);
+        return {
+          events: [
+            key(KEY.F, {
+              fn: CSI_FN_FINALS[final],
+              modifiers: mods,
+            }),
+          ],
+          next,
+        };
+      }
+      // TerminalView emits CSI-u for the modified Enter variants that xterm's
+      // legacy byte stream cannot otherwise distinguish from plain Enter.
+      if (final === "u" && params[0] === 13 && params.length <= 2) {
+        const modifierParam = params[1] ?? 1;
+        if (
+          Number.isSafeInteger(modifierParam) &&
+          modifierParam >= 1 &&
+          modifierParam <= 16
+        ) {
+          return {
+            events: [
+              key(KEY.Enter, {
+                modifiers: xtermModifiers(modifierParam),
+              }),
+            ],
+            next,
+          };
+        }
+      }
       return { events: [], next }; // unknown CSI: swallow
     }
 
@@ -402,7 +440,20 @@ export class VtInputClassifier {
         next: i + 1 + len,
       };
     }
-    // ESC + control byte: treat the ESC as Esc and reprocess the byte.
+    // xterm represents Alt+Backspace and Alt+Ctrl combinations by prefixing
+    // the ordinary control byte with ESC, just as it does for printable chars.
+    const controlEvent = controlByteKey(second);
+    if (controlEvent?.type === "key") {
+      return {
+        events: [
+          {
+            ...controlEvent,
+            modifiers: controlEvent.modifiers | MOD_ALT,
+          },
+        ],
+        next: i + 2,
+      };
+    }
     return { events: [key(KEY.Esc)], next: i + 1 };
   }
 }


### PR DESCRIPTION
## Summary

- distinguish Ctrl+J from Enter in VT control-byte input
- decode xterm CSI-u modified Enter sequences and modified F1-F4 sequences
- preserve Alt on control-byte combinations such as Alt+Backspace and Alt+Ctrl+C
- cover the supported modified-key families with focused classifier tests

## Compatibility

This extends endpoint terminal input decoding without changing the browser transport or Herdr protocol. Traditional VT key aliases that share the same byte sequence remain inherently indistinguishable.

## Verification

- `bun run precommit`
- `bun run build`
- public-content audit for changed files
- `git diff --check`
