### PR TITLE
Keep mobile terminal taps focusable for typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@
   a new recipient. The 0.9.0 legacy fallback remains unsupported.
 - Restore endpoint app clicks, drags, and wheels; preserve browser selection/copy with
   output paused during selection. Fix Unicode text alignment and stale repaint text.
-- Preserve modified keys including Ctrl+J, Shift/Alt+Enter, function keys, and
-  Alt-prefixed controls; wait for terminal readiness and reject pending requests on
-  disconnect.
+- Preserve mobile tap-to-type and modified keys including Ctrl+J, Shift/Alt+Enter,
+  function keys, and Alt-prefixed controls; wait for terminal readiness and reject
+  pending requests on disconnect.
 
 ## 0.5.3 - 2026-09-08
 

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -61,6 +61,7 @@ import {
   terminalFocusBlockedByOverlay,
   terminalPointerShouldBlurInput,
   terminalPointerShouldFocusInput,
+  terminalTouchShouldFocusInput,
 } from "../terminalFocus";
 import { uploadTerminalImage } from "../terminalImageUpload";
 import {
@@ -148,6 +149,7 @@ const ANSI_SEQUENCE_RE =
 const CLIPBOARD_READ_TIMEOUT_MS = 2000;
 const TERMINAL_EVICTION_WINDOW_MS = 60_000;
 const TERMINAL_EVICTION_MAX_RETRIES = 3;
+const TERMINAL_TOUCH_TAP_SLOP_PX = 8;
 
 function terminalDensity() {
   const compact =
@@ -1828,14 +1830,34 @@ export function TerminalView({
       passive: false,
     });
 
+    let touchStartX: number | null = null;
+    let touchStartY: number | null = null;
     let touchLastY: number | null = null;
+    let touchMoved = false;
     let touchRemainder = 0;
     const onTouchStart = (e: TouchEvent) => {
-      if (e.touches.length !== 1) return;
-      touchLastY = e.touches[0].clientY;
+      if (e.touches.length !== 1) {
+        touchMoved = true;
+        return;
+      }
+      const touch = e.touches[0];
+      touchStartX = touch.clientX;
+      touchStartY = touch.clientY;
+      touchLastY = touch.clientY;
+      touchMoved = false;
       touchRemainder = 0;
     };
     const onTouchMove = (e: TouchEvent) => {
+      if (e.touches.length !== 1 || touchLastY === null) return;
+      const touch = e.touches[0];
+      if (
+        touchStartX !== null &&
+        touchStartY !== null &&
+        Math.hypot(touch.clientX - touchStartX, touch.clientY - touchStartY) >
+          TERMINAL_TOUCH_TAP_SLOP_PX
+      ) {
+        touchMoved = true;
+      }
       if (
         endpointPresentation.mouseReporting !== undefined &&
         (term.hasSelection() ||
@@ -1846,8 +1868,6 @@ export function TerminalView({
         e.stopPropagation();
         return;
       }
-      if (e.touches.length !== 1 || touchLastY === null) return;
-      const touch = e.touches[0];
       const deltaY = touchLastY - touch.clientY;
       touchLastY = touch.clientY;
       touchRemainder += deltaY;
@@ -1879,7 +1899,25 @@ export function TerminalView({
       e.stopPropagation();
     };
     const onTouchEnd = () => {
+      const focusInput = terminalTouchShouldFocusInput(
+        touchStartX !== null && touchStartY !== null,
+        touchMoved,
+        composerOpenRef.current,
+      );
+      touchStartX = null;
+      touchStartY = null;
       touchLastY = null;
+      touchMoved = false;
+      touchRemainder = 0;
+      // Mobile Safari and installed PWAs do not reliably synthesize mousedown.
+      // Focus from the trusted touchend while user activation is still valid.
+      if (focusInput) term.focus();
+    };
+    const onTouchCancel = () => {
+      touchStartX = null;
+      touchStartY = null;
+      touchLastY = null;
+      touchMoved = false;
       touchRemainder = 0;
     };
     const onDocumentPointerDown = (e: PointerEvent) => {
@@ -1904,7 +1942,7 @@ export function TerminalView({
       passive: false,
     });
     container.addEventListener("touchend", onTouchEnd, { capture: true });
-    container.addEventListener("touchcancel", onTouchEnd, { capture: true });
+    container.addEventListener("touchcancel", onTouchCancel, { capture: true });
     document.addEventListener("pointerdown", onDocumentPointerDown, {
       capture: true,
     });
@@ -1978,7 +2016,7 @@ export function TerminalView({
         capture: true,
       });
       container.removeEventListener("touchend", onTouchEnd, { capture: true });
-      container.removeEventListener("touchcancel", onTouchEnd, {
+      container.removeEventListener("touchcancel", onTouchCancel, {
         capture: true,
       });
       document.removeEventListener("pointerdown", onDocumentPointerDown, {

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -57,7 +57,11 @@ import {
   TerminalEndpointPresentation,
   terminalMouseUsesSelection,
 } from "../terminalEndpointPresentation";
-import { terminalFocusBlockedByOverlay } from "../terminalFocus";
+import {
+  terminalFocusBlockedByOverlay,
+  terminalPointerShouldBlurInput,
+  terminalPointerShouldFocusInput,
+} from "../terminalFocus";
 import { uploadTerminalImage } from "../terminalImageUpload";
 import {
   isTerminalImeCommittedInputType,
@@ -1634,6 +1638,18 @@ export function TerminalView({
     const onTerminalMouseDown = (e: MouseEvent) => {
       if (replayingSelection) return;
       if (
+        terminalPointerShouldFocusInput(
+          shouldAvoidVirtualKeyboard(),
+          e.button,
+          composerOpenRef.current,
+        )
+      ) {
+        // Selection replay can defer xterm's own mousedown handler until after
+        // the browser's user-activation window. Focus during the physical tap
+        // so mobile browsers can open the virtual keyboard.
+        term.focus();
+      }
+      if (
         !terminalMouseUsesSelection(
           endpointPresentation.mouseReporting,
           e,
@@ -1867,8 +1883,16 @@ export function TerminalView({
       touchRemainder = 0;
     };
     const onDocumentPointerDown = (e: PointerEvent) => {
-      if (!shouldAvoidVirtualKeyboard()) return;
-      if (isEditableElement(e.target)) return;
+      const targetInsideTerminal =
+        e.target instanceof Node && container.contains(e.target);
+      if (
+        !terminalPointerShouldBlurInput(
+          shouldAvoidVirtualKeyboard(),
+          isEditableElement(e.target),
+          targetInsideTerminal,
+        )
+      )
+        return;
       term.textarea?.blur();
     };
     container.addEventListener("touchstart", onTouchStart, {

--- a/web/src/terminalFocus.test.ts
+++ b/web/src/terminalFocus.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { terminalFocusBlockedByOverlay } from "./terminalFocus";
+import {
+  terminalFocusBlockedByOverlay,
+  terminalPointerShouldBlurInput,
+  terminalPointerShouldFocusInput,
+} from "./terminalFocus";
 
 function docWithOpenPopper(open: boolean) {
   return {
@@ -52,5 +56,21 @@ describe("terminalFocusBlockedByOverlay", () => {
         docWithOpenPopper(false),
       ),
     ).toBe(false);
+  });
+});
+
+describe("terminal pointer focus", () => {
+  test("focuses coarse-pointer primary taps unless the composer is open", () => {
+    expect(terminalPointerShouldFocusInput(true, 0, false)).toBe(true);
+    expect(terminalPointerShouldFocusInput(true, 0, true)).toBe(false);
+    expect(terminalPointerShouldFocusInput(true, 1, false)).toBe(false);
+    expect(terminalPointerShouldFocusInput(false, 0, false)).toBe(false);
+  });
+
+  test("blurs coarse-pointer taps only outside terminal and editable input", () => {
+    expect(terminalPointerShouldBlurInput(true, false, false)).toBe(true);
+    expect(terminalPointerShouldBlurInput(true, true, false)).toBe(false);
+    expect(terminalPointerShouldBlurInput(true, false, true)).toBe(false);
+    expect(terminalPointerShouldBlurInput(false, false, false)).toBe(false);
   });
 });

--- a/web/src/terminalFocus.test.ts
+++ b/web/src/terminalFocus.test.ts
@@ -3,6 +3,7 @@ import {
   terminalFocusBlockedByOverlay,
   terminalPointerShouldBlurInput,
   terminalPointerShouldFocusInput,
+  terminalTouchShouldFocusInput,
 } from "./terminalFocus";
 
 function docWithOpenPopper(open: boolean) {
@@ -72,5 +73,12 @@ describe("terminal pointer focus", () => {
     expect(terminalPointerShouldBlurInput(true, true, false)).toBe(false);
     expect(terminalPointerShouldBlurInput(true, false, true)).toBe(false);
     expect(terminalPointerShouldBlurInput(false, false, false)).toBe(false);
+  });
+
+  test("focuses completed touch taps without treating scroll gestures as input", () => {
+    expect(terminalTouchShouldFocusInput(true, false, false)).toBe(true);
+    expect(terminalTouchShouldFocusInput(true, true, false)).toBe(false);
+    expect(terminalTouchShouldFocusInput(true, false, true)).toBe(false);
+    expect(terminalTouchShouldFocusInput(false, false, false)).toBe(false);
   });
 });

--- a/web/src/terminalFocus.ts
+++ b/web/src/terminalFocus.ts
@@ -21,6 +21,14 @@ export function terminalPointerShouldFocusInput(
   return coarsePointer && button === 0 && !composerOpen;
 }
 
+export function terminalTouchShouldFocusInput(
+  started: boolean,
+  moved: boolean,
+  composerOpen: boolean,
+): boolean {
+  return started && !moved && !composerOpen;
+}
+
 export function terminalPointerShouldBlurInput(
   coarsePointer: boolean,
   editableTarget: boolean,

--- a/web/src/terminalFocus.ts
+++ b/web/src/terminalFocus.ts
@@ -13,6 +13,22 @@ const RADIX_POPPER_CONTENT_WRAPPER = "[data-radix-popper-content-wrapper]";
 type FocusableLike = Pick<Element, "closest">;
 type DocumentLike = Pick<Document, "querySelector">;
 
+export function terminalPointerShouldFocusInput(
+  coarsePointer: boolean,
+  button: number,
+  composerOpen: boolean,
+): boolean {
+  return coarsePointer && button === 0 && !composerOpen;
+}
+
+export function terminalPointerShouldBlurInput(
+  coarsePointer: boolean,
+  editableTarget: boolean,
+  targetInsideTerminal: boolean,
+): boolean {
+  return coarsePointer && !editableTarget && !targetInsideTerminal;
+}
+
 export function terminalFocusBlockedByOverlay(
   activeElement: FocusableLike | null,
   doc: DocumentLike,


### PR DESCRIPTION
## Summary

- focus the terminal during coarse-pointer primary taps so mobile browsers can open the virtual keyboard inside the user-activation window (selection replay can defer xterm's own mousedown handler past it)
- focus from the trusted touchend for Mobile Safari and installed PWAs that do not reliably synthesize mousedown; 8px slop and multi-touch tracking keep scrolls and gestures from being treated as taps
- split touchcancel from touchend so a cancelled touch never focuses, and blur the input only when tapping outside the terminal
- cover the focus/blur/tap classifiers with truth-table tests

Split out from #123; the release PR is draft until this lands. Desktop behavior is unchanged: every new path is gated on coarse pointers.

## Compatibility

Browser-side focus behavior only; no transport, protocol, or desktop changes.

## Verification

- `bun test web/src/terminalFocus.test.ts` (7 pass)
- `bun run format:check`
- `bun run test`: 1215 pass, 1 pre-existing failure (`FitAddon ... hidden scrollbar`, also fails on origin/main with the local @xterm version)
- `git diff --check`
