### PR TITLE
Fix terminal sizing, rendering, and loading states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Stabilize split-pane sizing and terminal rendering during navigation and resizing.
+- Show loading and retryable errors while terminal layouts are fetched.
+
 ## 0.6.1 - 2026-09-11
 
 - Fix undersized terminal content in split panes when using Herdr 0.9.0 endpoints.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,6 +39,16 @@ capabilities. Attachment waits for the initial snapshot. Each terminal crops its
 pane from the server-rendered tab surface and sends semantic input to that pane;
 panes retain their shared layout dimensions.
 
+`terminal.attach` carries pane content dimensions in `cols`/`rows`. When layout
+is available, the browser also supplies `surface_cols`/`surface_rows` for the
+complete tab, including pane borders but excluding app sidebar/tab-bar insets.
+The bridge validates this optional pair as integers in 1..65535 and uses it in
+new endpoint handshakes. Surface feedback corrects stale or missing hints;
+legacy direct attachments continue to use the pane content dimensions.
+Endpoint repaints are clipped to each viewer's requested viewport, including
+wide-character and cursor boundaries. Browsers discard oversized frames that
+arrive after a local shrink or were held during text selection.
+
 Method/capability advertisements belong to each terminal socket, never another
 terminal or runtime. Reattachment negotiates again; browser reconnect and
 connection changes clear cached availability until refreshed. The bridge returns

--- a/server/src/bridge/endpoint-terminal-session.test.ts
+++ b/server/src/bridge/endpoint-terminal-session.test.ts
@@ -163,7 +163,12 @@ async function startSessionServer(handlers: {
   panes?: TestPane[];
   onConnection?: (sendSurface: (panes: TestPane[]) => void) => void;
   onClipboardConnection?: (send: (data: string) => void) => void;
+  onDisconnectConnection?: (disconnect: () => void) => void;
   initialSurface?: { frame: FrameData; panes: TestPane[] };
+  surfaceForHello?: (
+    cols: number,
+    rows: number,
+  ) => { frame: FrameData; panes: TestPane[] };
   onResize?: (
     cols: number,
     rows: number,
@@ -190,6 +195,7 @@ async function startSessionServer(handlers: {
       expect(["EPIPE", "ECONNRESET"]).toContain(error.code ?? "");
     });
     const connection = ++connectionSeq;
+    handlers.onDisconnectConnection?.(() => socket.destroy());
     handlers.onClipboardConnection?.((data) => {
       const w = new BinWriter();
       w.variant(5);
@@ -216,7 +222,12 @@ async function startSessionServer(handlers: {
         if (!greeted) {
           greeted = true;
           reader.string(); // kind
-          reader.string(); // data
+          const hello = JSON.parse(reader.string());
+          const initialSurface =
+            handlers.surfaceForHello?.(
+              hello.surface_size.cols,
+              hello.surface_size.rows,
+            ) ?? handlers.initialSurface;
           socket.write(
             encodeFrame(
               controlFrame(
@@ -245,8 +256,8 @@ async function startSessionServer(handlers: {
             encodeFrame(
               surfaceFrame(
                 1,
-                handlers.initialSurface?.frame ?? frame,
-                handlers.initialSurface?.panes ?? handlers.panes,
+                initialSurface?.frame ?? frame,
+                initialSurface?.panes ?? handlers.panes,
               ),
             ),
           );
@@ -300,7 +311,179 @@ async function startSessionServer(handlers: {
   return socketPath;
 }
 
+function splitSurface(cols: number, rows: number, count = 2) {
+  const frame: FrameData = {
+    width: cols,
+    height: rows,
+    cells: Array.from({ length: cols * rows }, () => cell("x")),
+    cursor: null,
+    hyperlinks: [],
+  };
+  const panes = Array.from({ length: count }, (_, index) => {
+    const x = Math.floor((cols * index) / count);
+    const width = Math.floor((cols * (index + 1)) / count) - x;
+    return {
+      paneId: `w1:p${index + 1}`,
+      x,
+      mouseReporting: false,
+      rect: { x, y: 0, width, height: rows },
+      innerRect: { x: x + 1, y: 1, width: width - 3, height: rows - 2 },
+    };
+  });
+  return { frame, panes };
+}
+
 describe("EndpointTerminalSession", () => {
+  test.each([
+    { cols: 252, rows: 26, count: 3, expected: [249, 26] },
+    { cols: 166, rows: 27, count: 2, expected: [166, 26] },
+  ])("corrects a one-cell overshoot ($cols x $rows)", async (initial) => {
+    const resizes: number[][] = [];
+    const socketPath = await startSessionServer({
+      surfaceForHello: (cols, rows) => splitSurface(cols, rows, initial.count),
+      onResize: (cols, rows, send) => {
+        resizes.push([cols, rows]);
+        const next = splitSurface(cols, rows, initial.count);
+        send(next.frame, next.panes);
+      },
+    });
+    const session = new EndpointTerminalSession(
+      socketPath,
+      "terminal",
+      async () => "w1:p1",
+    );
+    const frames: Array<{ width: number; height: number }> = [];
+    session.on("terminal", (frame) => frames.push(frame));
+    try {
+      await session.connect(80, 24, { cols: initial.cols, rows: initial.rows });
+      await Bun.sleep(60);
+      expect(resizes).toEqual([[...initial.expected]]);
+      expect(frames.at(-1)).toMatchObject({ width: 80, height: 24 });
+    } finally {
+      session.close();
+    }
+  });
+
+  test.each([
+    [2, 0],
+    [2, 1],
+    [3, 1],
+  ])(
+    "first visible frame fits a %i-way split pane %i without an extra viewer resize",
+    async (count, index) => {
+      const cols = count === 3 ? 135 : 134;
+      const initial = splitSurface(cols, 69, count);
+      const requested = Promise.withResolvers<() => void>();
+      const socketPath = await startSessionServer({
+        initialSurface: initial,
+        onResize: (cols, rows, send) => {
+          const settled = splitSurface(cols, rows, count);
+          send(initial.frame, initial.panes);
+          requested.resolve(() => send(settled.frame, settled.panes));
+        },
+      });
+      const session = new EndpointTerminalSession(
+        socketPath,
+        "terminal",
+        async () => initial.panes[index].paneId,
+      );
+      const frames: Array<{ width: number; height: number }> = [];
+      session.on("terminal", (frame) => frames.push(frame));
+      try {
+        await session.connect(cols, 69);
+        const settle = await requested.promise;
+        await Bun.sleep(60);
+        expect(frames).toEqual([]);
+        settle();
+        await Bun.sleep(60);
+        expect(frames).toEqual([
+          expect.objectContaining({ width: cols, height: 69 }),
+        ]);
+        await Bun.sleep(550);
+        expect(frames).toHaveLength(1); // no stale timer repaint
+      } finally {
+        session.close();
+      }
+    },
+  );
+
+  test("continuous stale frames cannot extend the first-frame deadline", async () => {
+    const initial = splitSurface(134, 69);
+    const requested = Promise.withResolvers<(reporting: boolean) => void>();
+    const socketPath = await startSessionServer({
+      initialSurface: initial,
+      onResize: (_cols, _rows, send) =>
+        requested.resolve((reporting) =>
+          send(
+            initial.frame,
+            initial.panes.map((pane) => ({
+              ...pane,
+              mouseReporting: reporting,
+            })),
+          ),
+        ),
+    });
+    const session = new EndpointTerminalSession(
+      socketPath,
+      "terminal",
+      async () => "w1:p1",
+    );
+    const frames: Array<{ width: number; mouseReporting: boolean }> = [];
+    session.on("terminal", (frame) => frames.push(frame));
+    try {
+      await session.connect(134, 69);
+      const send = await requested.promise;
+      expect(frames).toEqual([]);
+      for (let i = 0; i < 7; i++) {
+        send(true);
+        await Bun.sleep(100);
+      }
+      expect(frames.length).toBeGreaterThan(0);
+      expect(frames.at(-1)).toEqual(
+        expect.objectContaining({ width: 64, mouseReporting: true }),
+      );
+      send(false);
+      await Bun.sleep(40);
+      expect(frames.at(-1)?.mouseReporting).toBe(false);
+    } finally {
+      session.close();
+    }
+  });
+
+  test.each(["local", "remote"])(
+    "%s close cancels a pending first frame",
+    async (side) => {
+      const initial = splitSurface(134, 69);
+      const requested = Promise.withResolvers<void>();
+      let disconnect!: () => void;
+      const socketPath = await startSessionServer({
+        initialSurface: initial,
+        onDisconnectConnection: (close) => {
+          disconnect = close;
+        },
+        onResize: () => requested.resolve(),
+      });
+      const session = new EndpointTerminalSession(
+        socketPath,
+        "terminal",
+        async () => "w1:p1",
+      );
+      const frames: unknown[] = [];
+      session.on("terminal", (frame) => frames.push(frame));
+      try {
+        await session.connect(134, 69);
+        await requested.promise;
+        expect(frames).toEqual([]);
+        if (side === "local") session.close();
+        else disconnect();
+        await Bun.sleep(600);
+        expect(session.isClosed).toBe(true);
+        expect(frames).toEqual([]);
+      } finally {
+        session.close();
+      }
+    },
+  );
   test.each([
     ["single pane", 1, 1, 0, 1],
     ["stacked panes", 1, 0.5, 2, 3],
@@ -368,14 +551,15 @@ describe("EndpointTerminalSession", () => {
           session.on("terminal", onFrame);
         });
       try {
-        const first = waitForSize(100, 30);
         await session.connect(100, 30);
-        await first;
-        expect(resizes.length).toBeLessThanOrEqual(4);
+        // The viewer attach drives convergence: one targeted resize, at
+        // most one rounding follow-up, and the crop lands on the pane size.
         const resized = waitForSize(81, 25);
         session.resize(81, 25);
         await resized;
-        expect(resizes.length).toBeLessThanOrEqual(9);
+        // Boot correction + the attach resize + at most one rounding
+        // follow-up; never an iterative chase.
+        expect(resizes.length).toBeLessThanOrEqual(3);
         const refreshed = waitForSize(81, 25);
         session.resize(81, 25);
         await refreshed;
@@ -384,6 +568,128 @@ describe("EndpointTerminalSession", () => {
       }
     },
   );
+
+  test("defers pane fitting while surfaces lack the pane", async () => {
+    // Focus transits through tabs that do not contain the pane. Resizing
+    // from those foreign geometries reflows the whole tab and shows up as
+    // panes first rendering narrow, then expanding.
+    const other = {
+      frame: {
+        width: 48,
+        height: 12,
+        cells: Array.from({ length: 48 * 12 }, () => cell(" ")),
+        cursor: null,
+        hyperlinks: [],
+      } satisfies FrameData,
+      panes: [
+        {
+          paneId: "w1:other",
+          x: 0,
+          mouseReporting: false,
+          rect: { x: 0, y: 0, width: 48, height: 12 },
+          innerRect: { x: 0, y: 1, width: 47, height: 11 },
+        },
+      ],
+    };
+    const own = {
+      frame: {
+        width: 120,
+        height: 40,
+        cells: Array.from({ length: 120 * 40 }, () => cell(" ")),
+        cursor: null,
+        hyperlinks: [],
+      } satisfies FrameData,
+      panes: [
+        {
+          paneId: "w1:p1",
+          x: 0,
+          mouseReporting: false,
+          rect: { x: 0, y: 0, width: 120, height: 40 },
+          innerRect: { x: 0, y: 1, width: 119, height: 39 },
+        },
+      ],
+    };
+    const resizes: Array<[number, number]> = [];
+    const socketPath = await startSessionServer({
+      initialSurface: other,
+      onResize: (cols, rows, send) => {
+        resizes.push([cols, rows]);
+        send(own.frame, own.panes);
+      },
+    });
+    const session = new EndpointTerminalSession(
+      socketPath,
+      "term_1",
+      async () => "w1:p1",
+      silentLogger,
+      150,
+    );
+    const frames: Array<{ width: number; height: number }> = [];
+    session.on("terminal", (t) => frames.push(t));
+    try {
+      // The foreign surface never contains the pane, so connect times out
+      // rather than fitting against the wrong tab geometry.
+      await expect(session.connect(119, 39)).rejects.toThrow(
+        "timed out waiting for endpoint surface",
+      );
+      // No resize may derive from the foreign 48x12 geometry.
+      expect(resizes).toEqual([]);
+      expect(frames).toEqual([]);
+    } finally {
+      session.close();
+    }
+  });
+
+  test("ignores stale surfaces while a viewer resize is in flight", async () => {
+    // Split-pane attach: the viewer asks for the settled pane size while the
+    // server still streams pre-resize frames. Fitting against that stale
+    // ratio reflows the whole tab away from the requested size.
+    const makeSurface = (cols: number, rows: number, innerW: number) => ({
+      frame: {
+        width: cols,
+        height: rows,
+        cells: Array.from({ length: cols * rows }, () => cell(" ")),
+        cursor: null,
+        hyperlinks: [],
+      } satisfies FrameData,
+      panes: [
+        {
+          paneId: "w1:p1",
+          x: 0,
+          mouseReporting: false,
+          rect: { x: 0, y: 0, width: Math.floor(cols / 2), height: rows },
+          innerRect: { x: 0, y: 1, width: innerW, height: rows - 2 },
+        },
+      ],
+    });
+    const stale = makeSurface(134, 69, 64); // pre-resize split geometry
+    const settled = makeSurface(136, 70, 133); // after applying 136x70
+    const resizes: Array<[number, number]> = [];
+    const socketPath = await startSessionServer({
+      initialSurface: stale,
+      onResize: (cols, rows, send) => {
+        resizes.push([cols, rows]);
+        send(stale.frame, stale.panes); // in-flight stale frames
+        if (cols === 136 && rows === 70) send(settled.frame, settled.panes);
+      },
+    });
+    const session = new EndpointTerminalSession(
+      socketPath,
+      "term_1",
+      async () => "w1:p1",
+    );
+    try {
+      await session.connect(134, 69);
+      session.resize(134, 69);
+      await Bun.sleep(100);
+      // The attach resize carries the wanted pane size once; stale frames
+      // arriving while it is in flight must not trigger another resize.
+      expect(resizes.length).toBeLessThanOrEqual(2);
+      expect(resizes.every(([c, r]) => c === 274 && r === 71)).toBe(true);
+    } finally {
+      session.close();
+    }
+  });
 
   test("focuses the pane and emits cropped ANSI terminal frames", async () => {
     const requests: Array<{ method: string; params: any }> = [];
@@ -518,8 +824,9 @@ test("endpoint mouse stays pane-local and mode changes route application input v
   const modes: boolean[] = [];
   right.on("terminal", (frame) => modes.push(frame.mouseReporting));
   try {
-    await left.connect(20, 5);
-    await right.connect(20, 5);
+    // These input fixtures have fixed 8x3 content, not a resizing layout.
+    await left.connect(8, 3);
+    await right.connect(8, 3);
     const clickDragWheel = Buffer.from(
       "\x1b[<0;2;3M\x1b[<32;3;2M\x1b[<0;3;2m\x1b[<64;8;3M",
     );
@@ -668,8 +975,8 @@ test("terminal bridge carries endpoint mouse state and targets each attached ter
     for (const terminalId of ["left", "right"]) {
       await bridge.handleTerminalRpc(ws, "attach", "terminal.attach", {
         terminal_id: terminalId,
-        cols: 20,
-        rows: 5,
+        cols: 8,
+        rows: 3,
         relay_active: false,
       });
     }
@@ -708,6 +1015,187 @@ test("terminal bridge carries endpoint mouse state and targets each attached ter
       { pane_id: "w1:p2", offset_from_bottom: 7 },
     ]);
     expect(inputs).toHaveLength(2);
+  } finally {
+    bridge.dispose();
+  }
+});
+
+test("split tab reattach uses the full surface in every endpoint hello", async () => {
+  const hellos: Array<[number, number]> = [];
+  const resizes: Array<[number, number]> = [];
+  const socketPath = await startSessionServer({
+    surfaceForHello: (cols, rows) => {
+      hellos.push([cols, rows]);
+      return splitSurface(cols, rows);
+    },
+    onResize: (cols, rows, send) => {
+      resizes.push([cols, rows]);
+      const next = splitSurface(cols, rows);
+      send(next.frame, next.panes);
+    },
+  });
+  const frames: Array<{ width: number; height: number }> = [];
+  const errors: string[] = [];
+  const ws = {} as ServerWebSocket<unknown>;
+  const bridge = createTerminalBridge({
+    clientSocketPath: socketPath,
+    herdrProtocol: async () => 22,
+    lookupPaneId: async (id) => (id === "left" ? "w1:p1" : "w1:p2"),
+    safeSend: (_ws, payload) => {
+      const message = JSON.parse(payload);
+      if (message.terminal)
+        frames.push({
+          width: message.terminal.width,
+          height: message.terminal.height,
+        });
+      return true;
+    },
+    clientLabel: () => "test",
+    markRpcError: (_ws, _id, error) => errors.push(error ?? "error"),
+  });
+  try {
+    for (let visit = 0; visit < 2; visit++) {
+      for (const id of ["left", "right"]) {
+        await bridge.handleTerminalRpc(ws, "attach", "terminal.attach", {
+          terminal_id: id,
+          cols: 134,
+          rows: 69,
+          surface_cols: 274,
+          surface_rows: 71,
+          relay_active: false,
+        });
+      }
+      await Bun.sleep(40);
+      expect(errors).toEqual([]);
+      expect(frames.length).toBeGreaterThan(0);
+      expect(
+        frames.every((frame) => frame.width === 134 && frame.height === 69),
+      ).toBe(true);
+      for (const id of ["left", "right"]) {
+        await bridge.handleTerminalRpc(ws, "detach", "terminal.detach", {
+          terminal_id: id,
+        });
+      }
+      frames.length = 0;
+    }
+    expect(hellos).toEqual(Array.from({ length: 4 }, () => [274, 71]));
+    expect(resizes).toEqual([]);
+  } finally {
+    bridge.dispose();
+  }
+});
+
+test("endpoint frames are clipped per viewer and per terminal after resize", async () => {
+  const initial = splitSurface(26, 6);
+  const socketPath = await startSessionServer({
+    initialSurface: initial,
+    onResize: (_cols, _rows, send) => send(initial.frame, initial.panes),
+  });
+  const small = {} as ServerWebSocket<unknown>;
+  const large = {} as ServerWebSocket<unknown>;
+  const frames: Array<{
+    viewer: ServerWebSocket<unknown>;
+    terminal: { terminal_id: string; width: number; height: number };
+  }> = [];
+  const bridge = createTerminalBridge({
+    clientSocketPath: socketPath,
+    herdrProtocol: async () => 22,
+    lookupPaneId: async (id) => (id === "left" ? "w1:p1" : "w1:p2"),
+    safeSend: (viewer, payload) => {
+      const message = JSON.parse(payload);
+      if (message.terminal) frames.push({ viewer, terminal: message.terminal });
+      return true;
+    },
+    clientLabel: () => "test",
+    markRpcError: () => {},
+  });
+  try {
+    for (const [viewer, terminalId, cols, rows] of [
+      [small, "left", 6, 2],
+      [small, "right", 8, 3],
+      [large, "left", 10, 4],
+    ] as const) {
+      await bridge.handleTerminalRpc(viewer, "attach", "terminal.attach", {
+        terminal_id: terminalId,
+        cols,
+        rows,
+        surface_cols: 26,
+        surface_rows: 6,
+        relay_active: false,
+      });
+    }
+    await Bun.sleep(600);
+    for (const [viewer, terminalId, width, height] of [
+      [small, "left", 6, 2],
+      [small, "right", 8, 3],
+      [large, "left", 10, 4],
+    ] as const) {
+      expect(
+        frames.findLast(
+          (f) => f.viewer === viewer && f.terminal.terminal_id === terminalId,
+        )?.terminal,
+      ).toMatchObject({ width, height });
+    }
+    await bridge.handleTerminalRpc(small, "resize", "terminal.resize", {
+      terminal_id: "right",
+      cols: 7,
+      rows: 2,
+      relay_active: false,
+    });
+    await Bun.sleep(600);
+    expect(frames.at(-1)?.terminal).toMatchObject({
+      terminal_id: "right",
+      width: 7,
+      height: 2,
+    });
+  } finally {
+    bridge.dispose();
+  }
+});
+
+test("invalid initial surface hints are rejected before opening an endpoint", async () => {
+  let connections = 0;
+  const socketPath = await startSessionServer({
+    onConnection: () => {
+      connections++;
+    },
+  });
+  const errors: string[] = [];
+  const bridge = createTerminalBridge({
+    clientSocketPath: socketPath,
+    herdrProtocol: async () => 22,
+    lookupPaneId: async () => "w1:p1",
+    safeSend: () => true,
+    clientLabel: () => "test",
+    markRpcError: (_ws, _id, error) => errors.push(error ?? "error"),
+  });
+  try {
+    const invalid = [
+      { surface_cols: 274 },
+      { surface_cols: 274, surface_rows: 0 },
+      { surface_cols: -1, surface_rows: 71 },
+      { surface_cols: 1.5, surface_rows: 71 },
+      { surface_cols: 65536, surface_rows: 71 },
+      { surface_cols: "274", surface_rows: 71 },
+      { surface_cols: null, surface_rows: 71 },
+      { surface_cols: 274, surface_rows: Infinity },
+    ];
+    for (const hint of invalid) {
+      await bridge.handleTerminalRpc(
+        {} as ServerWebSocket<unknown>,
+        "attach",
+        "terminal.attach",
+        {
+          terminal_id: "terminal",
+          cols: 134,
+          rows: 69,
+          ...hint,
+        },
+      );
+    }
+    expect(errors).toHaveLength(invalid.length);
+    expect(errors.every((error) => error.includes("surface_cols"))).toBe(true);
+    expect(connections).toBe(0);
   } finally {
     bridge.dispose();
   }

--- a/server/src/bridge/endpoint-terminal-session.ts
+++ b/server/src/bridge/endpoint-terminal-session.ts
@@ -9,6 +9,10 @@ import { MOUSE_KIND, VtInputClassifier } from "./vt-input-classifier";
 
 const ESC_FLUSH_MS = 25;
 const FIRST_SURFACE_WAIT_MS = 10_000;
+// Boot correction plus rounding follow-ups; nested splits can need three.
+const SURFACE_FIT_MAX_ATTEMPTS = 3;
+// How long a misfitting frame waits for the settled replacement.
+const FIT_DEFER_MS = 500;
 
 /**
  * Terminal stream over the stable endpoint protocol (Herdr >= 0.9.0).
@@ -33,9 +37,14 @@ export class EndpointTerminalSession extends EventEmitter {
   } | null = null;
   private closed = false;
   private seq = 0;
+  private deferredFrame: {
+    timer: ReturnType<typeof setTimeout>;
+    emit: () => void;
+  } | null = null;
   private paneSize = { cols: 0, rows: 0 };
-  private surfaceSize = { cols: 0, rows: 0 };
   private fitAttempts = 0;
+  private fitResizeInFlight = false;
+  private lastRequest = { cols: 0, rows: 0 };
   private commandChain: Promise<unknown> = Promise.resolve();
   connecting: Promise<void> | null = null;
 
@@ -44,6 +53,7 @@ export class EndpointTerminalSession extends EventEmitter {
     private terminalId: string,
     private lookupPaneId: (terminalId: string) => Promise<string | null>,
     private logger: Logger = silentLogger,
+    private firstSurfaceWaitMs = FIRST_SURFACE_WAIT_MS,
   ) {
     super();
     this.client = new EndpointClient(socketPath);
@@ -53,8 +63,7 @@ export class EndpointTerminalSession extends EventEmitter {
     });
     this.client.on("error", (e) => this.emit("error", e));
     this.client.on("close", () => {
-      this.pressedMouseButtons.clear();
-      this.closed = true;
+      this.close();
       this.emit("close");
     });
     this.client.on("welcome", (w) => {
@@ -74,12 +83,18 @@ export class EndpointTerminalSession extends EventEmitter {
     return this.client.negotiation;
   }
 
-  connect(cols: number, rows: number): Promise<void> {
+  connect(
+    cols: number,
+    rows: number,
+    surfaceSize = { cols, rows },
+  ): Promise<void> {
     this.paneSize = { cols, rows };
-    this.surfaceSize = { cols, rows };
-    this.fitAttempts = 4;
+    // Browser layout supplies the initial full-tab viewport. Surface
+    // feedback still corrects stale hints and clients without layout data.
+    this.fitAttempts = SURFACE_FIT_MAX_ATTEMPTS;
+    this.lastRequest = surfaceSize;
     const ready = (async () => {
-      await this.client.connect(cols, rows);
+      await this.client.connect(surfaceSize.cols, surfaceSize.rows);
       this.client.assertMethod("pane.focus");
       const paneId = await this.lookupPaneId(this.terminalId);
       if (!paneId) {
@@ -103,6 +118,10 @@ export class EndpointTerminalSession extends EventEmitter {
     })();
     this.connecting = ready
       .catch((e) => {
+        this.logger.warn("endpoint connect failed", {
+          terminal: this.terminalId,
+          error: e instanceof Error ? e.message : String(e),
+        });
         this.close();
         throw e;
       })
@@ -183,7 +202,7 @@ export class EndpointTerminalSession extends EventEmitter {
         reject(
           new Error(`timed out waiting for endpoint surface of ${paneId}`),
         );
-      }, FIRST_SURFACE_WAIT_MS);
+      }, this.firstSurfaceWaitMs);
       const onSurface = (s: EndpointSurface) => {
         if (this.hasPane(s, paneId)) {
           cleanup();
@@ -213,45 +232,96 @@ export class EndpointTerminalSession extends EventEmitter {
   }
 
   private onSurface(surface: EndpointSurface) {
-    if (!this.paneId) return; // connect() replays once the lookup resolves
+    if (this.closed || !this.paneId) return; // connect() replays after lookup
     const pane = surface.panes.find((p) => p.paneId === this.paneId);
     if (!pane?.mouseReporting) this.pressedMouseButtons.clear();
     if (!pane) return;
-    this.fitSurface(surface);
+    this.fitSurface(surface, pane);
     this.lastScroll = pane.scroll
       ? {
           offsetFromBottom: pane.scroll.offsetFromBottom,
           maxOffsetFromBottom: pane.scroll.maxOffsetFromBottom,
         }
       : null;
+
     const cropped = cropFrame(surface.frame, pane.innerRect);
     const bytes = Buffer.from(frameToAnsi(cropped), "utf8");
-    this.seq += 1;
-    this.emit("terminal", {
-      seq: this.seq,
-      width: cropped.width,
-      height: cropped.height,
-      full: true,
-      mouseReporting: pane.mouseReporting,
-      bytes,
-    });
+    const mouseReporting = pane.mouseReporting;
+    const emitFrame = () => {
+      if (this.closed) return;
+      this.seq += 1;
+      this.emit("terminal", {
+        seq: this.seq,
+        width: cropped.width,
+        height: cropped.height,
+        full: true,
+        mouseReporting,
+        bytes,
+        frame: cropped,
+      });
+    };
+    // Wait for the requested geometry regardless of split ratio. New
+    // frames replace the pending payload, never extend its deadline.
+    if (this.fitResizeInFlight) {
+      if (this.deferredFrame) {
+        this.deferredFrame.emit = emitFrame;
+      } else {
+        const timer = setTimeout(() => {
+          const pending = this.deferredFrame;
+          if (pending?.timer !== timer) return;
+          this.deferredFrame = null;
+          this.fitResizeInFlight = false;
+          pending.emit();
+        }, FIT_DEFER_MS);
+        this.deferredFrame = { timer, emit: emitFrame };
+      }
+      return;
+    }
+    this.clearDeferredFrame();
+    emitFrame();
+  }
+
+  private clearDeferredFrame() {
+    if (!this.deferredFrame) return;
+    clearTimeout(this.deferredFrame.timer);
+    this.deferredFrame = null;
   }
 
   resize(cols: number, rows: number) {
+    this.clearDeferredFrame();
     this.paneSize = { cols, rows };
-    this.fitAttempts = 4;
-    const surface = this.latestSurface();
-    // A same-size resize must still repaint for newly attached viewers.
-    this.surfaceSize = surface ? this.sizeForPane(surface) : { cols, rows };
-    this.client.resize(this.surfaceSize.cols, this.surfaceSize.rows);
+    this.fitAttempts = SURFACE_FIT_MAX_ATTEMPTS;
+    const next = this.requestFor(this.latestSurface());
+    // Explicit viewer requests include same-size repaints for new viewers.
+    this.fitResizeInFlight = true;
+    this.lastRequest = next;
+    this.client.resize(next.cols, next.rows);
   }
 
-  private sizeForPane(surface: EndpointSurface) {
-    const pane = surface.panes.find((p) => p.paneId === this.paneId);
-    if (!pane || pane.rect.width < 1 || pane.rect.height < 1)
-      return this.surfaceSize;
-    // Endpoint dimensions describe the complete tab, unlike legacy direct
-    // terminal attachments. Include pane decorations before undoing the split.
+  // The wanted request for the latest observed geometry. The pane ratio
+  // inverts the split so the cropped content lands on the xterm size;
+  // without any observed pane the pane size itself is the best guess.
+  private requestFor(surface: EndpointSurface | null) {
+    const pane = surface?.panes.find((p) => p.paneId === this.paneId);
+    if (!surface || !pane) return { ...this.paneSize };
+    return this.sizeForPane(surface, pane);
+  }
+
+  // Endpoint dimensions describe the complete tab, unlike legacy direct
+  // terminal attachments. Invert the observed pane ratio, including pane
+  // decorations, so the first request already targets the wanted content
+  // size instead of converging through visible reflows.
+  private sizeForPane(
+    surface: EndpointSurface,
+    pane: NonNullable<EndpointSurface["panes"][number]>,
+  ) {
+    if (
+      pane.rect.width < 1 ||
+      pane.rect.height < 1 ||
+      pane.innerRect.width < 1 ||
+      pane.innerRect.height < 1
+    )
+      return { ...this.paneSize };
     const scale = (
       wanted: number,
       outer: number,
@@ -281,25 +351,65 @@ export class EndpointTerminalSession extends EventEmitter {
     };
   }
 
-  private fitSurface(surface: EndpointSurface) {
+  // Convergence is content-shaped, not frame-shaped: once the cropped pane
+  // content matches the xterm size the viewer sees the right geometry and
+  // no further resize may fire, even if the frame is still settling.
+  private fitSurface(
+    surface: EndpointSurface,
+    pane: NonNullable<EndpointSurface["panes"][number]>,
+  ) {
+    // Only the response to the latest request can settle or correct it.
     if (
-      this.fitAttempts === 0 ||
-      surface.frame.width !== this.surfaceSize.cols ||
-      surface.frame.height !== this.surfaceSize.rows
+      surface.frame.width !== this.lastRequest.cols ||
+      surface.frame.height !== this.lastRequest.rows
     )
       return;
-    const next = this.sizeForPane(surface);
+    this.fitResizeInFlight = false;
+    if (this.fitAttempts === 0) return;
     if (
-      next.cols === this.surfaceSize.cols &&
-      next.rows === this.surfaceSize.rows
+      pane.innerRect.width === this.paneSize.cols &&
+      pane.innerRect.height === this.paneSize.rows
+    ) {
+      this.fitAttempts = 0;
+      this.fitResizeInFlight = false;
+      return;
+    }
+    // Small undershoots leave harmless space. Overshoots hide content and
+    // must converge even when the difference is only one cell.
+    const off = (wanted: number, actual: number) =>
+      actual > wanted ||
+      (wanted - actual >= 2 && (wanted - actual) / wanted >= 0.02);
+    if (
+      !off(this.paneSize.cols, pane.innerRect.width) &&
+      !off(this.paneSize.rows, pane.innerRect.height)
     ) {
       this.fitAttempts = 0;
       return;
     }
-    // Split rounding can require a follow-up. Bound convergence and only use
-    // frames matching the last request, never resize again for stale patches.
-    this.fitAttempts -= 1;
-    this.surfaceSize = next;
+    this.requestResize(this.sizeForPane(surface, pane), surface);
+  }
+
+  // Sends at most one in-flight frame request: stale surfaces (frames from
+  // before the last request applied) never trigger another resize, and
+  // repeat requests for the in-flight size are dropped. Corrections resume
+  // once the server streams the requested frame.
+  private requestResize(
+    next: { cols: number; rows: number },
+    surface: EndpointSurface,
+  ) {
+    if (
+      next.cols === this.lastRequest.cols &&
+      next.rows === this.lastRequest.rows
+    )
+      return;
+    if (
+      surface.frame.width !== this.lastRequest.cols ||
+      surface.frame.height !== this.lastRequest.rows
+    )
+      return;
+    if (this.fitAttempts > 0) this.fitAttempts -= 1;
+    this.fitResizeInFlight = true;
+    this.lastRequest = next;
     this.client.resize(next.cols, next.rows);
   }
 
@@ -415,6 +525,7 @@ export class EndpointTerminalSession extends EventEmitter {
     this.closed = true;
     this.pressedMouseButtons.clear();
     if (this.escFlushTimer) clearTimeout(this.escFlushTimer);
+    this.clearDeferredFrame();
     this.client.close();
   }
 }

--- a/server/src/bridge/frame-to-ansi.test.ts
+++ b/server/src/bridge/frame-to-ansi.test.ts
@@ -95,7 +95,11 @@ describe("frameToAnsi", () => {
 
   test("positions and shapes the cursor", () => {
     const f: FrameData = {
-      ...frame([cell("a")], 1, 1),
+      ...frame(
+        Array.from({ length: 12 }, () => cell("a")),
+        3,
+        4,
+      ),
       cursor: { x: 2, y: 3, visible: true, shape: 5 },
     };
     const out = frameToAnsi(f);
@@ -103,11 +107,14 @@ describe("frameToAnsi", () => {
     expect(out).toContain("\x1b[5 q\x1b[?25h");
   });
 
-  test("separates rows with CRLF", () => {
+  test("positions rows without wrapping the cell grid", () => {
     const out = frameToAnsi(
       frame([cell("a"), cell("b"), cell("c"), cell("d")], 2, 2),
     );
     // Each row restarts style tracking, so row 2 opens with a fresh SGR.
-    expect(out).toContain("ab\r\n\x1b[0m\x1b[39;49mcd");
+    expect(out).toContain("ab\x1b[2;1H\x1b[0m\x1b[39;49mcd");
+    expect(out).toContain("\x1b[?7l");
+    expect(out).toContain("\x1b[?7h");
+    expect(out).not.toContain("\r\n");
   });
 });

--- a/server/src/bridge/frame-to-ansi.ts
+++ b/server/src/bridge/frame-to-ansi.ts
@@ -70,11 +70,19 @@ function isDefaultBlank(cell: CellData): boolean {
 }
 
 /** Serialize one frame as a full repaint: home, styled rows, cursor. */
-export function frameToAnsi(frame: FrameData): string {
-  let out = `${RESET}\x1b[H\x1b[2J`;
-  for (let y = 0; y < frame.height; y++) {
+export function frameToAnsi(
+  frame: FrameData,
+  viewport = { cols: frame.width, rows: frame.height },
+): string {
+  const width = Math.min(frame.width, viewport.cols);
+  const height = Math.min(frame.height, viewport.rows);
+  // Frames are positioned cell grids, not flowing text. A stale frame can
+  // exceed the viewer width during resize; never let it wrap and scroll.
+  let out = `${RESET}\x1b[H\x1b[2J\x1b[?7l`;
+  for (let y = 0; y < height; y++) {
+    if (y > 0) out += `\x1b[${y + 1};1H`;
     const rowStart = y * frame.width;
-    let rowEnd = frame.width;
+    let rowEnd = width;
     // Trim trailing default blanks; the terminal background fills them.
     while (rowEnd > 0 && isDefaultBlank(frame.cells[rowStart + rowEnd - 1])) {
       rowEnd--;
@@ -84,6 +92,8 @@ export function frameToAnsi(frame: FrameData): string {
     for (let x = 0; x < rowEnd; x++) {
       const cell = frame.cells[rowStart + x];
       if (cell.skip) continue;
+      const cellWidth = Bun.stringWidth(cell.symbol);
+      if (x + cellWidth > width) break;
       const key = styleKey(cell);
       if (key !== lastStyle) {
         if (linkOpen) {
@@ -103,16 +113,16 @@ export function frameToAnsi(frame: FrameData): string {
       }
       out += cell.symbol;
       // Herdr's wide-character padding is often a normal blank (skip=false).
-      const padding = Math.max(0, Bun.stringWidth(cell.symbol) - 1);
+      const padding = Math.max(0, cellWidth - 1);
       x += padding;
       // xterm can render the same grapheme narrower; anchor the next source cell.
       if (padding && x + 1 < rowEnd) out += `\x1b[${x + 2}G`;
     }
     if (linkOpen) out += "\x1b]8;;\x1b\\";
-    if (y < frame.height - 1) out += "\r\n";
   }
+  out += "\x1b[?7h";
   const cursor = frame.cursor;
-  if (cursor && cursor.visible) {
+  if (cursor?.visible && cursor.x < width && cursor.y < height) {
     out += `${RESET}\x1b[${cursor.y + 1};${cursor.x + 1}H`;
     out += `\x1b[${cursor.shape} q\x1b[?25h`;
   } else {

--- a/server/src/bridge/terminal-bridge.ts
+++ b/server/src/bridge/terminal-bridge.ts
@@ -13,6 +13,7 @@ import { NO_TERMINAL_ATTACHED_MESSAGE } from "../utils/rpc-logging";
 import { ThinClient } from "./thin-client";
 import { isTerminalHelloProtocol } from "./protocol-compat";
 import { EndpointTerminalSession } from "./endpoint-terminal-session";
+import { frameToAnsi } from "./frame-to-ansi";
 import { isTerminalClipboardPayload } from "./terminal-clipboard";
 
 type TerminalSession = {
@@ -85,7 +86,10 @@ export function createTerminalBridge(args: {
 }) {
   const logger = args.logger ?? silentLogger;
   const terminals = new Map<ServerWebSocket<unknown>, TerminalSession>();
-  const terminalViewers = new Map<ServerWebSocket<unknown>, Set<string>>();
+  const terminalViewers = new Map<
+    ServerWebSocket<unknown>,
+    Map<string, { cols: number; rows: number }>
+  >();
   const sharedTerminals = new Map<string, SharedTerminalSession>();
   const attachmentTokens = new Map<
     ServerWebSocket<unknown>,
@@ -437,7 +441,9 @@ export function createTerminalBridge(args: {
     const viewed = terminalViewers.get(ws);
     const terminalIds = terminalId
       ? [terminalId]
-      : Array.from(viewed ?? (current?.terminalId ? [current.terminalId] : []));
+      : Array.from(
+          viewed?.keys() ?? (current?.terminalId ? [current.terminalId] : []),
+        );
     for (const id of terminalIds) {
       attachmentTokens.get(ws)?.delete(id);
       if (clipboardTarget?.ws === ws && clipboardTarget.terminalId === id) {
@@ -460,7 +466,7 @@ export function createTerminalBridge(args: {
     }
     if (current?.terminalId && !viewed.has(current.terminalId)) {
       terminals.set(ws, {
-        terminalId: Array.from(viewed)[viewed.size - 1] ?? null,
+        terminalId: Array.from(viewed.keys())[viewed.size - 1] ?? null,
         cols: current.cols,
         rows: current.rows,
       });
@@ -471,6 +477,7 @@ export function createTerminalBridge(args: {
     terminalId: string,
     cols: number,
     rows: number,
+    surfaceSize?: { cols: number; rows: number },
   ): Promise<SharedTerminalSession> {
     if (disposed) throw new Error("terminal bridge disposed");
     const creationRevision = lifecycleRevision;
@@ -543,22 +550,35 @@ export function createTerminalBridge(args: {
         shared.firstFrameLogged = true;
         shared.lastFrameLogAt = now;
       }
-      const payload = serialize({
-        terminal: {
-          terminal_id: terminalId,
-          width: t.width,
-          height: t.height,
-          full: t.full,
-          ...(typeof t.mouseReporting === "boolean"
-            ? { mouse_reporting: t.mouseReporting }
-            : {}),
-          bytes: Buffer.from(t.bytes).toString("base64"),
-        },
-      });
+      const payloads = new Map<string, string>();
       for (const viewer of Array.from(shared.viewers)) {
-        if (!terminalViewers.get(viewer)?.has(terminalId)) {
+        const viewport = terminalViewers.get(viewer)?.get(terminalId);
+        if (!viewport) {
           shared.viewers.delete(viewer);
           continue;
+        }
+        const width = t.frame ? Math.min(t.width, viewport.cols) : t.width;
+        const height = t.frame ? Math.min(t.height, viewport.rows) : t.height;
+        const key = `${width}x${height}`;
+        let payload = payloads.get(key);
+        if (!payload) {
+          const bytes =
+            t.frame && (width !== t.width || height !== t.height)
+              ? frameToAnsi(t.frame, viewport)
+              : t.bytes;
+          payload = serialize({
+            terminal: {
+              terminal_id: terminalId,
+              width,
+              height,
+              full: t.full,
+              ...(typeof t.mouseReporting === "boolean"
+                ? { mouse_reporting: t.mouseReporting }
+                : {}),
+              bytes: Buffer.from(bytes).toString("base64"),
+            },
+          });
+          payloads.set(key, payload);
         }
         args.safeSend(viewer, payload, "terminal-frame");
       }
@@ -640,7 +660,7 @@ export function createTerminalBridge(args: {
               }
               thin.attach(terminalId, true);
             })
-        : thin.connect(cols, rows)
+        : thin.connect(cols, rows, surfaceSize)
     ).then(() => {
       if (!isCurrent(creationRevision)) {
         thin.close();
@@ -812,13 +832,35 @@ export function createTerminalBridge(args: {
         const cols = Number(params.cols ?? 100);
         const rows = Number(params.rows ?? 30);
         if (!terminalId) return fail("terminal_id required");
+        let surfaceSize: { cols: number; rows: number } | undefined;
+        if (
+          params.surface_cols !== undefined ||
+          params.surface_rows !== undefined
+        ) {
+          const surfaceCols = params.surface_cols;
+          const surfaceRows = params.surface_rows;
+          if (
+            typeof surfaceCols !== "number" ||
+            typeof surfaceRows !== "number" ||
+            !Number.isInteger(surfaceCols) ||
+            !Number.isInteger(surfaceRows) ||
+            surfaceCols < 1 ||
+            surfaceCols > 65_535 ||
+            surfaceRows < 1 ||
+            surfaceRows > 65_535
+          )
+            return fail(
+              "surface_cols and surface_rows must be integers between 1 and 65535",
+            );
+          surfaceSize = { cols: surfaceCols, rows: surfaceRows };
+        }
         const relaySize = relaySizeFromParams(params, { cols, rows });
         const relayRevision = relaySize ? ++clipboardRelayRevision : null;
 
         const existingShared = sharedTerminals.get(terminalId);
         const sharedMode =
           existingShared && !existingShared.thin.isClosed ? "reused" : "new";
-        const viewed = terminalViewers.get(ws) ?? new Set<string>();
+        const viewed = terminalViewers.get(ws) ?? new Map();
         const refreshReusedTerminal =
           sharedMode === "reused" &&
           !existingShared?.connecting &&
@@ -826,12 +868,17 @@ export function createTerminalBridge(args: {
           existingShared?.cols === cols &&
           existingShared.rows === rows;
         terminals.set(ws, { terminalId, cols, rows });
-        viewed.add(terminalId);
+        viewed.set(terminalId, { cols, rows });
         terminalViewers.set(ws, viewed);
         const tokens = attachmentTokens.get(ws) ?? new Map<string, object>();
         tokens.set(terminalId, {});
         attachmentTokens.set(ws, tokens);
-        const shared = await getSharedTerminal(terminalId, cols, rows);
+        const shared = await getSharedTerminal(
+          terminalId,
+          cols,
+          rows,
+          surfaceSize,
+        );
         shared.viewers.add(ws);
         try {
           await shared.connecting;
@@ -980,6 +1027,7 @@ export function createTerminalBridge(args: {
         const rows = Number(params.rows ?? 30);
         const relaySize = relaySizeFromParams(params, { cols, rows });
         thin.resize(cols, rows);
+        terminalViewers.get(ws)!.set(requestedTerminalId!, { cols, rows });
         shared.cols = cols;
         shared.rows = rows;
         if (relaySize) {
@@ -1023,7 +1071,7 @@ export function createTerminalBridge(args: {
   }
 
   function viewedTerminals(ws: ServerWebSocket<unknown>): string[] {
-    return Array.from(terminalViewers.get(ws) ?? []);
+    return Array.from(terminalViewers.get(ws)?.keys() ?? []);
   }
 
   function endpointAvailability() {

--- a/web/src/browserNavigation.test.ts
+++ b/web/src/browserNavigation.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { TerminalView } from "./components/TerminalView";
 import {
   browserPaneInDirection,
   emptyBrowserNavigation,
@@ -169,6 +172,7 @@ import {
   activateConnectionState,
   emptyServerSessionState,
   endpointCreationReason,
+  terminalNavigationLoading,
   store,
   type State,
 } from "./store";
@@ -323,7 +327,117 @@ async function withBrowserStore(
   }
 }
 
+function renderTerminalSnapshot() {
+  const snapshot = spyOn(React, "useSyncExternalStore").mockImplementation(
+    (_subscribe, getSnapshot) => getSnapshot(),
+  );
+  const layoutEffect = spyOn(React, "useLayoutEffect").mockImplementation(
+    () => {},
+  );
+  try {
+    return renderToStaticMarkup(
+      React.createElement(TerminalView, { resolvedTheme: "dark" }),
+    );
+  } finally {
+    snapshot.mockRestore();
+    layoutEffect.mockRestore();
+  }
+}
+
 describe("store browser-local navigation", () => {
+  test.each(["workspace", "tab", "agent"])(
+    "%s selection shows loading while its layout is deferred",
+    async (route) => {
+      await withBrowserStore(async (_calls, _topology, control) => {
+        let release!: () => void;
+        control.layoutWait = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        const pending =
+          route === "workspace"
+            ? store.focusWorkspace("b")
+            : route === "tab"
+              ? store.focusTab("b1")
+              : store.focusPane("b1p");
+        try {
+          expect(store.get().selectedPaneId).toBe("b1p");
+          expect(store.get().layout).toBeNull();
+          expect(terminalNavigationLoading(store.get())).toBe(true);
+          const waiting = renderTerminalSnapshot();
+          expect(waiting).toContain("Loading terminal");
+          expect(waiting).toContain('role="status"');
+          expect(waiting).not.toContain("Select a workspace");
+          expect(waiting).not.toContain('class="terminal-view"');
+        } finally {
+          release();
+          await pending;
+        }
+        expect(store.get().layout?.tab_id).toBe("b1");
+        expect(terminalNavigationLoading(store.get())).toBe(false);
+        const attaching = renderTerminalSnapshot();
+        expect(attaching).toContain('class="terminal-view"');
+        expect(attaching).toContain("Loading terminal");
+        expect(attaching).not.toContain("Select a workspace");
+      });
+    },
+  );
+
+  test("failed layout requests stop loading and a successful retry restores the terminal", async () => {
+    await withBrowserStore(async (_calls, _topology, control) => {
+      control.actionWait = (method) =>
+        method === "pane.layout"
+          ? Promise.reject(new Error("Layout unavailable"))
+          : Promise.resolve();
+      await store.focusWorkspace("b");
+      expect(store.get().layout).toBeNull();
+      expect(store.get().error).toBe("Layout unavailable");
+      expect(terminalNavigationLoading(store.get())).toBe(false);
+      const failed = renderTerminalSnapshot();
+      expect(failed).toContain('role="alert"');
+      expect(failed).toContain("Layout unavailable");
+      expect(failed).toContain("Retry");
+      expect(failed).not.toContain("Loading terminal");
+      control.actionWait = undefined;
+      await store.refresh();
+      expect(store.get().error).toBeNull();
+      expect(store.get().layout?.tab_id).toBe("b1");
+      expect(renderTerminalSnapshot()).toContain('class="terminal-view"');
+    });
+  });
+
+  test("a workspace with no panes keeps the empty prompt", async () => {
+    await withBrowserStore(async (_calls, topology) => {
+      topology.panes = topology.panes.filter(
+        (pane) => pane.workspace_id !== "b",
+      );
+      await store.focusWorkspace("b");
+      const empty = renderTerminalSnapshot();
+      expect(empty).toContain("Select a workspace");
+      expect(empty).not.toContain("Loading terminal");
+    });
+  });
+
+  test("empty, removed, paused, disconnected and failed targets do not spin", () => {
+    const pending = { ...browserState(), layout: null };
+    expect(terminalNavigationLoading(pending)).toBe(true);
+    for (const patch of [
+      { selectedPaneId: null },
+      { panes: [] },
+      { connectionPaused: true },
+      { status: "disconnected" as const },
+      { error: "Refresh failed" },
+    ]) {
+      expect(terminalNavigationLoading({ ...pending, ...patch })).toBe(false);
+    }
+    expect(
+      terminalNavigationLoading({
+        ...pending,
+        selectedPaneId: null,
+        pendingFocusWorkspaceId: "b",
+      }),
+    ).toBe(true);
+  });
+
   test("all navigation routes avoid shared focus and target input explicitly", async () => {
     await withBrowserStore(async (calls) => {
       await store.focusWorkspace("b");
@@ -395,11 +509,13 @@ describe("store browser-local navigation", () => {
       await Bun.sleep(1);
       await store.focusTab("b1");
       expect(store.get().layout).toBeNull();
+      expect(terminalNavigationLoading(store.get())).toBe(true);
       resolve();
       await refresh;
       await Bun.sleep(5);
       expect(store.get().selectedPaneId).toBe("b1p");
       expect(store.get().layout?.tab_id).toBe("b1");
+      expect(terminalNavigationLoading(store.get())).toBe(false);
     });
   });
 

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -29,7 +29,12 @@ import {
   mobileTerminalShortcutOption,
 } from "../mobileTerminalShortcuts";
 import { paneCanClose } from "../paneJump";
-import { shallowEqual, store, useStoreSelector } from "../store";
+import {
+  shallowEqual,
+  store,
+  terminalNavigationLoading,
+  useStoreSelector,
+} from "../store";
 import {
   createTerminalClipboardProvider,
   decodeTerminalClipboard,
@@ -99,6 +104,7 @@ import {
   TerminalAttachFrameWatchdog,
   TerminalResizeSync,
   terminalAttachWatchdogMs,
+  terminalEndpointViewportSize,
   terminalRelayViewportSize,
 } from "../terminalResize";
 import { terminalPageScroll, terminalWheelScroll } from "../terminalScroll";
@@ -447,6 +453,8 @@ export function TerminalView({
       status: state.status,
       terminalAttachEpoch: state.terminalAttachEpoch,
       endpointAvailability: state.endpointAvailability,
+      navigationLoading: terminalNavigationLoading(state),
+      error: state.error,
     }),
     shallowEqual,
   );
@@ -493,7 +501,9 @@ export function TerminalView({
   );
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const [uploadError, setUploadError] = useState("");
-  const [terminalLoading, setTerminalLoading] = useState(false);
+  const [terminalLoading, setTerminalLoading] = useState(
+    s.status === "connected" && !s.connectionPaused,
+  );
   const [terminalAttachError, setTerminalAttachError] = useState("");
   const [pasteLoading, setPasteLoading] = useState(false);
   const [attachRetry, setAttachRetry] = useState(0);
@@ -884,6 +894,7 @@ export function TerminalView({
     const endpointPresentation = new TerminalEndpointPresentation(
       () => term.hasSelection(),
       (text, parsed) => term.write(colorHttpLinks(text), parsed),
+      () => ({ cols: term.cols, rows: term.rows }),
     );
     endpointPresentationRef.current = endpointPresentation;
     const selectionChange = term.onSelectionChange(() =>
@@ -910,7 +921,10 @@ export function TerminalView({
       setTerminalAttachError("");
       if (typeof t.mouse_reporting === "boolean") {
         term.options.macOptionClickForcesSelection = true;
-        endpointPresentation.update(text, t.mouse_reporting);
+        endpointPresentation.update(text, t.mouse_reporting, {
+          cols: t.width,
+          rows: t.height,
+        });
       } else {
         term.write(colorHttpLinks(text));
       }
@@ -2122,6 +2136,13 @@ export function TerminalView({
     const cols = fitSize?.cols ?? term.cols;
     const rows = fitSize?.rows ?? term.rows;
     const relaySize = relayViewportFor({ cols, rows });
+    const surfaceSize = terminalEndpointViewportSize(
+      { cols, rows },
+      paneLayoutRef.current?.tab_id === paneTabIdRef.current
+        ? paneLayoutRef.current
+        : null,
+      paneIdRef.current,
+    );
     // Keep the current buffer when re-attaching the same terminal (watchdog
     // retry, reconnect): the server repaints a full frame anyway, and keeping
     // the buffer avoids a blank flash plus losing local scrollback.
@@ -2137,6 +2158,9 @@ export function TerminalView({
         terminal_id: terminalId,
         cols,
         rows,
+        ...(surfaceSize
+          ? { surface_cols: surfaceSize.cols, surface_rows: surfaceSize.rows }
+          : {}),
         relay_active: relaySize !== null,
         ...(relaySize
           ? { relay_cols: relaySize.cols, relay_rows: relaySize.rows }
@@ -2331,9 +2355,31 @@ export function TerminalView({
   if (!pane) {
     return (
       <>
-        <div className="terminal-empty muted">
-          Select a workspace or agent to open its terminal.
-        </div>
+        {s.error ? (
+          <div className="terminal-empty" role="alert">
+            <span>{s.error}</span>
+            <button type="button" onClick={() => void store.refresh()}>
+              Retry
+            </button>
+          </div>
+        ) : s.navigationLoading ? (
+          <div className="terminal-shell">
+            <div className="terminal-main">
+              <div
+                className="terminal-loading"
+                role="status"
+                aria-live="polite"
+              >
+                <span className="terminal-loading-dot" />
+                <span>Loading terminal</span>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="terminal-empty muted">
+            Select a workspace or agent to open its terminal.
+          </div>
+        )}
         <MessageDialog
           open={!!uploadError}
           title="Upload Failed"

--- a/web/src/endpointFrame.test.ts
+++ b/web/src/endpointFrame.test.ts
@@ -48,6 +48,91 @@ test.each(["中", "🙂", "👩‍💻", "🇨🇳", "ｶﾞ", "e\u0301"])(
   },
 );
 
+test.each([10, 11, 14])(
+  "a %i-column TUI frame never wraps or scrolls a 10-column viewport",
+  async (width) => {
+    const term = new Terminal({ allowProposedApi: true, cols: 10, rows: 4 });
+    term.loadAddon(new UnicodeGraphemesAddon());
+    try {
+      const lines = ["top", "item A", "item B", "bottom"].map(
+        (text) => `|${text.padEnd(width - 2)}|`,
+      );
+      const frame: FrameData = {
+        width,
+        height: lines.length,
+        cursor: null,
+        hyperlinks: [],
+        cells: Array.from(lines.join(""), (symbol) => ({
+          symbol,
+          fg: 0,
+          bg: 0,
+          modifier: 0,
+          skip: false,
+          hyperlink: null,
+        })),
+      };
+      for (let repaint = 0; repaint < 2; repaint++) {
+        await new Promise<void>((resolve) =>
+          term.write(
+            frameToAnsi(frame, { cols: term.cols, rows: term.rows }),
+            resolve,
+          ),
+        );
+        expect(term.buffer.active.baseY).toBe(0);
+        for (let y = 0; y < lines.length; y++) {
+          expect(term.buffer.active.getLine(y)?.translateToString(false)).toBe(
+            lines[y].slice(0, 10),
+          );
+        }
+        expect(term.modes.wraparoundMode).toBe(true);
+      }
+    } finally {
+      term.dispose();
+    }
+  },
+);
+
+test("viewport clipping preserves the final column and row and hides outside cursors", async () => {
+  const term = new Terminal({ allowProposedApi: true, cols: 10, rows: 3 });
+  term.loadAddon(new UnicodeGraphemesAddon());
+  const lines = ["123456789AB", "abcdefghijk", "ABCDEFGHIJK", "bottom-row!"];
+  const frame: FrameData = {
+    width: 11,
+    height: 4,
+    cursor: { x: 10, y: 3, visible: true, shape: 1 },
+    hyperlinks: [],
+    cells: Array.from(lines.join(""), (symbol) => ({
+      symbol,
+      fg: 0,
+      bg: 0,
+      modifier: 0,
+      skip: false,
+      hyperlink: null,
+    })),
+  };
+  try {
+    const ansi = frameToAnsi(frame, { cols: 10, rows: 3 });
+    expect(ansi).toEndWith("\x1b[?25l");
+    await new Promise<void>((resolve) => term.write(ansi, resolve));
+    for (let y = 0; y < 3; y++) {
+      expect(term.buffer.active.getLine(y)?.translateToString()).toBe(
+        lines[y].slice(0, 10),
+      );
+    }
+    frame.cells[9].symbol = "中";
+    frame.cells[10].symbol = " ";
+    await new Promise<void>((resolve) =>
+      term.write(frameToAnsi(frame, { cols: 10, rows: 3 }), resolve),
+    );
+    expect(term.buffer.active.getLine(0)?.translateToString()).toBe(
+      "123456789 ",
+    );
+    expect(term.buffer.active.baseY).toBe(0);
+  } finally {
+    term.dispose();
+  }
+});
+
 test("endpoint repaints clear shortened text, blank rows, and a smaller pane", async () => {
   const term = new Terminal({ allowProposedApi: true, cols: 10, rows: 3 });
   try {

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -712,6 +712,16 @@ function reloadWhenUpdatedServerIsReady(
   return promise;
 }
 
+export function terminalNavigationLoading(s: State): boolean {
+  return (
+    s.status === "connected" &&
+    !s.connectionPaused &&
+    !s.error &&
+    (!!s.pendingFocusWorkspaceId ||
+      (!s.layout && s.panes.some((pane) => pane.pane_id === s.selectedPaneId)))
+  );
+}
+
 function pickActiveTabId(s: State): string | undefined {
   const focusedWs = s.workspaces.find((w) => w.focused);
   if (focusedWs?.active_tab_id) return focusedWs.active_tab_id;
@@ -1221,8 +1231,9 @@ async function refreshNow(lease = captureConnectionLease()) {
         ) {
           next.selectedPaneId = null;
         }
-      } catch {
+      } catch (error) {
         next.layout = null;
+        next.error = error instanceof Error ? error.message : String(error);
       }
     } else {
       next.layout = null;

--- a/web/src/terminalEndpointPresentation.test.ts
+++ b/web/src/terminalEndpointPresentation.test.ts
@@ -6,6 +6,31 @@ import {
 } from "./terminalEndpointPresentation";
 
 describe("endpoint selection presentation", () => {
+  test.each([false, true])(
+    "drops oversized frames after resize, including selection-held frames (%s)",
+    (held) => {
+      let selected = held;
+      let viewport = { cols: held ? 11 : 10, rows: held ? 4 : 3 };
+      const writes: string[] = [];
+      const presentation = new TerminalEndpointPresentation(
+        () => selected,
+        (text, parsed) => {
+          writes.push(text);
+          parsed();
+        },
+        () => viewport,
+      );
+      presentation.update("oversized", true, { cols: 11, rows: 4 });
+      viewport = { cols: 10, rows: 3 };
+      selected = false;
+      presentation.flush();
+      expect(writes.every((text) => !text.includes("oversized"))).toBe(true);
+      presentation.update("clipped", true, viewport);
+      expect(writes.join("")).toContain("\x1b[?1006h\x1b[?1002h");
+      expect(writes[writes.length - 1]).toContain("clipped");
+    },
+  );
+
   test("selection cannot begin while an endpoint frame is still queued for parsing", async () => {
     let selected = false;
     let visible = "A";

--- a/web/src/terminalEndpointPresentation.ts
+++ b/web/src/terminalEndpointPresentation.ts
@@ -18,7 +18,10 @@ export class TerminalEndpointPresentation {
   mouseReporting: boolean | undefined;
   selectionDrag = false;
   private appliedMouseReporting: boolean | undefined;
-  private pendingFrame: string | null = null;
+  private pendingFrame: {
+    text: string;
+    size?: { cols: number; rows: number };
+  } | null = null;
   private writing = false;
   private disposed = false;
   private deferredSelection: (() => void) | null = null;
@@ -26,6 +29,7 @@ export class TerminalEndpointPresentation {
   constructor(
     private hasSelection: () => boolean,
     private write: (text: string, parsed: () => void) => void,
+    private viewportSize?: () => { cols: number; rows: number },
   ) {}
 
   get selectionPending(): boolean {
@@ -51,10 +55,14 @@ export class TerminalEndpointPresentation {
     this.flush();
   }
 
-  update(text: string, mouseReporting: boolean): void {
+  update(
+    text: string,
+    mouseReporting: boolean,
+    size?: { cols: number; rows: number },
+  ): void {
     if (this.disposed) return;
     this.mouseReporting = mouseReporting;
-    this.pendingFrame = text;
+    this.pendingFrame = { text, size };
     this.flush();
   }
 
@@ -64,6 +72,17 @@ export class TerminalEndpointPresentation {
       this.writing ||
       this.selectionDrag ||
       this.hasSelection()
+    )
+      return;
+    const frame = this.pendingFrame;
+    this.pendingFrame = null;
+    const viewport = this.viewportSize?.();
+    // A resize can overtake a frame on the wire or while selection holds it.
+    // The bridge clips subsequent frames to the new viewer size.
+    if (
+      frame?.size &&
+      viewport &&
+      (frame.size.cols > viewport.cols || frame.size.rows > viewport.rows)
     )
       return;
     let prefix = "";
@@ -79,11 +98,9 @@ export class TerminalEndpointPresentation {
         : "\x1b[?1002l\x1b[?1006l";
       this.appliedMouseReporting = this.mouseReporting;
     }
-    const frame = this.pendingFrame;
-    this.pendingFrame = null;
     if (prefix || frame !== null) {
       this.writing = true;
-      this.write(prefix + (frame ?? ""), () => {
+      this.write(prefix + (frame?.text ?? ""), () => {
         // reset() cannot cancel the physical xterm write. Its completion must
         // still release the gate for current intent, never restore old state.
         this.writing = false;

--- a/web/src/terminalResize.test.ts
+++ b/web/src/terminalResize.test.ts
@@ -6,6 +6,7 @@ import {
   forgetTerminalRelayViewportsExcept,
   rememberTerminalRelayViewport,
   terminalAttachWatchdogMs,
+  terminalEndpointViewportSize,
   terminalRelayViewportForTab,
   terminalRelayViewportSize,
 } from "./terminalResize";
@@ -185,6 +186,72 @@ describe("terminal relay viewport", () => {
     expect(
       terminalRelayViewportSize({ cols: 100, rows: 30 }, null, "pane_1"),
     ).toEqual({ cols: 100, rows: 30 });
+  });
+});
+
+describe("endpoint initial viewport", () => {
+  const layout = {
+    area: { x: 26, y: 1, width: 134, height: 69 },
+    panes: [
+      { pane_id: "left", rect: { width: 67, height: 69 } },
+      { pane_id: "right", rect: { width: 67, height: 69 } },
+    ],
+  };
+
+  test("both panes project a full-tab surface without app chrome", () => {
+    for (const paneId of ["left", "right"]) {
+      expect(
+        terminalEndpointViewportSize({ cols: 134, rows: 69 }, layout, paneId),
+      ).toEqual({ cols: 274, rows: 71 });
+    }
+  });
+
+  test("single and zoomed panes include only pane chrome", () => {
+    const fullPane = { pane_id: "left", rect: { width: 134, height: 69 } };
+    for (const panes of [[fullPane], [fullPane, layout.panes[1]]]) {
+      expect(
+        terminalEndpointViewportSize(
+          { cols: 271, rows: 70 },
+          { ...layout, zoomed: true, panes },
+          "left",
+        ),
+      ).toEqual({ cols: 272, rows: 70 });
+    }
+  });
+
+  test("projects nested split dimensions", () => {
+    expect(
+      terminalEndpointViewportSize(
+        { cols: 81, rows: 25 },
+        {
+          area: { x: 26, y: 1, width: 100, height: 40 },
+          panes: [
+            { pane_id: "small", rect: { width: 30, height: 10 } },
+            { pane_id: "other", rect: { width: 70, height: 40 } },
+          ],
+        },
+        "small",
+      ),
+    ).toEqual({ cols: 280, rows: 108 });
+  });
+
+  test("missing or unusable layout leaves sizing to endpoint feedback", () => {
+    expect(
+      terminalEndpointViewportSize({ cols: 134, rows: 69 }, null, "left"),
+    ).toBeNull();
+    expect(
+      terminalEndpointViewportSize({ cols: 134, rows: 69 }, layout, "absent"),
+    ).toBeNull();
+    expect(
+      terminalEndpointViewportSize(
+        { cols: 134, rows: 69 },
+        {
+          ...layout,
+          area: { ...layout.area, width: 0 },
+        },
+        "left",
+      ),
+    ).toBeNull();
   });
 });
 

--- a/web/src/terminalResize.ts
+++ b/web/src/terminalResize.ts
@@ -93,7 +93,21 @@ export function terminalRelayViewportSize(
   layout: TerminalRelayLayout | null | undefined,
   paneId: string | null | undefined,
 ): TerminalSize {
-  if (!validSize(size) || !layout || !paneId) return size;
+  const surface = terminalEndpointViewportSize(size, layout, paneId);
+  if (!surface || !layout) return size;
+  return {
+    cols: Math.min(65_535, surface.cols + Math.max(0, layout.area.x)),
+    rows: Math.min(65_535, surface.rows + Math.max(0, layout.area.y)),
+  };
+}
+
+/** Endpoint surfaces cover the tab, excluding app sidebar and tab-bar insets. */
+export function terminalEndpointViewportSize(
+  size: TerminalSize,
+  layout: TerminalRelayLayout | null | undefined,
+  paneId: string | null | undefined,
+): TerminalSize | null {
+  if (!validSize(size) || !layout || !paneId) return null;
   const pane = layout.panes.find((item) => item.pane_id === paneId);
   const area = layout.area;
   if (
@@ -103,7 +117,7 @@ export function terminalRelayViewportSize(
     pane.rect.width <= 0 ||
     pane.rect.height <= 0
   ) {
-    return size;
+    return null;
   }
 
   const splitLayout = layout.panes.length > 1 && !layout.zoomed;
@@ -118,8 +132,8 @@ export function terminalRelayViewportSize(
     Math.round(((size.rows + paneChromeRows) * area.height) / pane.rect.height),
   );
   return {
-    cols: Math.min(65_535, terminalAreaCols + Math.max(0, area.x)),
-    rows: Math.min(65_535, terminalAreaRows + Math.max(0, area.y)),
+    cols: Math.min(65_535, terminalAreaCols),
+    rows: Math.min(65_535, terminalAreaRows),
   };
 }
 


### PR DESCRIPTION
## Summary
- Stabilize initial split-pane sizing and bound resize correction.
- Clip terminal repaints to each viewer's viewport and preserve selection during resizing.
- Show accurate loading states and retryable errors during terminal navigation.

## Validation
- Formatting, ESLint, and TypeScript checks passed.
- `bun run test`: 1,250 passed, 1 skipped, 0 failed.
- `bun run build:linux-x64` passed.
- Regression coverage includes split-pane reattachment, resize deadlines, viewport clipping, concurrent viewers, text selection, and layout-fetch failures.

## Compatibility
- Full-surface size hints are optional; existing clients and legacy direct-terminal attachments remain supported.
