### PR TITLE
Prepare release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.6.0 - 2026-09-10
+
 - Use stable Herdr 0.9.0 endpoints for terminals, with optional legacy fallback via
   `HERDR_GUI_DISABLE_ENDPOINT=1`; split panes retain their shared layout sizes.
 - Keep endpoint workspace/tab navigation local to each browser across reconnects.

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "herdr.studio"
 name = "Herdr Studio"
-version = "0.5.3"
+version = "0.6.0"
 min_herdr_version = "0.7.2"
 description = "Browser and PWA client for Herdr: workspaces, tabs, panes, agent status, session inspection, diffs, and review annotations"
 platforms = ["linux", "macos", "windows"]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "herdr-studio",
   "private": true,
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Herdr Studio: a web client for Herdr (local socket bridge + React dashboard).",
   "license": "MIT",
   "author": "Arthur",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "herdr-studio-server",
   "private": true,
-  "version": "0.5.3",
+  "version": "0.6.0",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "herdr-studio-web",
   "private": true,
-  "version": "0.5.3",
+  "version": "0.6.0",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- set the root, web, server, and Herdr plugin versions to `0.6.0`
- finalize the `0.6.0` changelog for stable Herdr 0.9 endpoint terminals, browser-local navigation, capability gating, and endpoint input/output fixes
- retain an empty `Unreleased` section for subsequent changes

The mobile tap-to-type fix was split out to #124; this PR stays draft until that merges and this branch is rebased.

## Verification

- `bun run precommit`
- `bun run build`
- `bun run package:linux-x64`
- `bun run package:linux-arm64`
- `bun run package:darwin-x64`
- `bun run package:darwin-arm64`
- `bun run package:windows-x64`
- `bun run package:windows-arm64`
- verified archive checksums, platform formats, executable permissions, update metadata, and `VERSION` files
- verified the native macOS ARM64 binary reports `herdr-gui 0.6.0`
- public-content audit for changed files; full-snapshot findings reviewed as synthetic test fixtures
- `git diff --check`

## Release process

After this PR is merged, run the **Publish Release** workflow for `0.6.0` to create the `v0.6.0` tag and release artifacts from the merged release commit.