### PR TITLE
Fix endpoint terminal sizing in split panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix undersized terminal content in split panes when using Herdr 0.9.0 endpoints.
+
 ## 0.6.0 - 2026-09-10
 
 - Use stable Herdr 0.9.0 endpoints for terminals, with optional legacy fallback via

--- a/server/src/bridge/endpoint-terminal-session.test.ts
+++ b/server/src/bridge/endpoint-terminal-session.test.ts
@@ -63,7 +63,14 @@ function writeFrame(w: BinWriter, frame: FrameData) {
   w.bytes(Buffer.alloc(0));
 }
 
-type TestPane = { paneId: string; x: number; mouseReporting: boolean };
+type Rect = { x: number; y: number; width: number; height: number };
+type TestPane = {
+  paneId: string;
+  x: number;
+  mouseReporting: boolean;
+  rect?: Rect;
+  innerRect?: Rect;
+};
 const DEFAULT_PANES: TestPane[] = [
   { paneId: "w1:p1", x: 0, mouseReporting: false },
 ];
@@ -74,17 +81,16 @@ function writePane(
   x = 0,
   y = 0,
   mouseReporting = false,
+  rect = { x, y, width: 10, height: 5 },
+  innerRect = { x: x + 1, y: y + 1, width: 8, height: 3 },
 ) {
   w.string(paneId);
   w.varint(1);
-  for (const rect of [
-    { x, y, width: 10, height: 5 },
-    { x: x + 1, y: y + 1, width: 8, height: 3 },
-  ]) {
-    w.varint(rect.x);
-    w.varint(rect.y);
-    w.varint(rect.width);
-    w.varint(rect.height);
+  for (const bounds of [rect, innerRect]) {
+    w.varint(bounds.x);
+    w.varint(bounds.y);
+    w.varint(bounds.width);
+    w.varint(bounds.height);
   }
   w.bool(false);
   w.bool(true); // scroll metrics present
@@ -112,7 +118,15 @@ function surfaceFrame(
   writeFrame(w, frame);
   w.varint(panes.length);
   for (const pane of panes)
-    writePane(w, pane.paneId, pane.x, 0, pane.mouseReporting);
+    writePane(
+      w,
+      pane.paneId,
+      pane.x,
+      0,
+      pane.mouseReporting,
+      pane.rect,
+      pane.innerRect,
+    );
   w.varint(0);
   w.bool(false);
   return w.toBuffer();
@@ -149,6 +163,12 @@ async function startSessionServer(handlers: {
   panes?: TestPane[];
   onConnection?: (sendSurface: (panes: TestPane[]) => void) => void;
   onClipboardConnection?: (send: (data: string) => void) => void;
+  initialSurface?: { frame: FrameData; panes: TestPane[] };
+  onResize?: (
+    cols: number,
+    rows: number,
+    send: (frame: FrameData, panes: TestPane[]) => void,
+  ) => void;
 }) {
   const socketPath = path.join(
     tmpdir(),
@@ -221,7 +241,15 @@ async function startSessionServer(handlers: {
               ),
             ),
           );
-          socket.write(encodeFrame(surfaceFrame(1, frame, handlers.panes)));
+          socket.write(
+            encodeFrame(
+              surfaceFrame(
+                1,
+                handlers.initialSurface?.frame ?? frame,
+                handlers.initialSurface?.panes ?? handlers.panes,
+              ),
+            ),
+          );
           continue;
         }
         if (variant === 15) {
@@ -247,6 +275,16 @@ async function startSessionServer(handlers: {
             );
             socket.write(encodeFrame(w.toBuffer()));
           }
+        } else if (variant === 12) {
+          reader.varint(); // cell_width_px
+          reader.varint(); // cell_height_px
+          const cols = reader.varint();
+          const rows = reader.varint();
+          handlers.onResize?.(cols, rows, (nextFrame, panes) =>
+            socket.write(
+              encodeFrame(surfaceFrame(++revision, nextFrame, panes)),
+            ),
+          );
         } else if (variant === 13) {
           const paneId = reader.string();
           handlers.onPaneInput?.(paneId, reader);
@@ -263,6 +301,90 @@ async function startSessionServer(handlers: {
 }
 
 describe("EndpointTerminalSession", () => {
+  test.each([
+    ["single pane", 1, 1, 0, 1],
+    ["stacked panes", 1, 0.5, 2, 3],
+    ["three stacked panes", 1, 1 / 3, 2, 3],
+    ["side-by-side panes", 0.5, 1, 2, 3],
+    ["unequal nested splits", 0.3, 0.25, 2, 3],
+  ] as const)(
+    "fits pane content through a full-tab surface: %s",
+    async (_name, widthRatio, heightRatio, rowChrome, colChrome) => {
+      const makeSurface = (cols: number, rows: number) => {
+        const rect = {
+          x: 0,
+          y: 0,
+          width: Math.floor(cols * widthRatio),
+          height: Math.floor(rows * heightRatio),
+        };
+        const innerRect = {
+          x: colChrome > 1 ? 1 : 0,
+          y: rowChrome > 0 ? 1 : 0,
+          width: rect.width - colChrome,
+          height: rect.height - rowChrome,
+        };
+        return {
+          frame: {
+            width: cols,
+            height: rows,
+            cells: Array.from({ length: cols * rows }, () => cell(" ")),
+            cursor: null,
+            hyperlinks: [],
+          } satisfies FrameData,
+          panes: [
+            { paneId: "w1:p1", x: 0, mouseReporting: false, rect, innerRect },
+          ],
+        };
+      };
+      const resizes: Array<[number, number]> = [];
+      const initial = makeSurface(100, 30);
+      const socketPath = await startSessionServer({
+        initialSurface: initial,
+        onResize: (cols, rows, send) => {
+          resizes.push([cols, rows]);
+          // A queued old surface must not cause another correction.
+          send(initial.frame, initial.panes);
+          const next = makeSurface(cols, rows);
+          send(next.frame, next.panes);
+        },
+      });
+      const session = new EndpointTerminalSession(
+        socketPath,
+        "term_1",
+        async () => "w1:p1",
+      );
+      const waitForSize = (width: number, height: number) =>
+        new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(() => {
+            session.off("terminal", onFrame);
+            reject(new Error(`missing ${width}x${height} frame`));
+          }, 2000);
+          const onFrame = (frame: { width: number; height: number }) => {
+            if (frame.width !== width || frame.height !== height) return;
+            clearTimeout(timer);
+            session.off("terminal", onFrame);
+            resolve();
+          };
+          session.on("terminal", onFrame);
+        });
+      try {
+        const first = waitForSize(100, 30);
+        await session.connect(100, 30);
+        await first;
+        expect(resizes.length).toBeLessThanOrEqual(4);
+        const resized = waitForSize(81, 25);
+        session.resize(81, 25);
+        await resized;
+        expect(resizes.length).toBeLessThanOrEqual(9);
+        const refreshed = waitForSize(81, 25);
+        session.resize(81, 25);
+        await refreshed;
+      } finally {
+        session.close();
+      }
+    },
+  );
+
   test("focuses the pane and emits cropped ANSI terminal frames", async () => {
     const requests: Array<{ method: string; params: any }> = [];
     const socketPath = await startSessionServer({
@@ -564,7 +686,8 @@ test("terminal bridge carries endpoint mouse state and targets each attached ter
       });
     }
     await Bun.sleep(40);
-    expect(inputs).toEqual(["w1:p1", "w1:p2"]);
+    // Each pane has its own socket; delivery order across sockets is undefined.
+    expect(inputs.toSorted()).toEqual(["w1:p1", "w1:p2"]);
     expect(errors).toHaveLength(1);
     for (const [direction, source] of [
       ["up", "history"],

--- a/server/src/bridge/endpoint-terminal-session.ts
+++ b/server/src/bridge/endpoint-terminal-session.ts
@@ -33,6 +33,9 @@ export class EndpointTerminalSession extends EventEmitter {
   } | null = null;
   private closed = false;
   private seq = 0;
+  private paneSize = { cols: 0, rows: 0 };
+  private surfaceSize = { cols: 0, rows: 0 };
+  private fitAttempts = 0;
   private commandChain: Promise<unknown> = Promise.resolve();
   connecting: Promise<void> | null = null;
 
@@ -72,6 +75,9 @@ export class EndpointTerminalSession extends EventEmitter {
   }
 
   connect(cols: number, rows: number): Promise<void> {
+    this.paneSize = { cols, rows };
+    this.surfaceSize = { cols, rows };
+    this.fitAttempts = 4;
     const ready = (async () => {
       await this.client.connect(cols, rows);
       this.client.assertMethod("pane.focus");
@@ -211,6 +217,7 @@ export class EndpointTerminalSession extends EventEmitter {
     const pane = surface.panes.find((p) => p.paneId === this.paneId);
     if (!pane?.mouseReporting) this.pressedMouseButtons.clear();
     if (!pane) return;
+    this.fitSurface(surface);
     this.lastScroll = pane.scroll
       ? {
           offsetFromBottom: pane.scroll.offsetFromBottom,
@@ -231,7 +238,69 @@ export class EndpointTerminalSession extends EventEmitter {
   }
 
   resize(cols: number, rows: number) {
-    this.client.resize(cols, rows);
+    this.paneSize = { cols, rows };
+    this.fitAttempts = 4;
+    const surface = this.latestSurface();
+    // A same-size resize must still repaint for newly attached viewers.
+    this.surfaceSize = surface ? this.sizeForPane(surface) : { cols, rows };
+    this.client.resize(this.surfaceSize.cols, this.surfaceSize.rows);
+  }
+
+  private sizeForPane(surface: EndpointSurface) {
+    const pane = surface.panes.find((p) => p.paneId === this.paneId);
+    if (!pane || pane.rect.width < 1 || pane.rect.height < 1)
+      return this.surfaceSize;
+    // Endpoint dimensions describe the complete tab, unlike legacy direct
+    // terminal attachments. Include pane decorations before undoing the split.
+    const scale = (
+      wanted: number,
+      outer: number,
+      inner: number,
+      total: number,
+    ) =>
+      Math.max(
+        1,
+        Math.min(
+          65_535,
+          Math.round(((wanted + outer - inner) * total) / outer),
+        ),
+      );
+    return {
+      cols: scale(
+        this.paneSize.cols,
+        pane.rect.width,
+        pane.innerRect.width,
+        surface.frame.width,
+      ),
+      rows: scale(
+        this.paneSize.rows,
+        pane.rect.height,
+        pane.innerRect.height,
+        surface.frame.height,
+      ),
+    };
+  }
+
+  private fitSurface(surface: EndpointSurface) {
+    if (
+      this.fitAttempts === 0 ||
+      surface.frame.width !== this.surfaceSize.cols ||
+      surface.frame.height !== this.surfaceSize.rows
+    )
+      return;
+    const next = this.sizeForPane(surface);
+    if (
+      next.cols === this.surfaceSize.cols &&
+      next.rows === this.surfaceSize.rows
+    ) {
+      this.fitAttempts = 0;
+      return;
+    }
+    // Split rounding can require a follow-up. Bound convergence and only use
+    // frames matching the last request, never resize again for stale patches.
+    this.fitAttempts -= 1;
+    this.surfaceSize = next;
+    this.client.resize(next.cols, next.rows);
   }
 
   input(data: Buffer) {


### PR DESCRIPTION
## Summary

Fix the terminal height regression reported in #125. Studio was sending an individual pane's dimensions as the endpoint's full-tab surface size, so Herdr applied the split layout a second time and shrank the underlying PTY as well as the browser content.

- Convert requested pane content dimensions into full-tab dimensions using the surface's pane rectangles and decoration sizes.
- Allow bounded corrections for split rounding, ignore stale-size frames for correction, and preserve same-size refreshes for new viewers. Legacy direct terminal attachments are unchanged.
- Add coverage for single panes, vertical/horizontal splits, one-third-height panes, nested unequal splits, resize, and refresh. Remove an invalid cross-socket delivery-order assumption from an existing mouse-routing test.

## Verification

- `bun run precommit`: 1,221 tests passed, 1 skipped, 0 failed; formatting, lint, and type checks passed.
- `bun run build:web`: passed, including the asset budget check; existing large-chunk warnings remain.
- All five new sizing regression cases fail against the released v0.6.0 session implementation and pass with this fix.
- Isolated real Herdr 0.9.0 comparison: a requested 100x30 pane in a one-third-height split returned 97x8 on v0.6.0 and 100x30 with the fix; PTY viewport rows changed from 8 to 30.
- Real-server checks passed for single, stacked, side-by-side, one-third-height, and unequal nested layouts, plus resize and another endpoint viewer retaking geometry control. The maintainer also reproduced the visible issue and confirmed the fix using the local development server with the same layout.

## Scope

Addresses the sizing portion of #125. The cursor-blinking report has not been confirmed or fixed, so this PR deliberately does not auto-close the issue. Same-tab PTY geometry remains shared between Herdr clients; independent per-client PTY sizes are not introduced.
