### PR TITLE
Fix login redirect behind reverse proxies

### DIFF
--- a/server/src/http/auth.test.ts
+++ b/server/src/http/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { createAuthHandlers } from "./auth";
+import { createAuthHandlers, unauthenticatedLoginRedirect } from "./auth";
 import { browserUrlFor, withLoginToken } from "../config/server-config";
 
 function cookieHeader(response: Response): string {
@@ -41,6 +41,13 @@ describe("request authentication boundaries", () => {
     });
 
     expect(handlers.isAuthed(proxiedRequest)).toBe(true);
+  });
+
+  test("redirects unauthenticated HTML requests with a relative location", () => {
+    const response = unauthenticatedLoginRedirect();
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/login");
   });
 });
 

--- a/server/src/http/auth.ts
+++ b/server/src/http/auth.ts
@@ -183,3 +183,13 @@ export function createAuthHandlers(args: {
 
   return { isAuthed, handleTokenLogin, handleLogin, loginPage };
 }
+
+export function unauthenticatedLoginRedirect(): Response {
+  // Use a relative Location so reverse proxies preserve the public origin
+  // instead of leaking the internal upstream host. Intentionally ignores
+  // request URLs and forwarded headers.
+  return new Response(null, {
+    status: 302,
+    headers: { location: "/login" },
+  });
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -65,7 +65,7 @@ import {
 import { createShutdownController } from "./connections/shutdown";
 import { bindListenerBeforeConnectionStart } from "./connections/startup";
 import { LEGACY_DEFAULT_CONNECTION_ID } from "./connections/types";
-import { createAuthHandlers } from "./http/auth";
+import { createAuthHandlers, unauthenticatedLoginRedirect } from "./http/auth";
 import { serveStatic } from "./http/static-files";
 import {
   createUpdateHandlers,
@@ -1211,10 +1211,7 @@ function main() {
           if (!isAuthed(req)) {
             const accept = req.headers.get("accept") ?? "";
             if (req.method === "GET" && accept.includes("text/html")) {
-              return Response.redirect(
-                new URL("/login", req.url).toString(),
-                302,
-              );
+              return unauthenticatedLoginRedirect();
             }
             return new Response("unauthorized", { status: 401 });
           }


### PR DESCRIPTION
## Summary

Unauthenticated HTML requests now redirect with a relative Location header instead of constructing an absolute URL from the upstream request URL.

When Herdr Studio runs behind a reverse proxy, req.url can contain the internal HTTP origin. The previous redirect therefore exposed the upstream host and could send users to an internal HTTP login URL.

## Changes

- Return `Location: /login` for unauthenticated HTML requests.
- Add a regression test for the relative redirect.
- Do not trust forwarded headers or the internal request URL for this redirect.

## Verification

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test` — 1222 pass, 1 skipped, 0 failed
- Direct reverse-proxy reproduction returns `302 Location: /login`.