### PR TITLE
Add terminal color themes with presets and custom theme editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Add terminal color themes: choose from built-in presets per dark/light mode,
+  or create custom themes with your own colors (Menu → Terminal theme).
+
 ## 0.6.1 - 2026-09-11
 
 - Fix undersized terminal content in split panes when using Herdr 0.9.0 endpoints.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -332,6 +332,11 @@ browser and do not change Herdr server configuration.
 - Enable browser task-completion notifications that return directly to the
   relevant pane.
 - Choose light/dark themes (or follow the system color scheme) and persistent accent colors.
+- Pick a terminal color theme per appearance mode from built-in presets
+  (Solarized, Dracula, One Dark, Nord, Tokyo Night, Catppuccin, GitHub, and
+  more) via Menu → Appearance → Terminal theme, or create custom themes with
+  your own base and ANSI colors; themes apply live to every terminal and are
+  stored per browser.
 - Scale the interface from 80% to 150% via Menu → Appearance → Text size,
   useful on mobile where browser zoom shortcuts are unavailable.
 - Install and manage a systemd or launchd user service from the CLI.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -25,6 +25,7 @@ import {
   useRef,
   useState,
 } from "react";
+import type { ITheme } from "@xterm/xterm";
 import packageJson from "../package.json";
 import {
   type AccentColor,
@@ -73,6 +74,17 @@ import {
   serializeMobileTerminalShortcutRows,
   serializeMobileTerminalSideShortcuts,
 } from "./mobileTerminalShortcuts";
+import {
+  CUSTOM_TERMINAL_THEMES_STORAGE_KEY,
+  type CustomTerminalTheme,
+  parseCustomTerminalThemes,
+  parseTerminalThemeSelection,
+  resolveTerminalTheme,
+  serializeCustomTerminalThemes,
+  serializeTerminalThemeSelection,
+  TERMINAL_THEME_SELECTION_STORAGE_KEY,
+  type TerminalThemeSelection,
+} from "./terminalThemes";
 import {
   activePaneIdForSnapshot,
   type PaneJumpEntry,
@@ -148,7 +160,7 @@ const LazyTerminalView = lazy(() =>
 
 type TerminalViewProps = {
   paneId?: string;
-  resolvedTheme: ResolvedTheme;
+  terminalTheme: ITheme;
   showMobileKeys?: boolean;
   mobileShortcuts?: MobileTerminalShortcutRows;
   mobileSideShortcuts?: MobileTerminalSideShortcuts;
@@ -247,6 +259,18 @@ function loadAccentColor(): AccentColor {
 
 function loadUiScale(): number {
   return normalizeUiScale(localStorage.getItem(UI_SCALE_KEY));
+}
+
+function loadTerminalThemeSelection(): TerminalThemeSelection {
+  return parseTerminalThemeSelection(
+    localStorage.getItem(TERMINAL_THEME_SELECTION_STORAGE_KEY),
+  );
+}
+
+function loadCustomTerminalThemes(): CustomTerminalTheme[] {
+  return parseCustomTerminalThemes(
+    localStorage.getItem(CUSTOM_TERMINAL_THEMES_STORAGE_KEY),
+  );
 }
 
 function loadMobileTerminalShortcuts(): MobileTerminalShortcutRows {
@@ -765,7 +789,7 @@ function resizeTargetForSplit(
 // Render the active tab's Herdr pane layout; single-pane and zoomed tabs keep
 // the old full terminal view.
 function TerminalPaneLayout({
-  resolvedTheme,
+  terminalTheme,
   mobileShortcuts,
   mobileSideShortcuts,
   composerOpen,
@@ -774,7 +798,7 @@ function TerminalPaneLayout({
   onAgentHistoryOpenChange,
   onOpenWorkspaceFile,
 }: {
-  resolvedTheme: ResolvedTheme;
+  terminalTheme: ITheme;
   mobileShortcuts: MobileTerminalShortcutRows;
   mobileSideShortcuts: MobileTerminalSideShortcuts;
   composerOpen: boolean;
@@ -823,7 +847,7 @@ function TerminalPaneLayout({
     return (
       <TerminalView
         key={mountKeyForPane(activePaneId)}
-        resolvedTheme={resolvedTheme}
+        terminalTheme={terminalTheme}
         mobileShortcuts={mobileShortcuts}
         mobileSideShortcuts={mobileSideShortcuts}
         composerOpen={composerOpen}
@@ -878,7 +902,7 @@ function TerminalPaneLayout({
         <TerminalView
           key={mountKeyForPane(activePaneId)}
           paneId={activePaneId}
-          resolvedTheme={resolvedTheme}
+          terminalTheme={terminalTheme}
           mobileShortcuts={mobileShortcuts}
           mobileSideShortcuts={mobileSideShortcuts}
           composerOpen={composerOpen}
@@ -982,7 +1006,7 @@ function TerminalPaneLayout({
             <TerminalView
               key={mountKeyForPane(layoutPane.pane_id)}
               paneId={layoutPane.pane_id}
-              resolvedTheme={resolvedTheme}
+              terminalTheme={terminalTheme}
               showMobileKeys={isActive}
               mobileShortcuts={mobileShortcuts}
               mobileSideShortcuts={mobileSideShortcuts}
@@ -1069,6 +1093,20 @@ export default function App() {
     useState<MobileTerminalShortcutRows>(loadMobileTerminalShortcuts);
   const [mobileTerminalSideShortcuts, setMobileTerminalSideShortcuts] =
     useState<MobileTerminalSideShortcuts>(loadMobileTerminalSideShortcuts);
+  const [terminalThemeSelection, setTerminalThemeSelection] =
+    useState<TerminalThemeSelection>(loadTerminalThemeSelection);
+  const [customTerminalThemes, setCustomTerminalThemes] = useState<
+    CustomTerminalTheme[]
+  >(loadCustomTerminalThemes);
+  const terminalTheme = useMemo(
+    () =>
+      resolveTerminalTheme(
+        resolvedTheme,
+        terminalThemeSelection,
+        customTerminalThemes,
+      ),
+    [resolvedTheme, terminalThemeSelection, customTerminalThemes],
+  );
   const [sidebarHidden, setSidebarHidden] = useState(false);
   const [mobileControlsCollapsed, setMobileControlsCollapsed] = useState(false);
   const [mobileTabSheetOpen, setMobileTabSheetOpen] = useState(false);
@@ -2332,6 +2370,18 @@ export default function App() {
     );
   }, [mobileTerminalSideShortcuts]);
   useEffect(() => {
+    localStorage.setItem(
+      TERMINAL_THEME_SELECTION_STORAGE_KEY,
+      serializeTerminalThemeSelection(terminalThemeSelection),
+    );
+  }, [terminalThemeSelection]);
+  useEffect(() => {
+    localStorage.setItem(
+      CUSTOM_TERMINAL_THEMES_STORAGE_KEY,
+      serializeCustomTerminalThemes(customTerminalThemes),
+    );
+  }, [customTerminalThemes]);
+  useEffect(() => {
     const onStorage = (event: StorageEvent) => {
       if (event.key === MOBILE_TERMINAL_SHORTCUTS_STORAGE_KEY) {
         setMobileTerminalShortcuts(
@@ -2341,6 +2391,10 @@ export default function App() {
         setMobileTerminalSideShortcuts(
           parseMobileTerminalSideShortcuts(event.newValue),
         );
+      } else if (event.key === TERMINAL_THEME_SELECTION_STORAGE_KEY) {
+        setTerminalThemeSelection(parseTerminalThemeSelection(event.newValue));
+      } else if (event.key === CUSTOM_TERMINAL_THEMES_STORAGE_KEY) {
+        setCustomTerminalThemes(parseCustomTerminalThemes(event.newValue));
       }
     };
     window.addEventListener("storage", onStorage);
@@ -2539,6 +2593,8 @@ export default function App() {
               accentColor={accentColor}
               mobileTerminalShortcuts={mobileTerminalShortcuts}
               mobileTerminalSideShortcuts={mobileTerminalSideShortcuts}
+              terminalThemeSelection={terminalThemeSelection}
+              customTerminalThemes={customTerminalThemes}
               onThemeChange={setTheme}
               onAccentColorChange={setAccentColor}
               uiScale={uiScale}
@@ -2547,6 +2603,8 @@ export default function App() {
               onMobileTerminalSideShortcutsChange={
                 setMobileTerminalSideShortcuts
               }
+              onTerminalThemeSelectionChange={setTerminalThemeSelection}
+              onCustomTerminalThemesChange={setCustomTerminalThemes}
             />
           </div>
         </div>
@@ -2858,7 +2916,7 @@ export default function App() {
           >
             <div className="workspace-terminal-surface">
               <TerminalPaneLayout
-                resolvedTheme={resolvedTheme}
+                terminalTheme={terminalTheme}
                 mobileShortcuts={mobileTerminalShortcuts}
                 mobileSideShortcuts={mobileTerminalSideShortcuts}
                 composerOpen={terminalComposerOpen}

--- a/web/src/components/ConfigMenu.tsx
+++ b/web/src/components/ConfigMenu.tsx
@@ -15,6 +15,7 @@ import {
   RefreshCw,
   ScrollText,
   Server,
+  SquareTerminal,
   Sun,
   SunMoon,
   Wifi,
@@ -38,10 +39,16 @@ import {
   type MobileTerminalShortcutRows,
   type MobileTerminalSideShortcuts,
 } from "../mobileTerminalShortcuts";
+import {
+  type CustomTerminalTheme,
+  resolveTerminalThemeDefinition,
+  type TerminalThemeSelection,
+} from "../terminalThemes";
 import { AutoSyncRepositoriesDialog } from "./AutoSyncRepositoriesDialog";
 import { ChangelogDialog } from "./ChangelogDialog";
 import { ShortcutLookupDialog } from "./ShortcutLookupDialog";
 import { MobileTerminalShortcutsDialog } from "./MobileTerminalShortcutsDialog";
+import { TerminalThemeDialog } from "./TerminalThemeDialog";
 
 const APP_VERSION = packageJson.version;
 export const CONFIG_MENU_ID = "herdr-config-menu";
@@ -67,6 +74,8 @@ type ConfigMenuProps = {
   uiScale: number;
   mobileTerminalShortcuts: MobileTerminalShortcutRows;
   mobileTerminalSideShortcuts: MobileTerminalSideShortcuts;
+  terminalThemeSelection: TerminalThemeSelection;
+  customTerminalThemes: CustomTerminalTheme[];
   onThemeChange: (theme: Theme) => void;
   onAccentColorChange: (accentColor: AccentColor) => void;
   onUiScaleChange: (scale: number) => void;
@@ -74,6 +83,8 @@ type ConfigMenuProps = {
   onMobileTerminalSideShortcutsChange: (
     shortcuts: MobileTerminalSideShortcuts,
   ) => void;
+  onTerminalThemeSelectionChange: (selection: TerminalThemeSelection) => void;
+  onCustomTerminalThemesChange: (themes: CustomTerminalTheme[]) => void;
 };
 
 export function ConfigMenu({
@@ -82,11 +93,15 @@ export function ConfigMenu({
   uiScale,
   mobileTerminalShortcuts,
   mobileTerminalSideShortcuts,
+  terminalThemeSelection,
+  customTerminalThemes,
   onThemeChange,
   onAccentColorChange,
   onUiScaleChange,
   onMobileTerminalShortcutsChange,
   onMobileTerminalSideShortcutsChange,
+  onTerminalThemeSelectionChange,
+  onCustomTerminalThemesChange,
 }: ConfigMenuProps) {
   const s = useStoreSelector(
     (state) => ({
@@ -117,6 +132,7 @@ export function ConfigMenu({
   const [changelogOpen, setChangelogOpen] = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [mobileShortcutsOpen, setMobileShortcutsOpen] = useState(false);
+  const [terminalThemesOpen, setTerminalThemesOpen] = useState(false);
   const [autoSyncOpen, setAutoSyncOpen] = useState(false);
   const [connectionDetailsOpen, setConnectionDetailsOpen] = useState(false);
   const [health, setHealth] = useState<HealthInfo | null>(null);
@@ -326,6 +342,27 @@ export function ConfigMenu({
                   ))}
                 </div>
               </div>
+              <ConfigMenuItem
+                icon={<SquareTerminal size={15} />}
+                label="Terminal theme"
+                description={`Dark: ${
+                  resolveTerminalThemeDefinition(
+                    "dark",
+                    terminalThemeSelection,
+                    customTerminalThemes,
+                  ).name
+                } · Light: ${
+                  resolveTerminalThemeDefinition(
+                    "light",
+                    terminalThemeSelection,
+                    customTerminalThemes,
+                  ).name
+                }`}
+                onClick={() => {
+                  setOpen(false);
+                  setTerminalThemesOpen(true);
+                }}
+              />
               <div className="config-preference-row">
                 <span className="config-item-icon">
                   <ALargeSmall size={15} />
@@ -569,6 +606,14 @@ export function ConfigMenu({
         onChange={onMobileTerminalShortcutsChange}
         onSideChange={onMobileTerminalSideShortcutsChange}
         onClose={() => setMobileShortcutsOpen(false)}
+      />
+      <TerminalThemeDialog
+        open={terminalThemesOpen}
+        selection={terminalThemeSelection}
+        customThemes={customTerminalThemes}
+        onSelectionChange={onTerminalThemeSelectionChange}
+        onCustomThemesChange={onCustomTerminalThemesChange}
+        onClose={() => setTerminalThemesOpen(false)}
       />
       <AutoSyncRepositoriesDialog
         open={autoSyncOpen}

--- a/web/src/components/TerminalThemeDialog.browser.tsx
+++ b/web/src/components/TerminalThemeDialog.browser.tsx
@@ -1,0 +1,260 @@
+import { useState } from "react";
+import { createRoot } from "react-dom/client";
+import { flushSync } from "react-dom";
+import { Terminal } from "@xterm/xterm";
+import {
+  type CustomTerminalTheme,
+  type TerminalThemeSelection,
+  MAX_CUSTOM_TERMINAL_THEMES,
+  parseCustomTerminalThemes,
+  serializeCustomTerminalThemes,
+  TERMINAL_ANSI_COLOR_KEYS,
+} from "../terminalThemes";
+import { TerminalThemeDialog } from "./TerminalThemeDialog";
+
+const failures: string[] = [];
+const check = (condition: boolean, message: string) => {
+  if (!condition) failures.push(message);
+};
+const settle = () =>
+  new Promise((resolve) =>
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() => setTimeout(resolve, 200)),
+    ),
+  );
+const button = (label: string) => {
+  const found = [...document.querySelectorAll("button")].find(
+    (element) =>
+      element.getAttribute("aria-label") === label ||
+      element.textContent === label,
+  );
+  if (!found) throw new Error(`Missing button: ${label}`);
+  return found;
+};
+const click = (label: string) => flushSync(() => button(label).click());
+let customThemes: CustomTerminalTheme[] = [];
+let selection: TerminalThemeSelection;
+let replaceThemes: (themes: CustomTerminalTheme[]) => void;
+
+function Harness() {
+  const [themes, setThemes] = useState<CustomTerminalTheme[]>([]);
+  const [selected, setSelected] = useState({
+    dark: "herdr-dark",
+    light: "herdr-light",
+  });
+  customThemes = themes;
+  selection = selected;
+  replaceThemes = setThemes;
+  return (
+    <TerminalThemeDialog
+      open
+      customThemes={themes}
+      selection={selected}
+      onCustomThemesChange={setThemes}
+      onSelectionChange={setSelected}
+      onClose={() => {}}
+    />
+  );
+}
+
+async function run() {
+  const rootElement = document.createElement("div");
+  document.body.append(rootElement);
+  const root = createRoot(rootElement);
+  flushSync(() => root.render(<Harness />));
+  await settle();
+  click("Duplicate Herdr Dark");
+  await settle();
+  const input = document.querySelector<HTMLInputElement>(
+    ".terminal-theme-name-field input",
+  )!;
+  input.focus();
+  check(document.activeElement === input, "Input was not focused initially");
+  const setValue = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  )!.set!;
+  for (const name of ["C", "Co", "Copy"]) {
+    setValue.call(input, name);
+    flushSync(() => input.dispatchEvent(new Event("input", { bubbles: true })));
+    check(
+      document.activeElement === input,
+      `Name input lost focus during ${name}`,
+    );
+    await settle();
+    check(
+      document.activeElement === input,
+      `Name input lost focus after ${name}`,
+    );
+    check(input.value === name, "Name input did not update");
+  }
+
+  const termElement = document.createElement("div");
+  document.body.append(termElement);
+  const term = new Terminal();
+  term.open(termElement);
+  const defaults: string[] = [];
+  term.onData((data) => {
+    const match = /\]4;(\d+);rgb:([\da-f]+)\/([\da-f]+)\/([\da-f]+)/i.exec(
+      data,
+    );
+    if (match)
+      defaults[Number(match[1])] = `#${match
+        .slice(2)
+        .map((part) => part.slice(0, 2))
+        .join("")}`;
+  });
+  await new Promise<void>((resolve) =>
+    term.write(
+      TERMINAL_ANSI_COLOR_KEYS.map((_, i) => `\x1b]4;${i};?\x07`).join(""),
+      resolve,
+    ),
+  );
+  const colors = [
+    ...document.querySelectorAll<HTMLInputElement>('input[type="color"]'),
+  ].slice(5);
+  check(
+    defaults.filter(Boolean).length === 16,
+    "xterm did not report its default ANSI palette",
+  );
+  for (const [index, key] of TERMINAL_ANSI_COLOR_KEYS.entries()) {
+    check(
+      colors[index].value === defaults[index],
+      `Duplicate changed default ANSI ${key}`,
+    );
+  }
+  term.dispose();
+  termElement.remove();
+
+  click("Cancel");
+  await settle();
+  const radios = document.querySelectorAll<HTMLButtonElement>('[role="radio"]');
+  radios[0].focus();
+  flushSync(() =>
+    radios[0].dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
+    ),
+  );
+  await settle();
+  check(
+    document.activeElement === radios[1],
+    "Arrow navigation lost focus after selection",
+  );
+  check(
+    selection.dark === "solarized-dark",
+    "Arrow navigation did not select the next theme",
+  );
+
+  const full = Array.from(
+    { length: MAX_CUSTOM_TERMINAL_THEMES },
+    (_, index): CustomTerminalTheme => ({
+      id: `custom-${index}`,
+      name: `Custom ${index}`,
+      variant: "dark",
+      colors: { background: "#000000", foreground: "#ffffff" },
+    }),
+  );
+  flushSync(() => replaceThemes(full.slice(1)));
+  click("Duplicate Herdr Dark");
+  await settle();
+  // Another browser tab can fill the final slot while this draft is open.
+  flushSync(() => replaceThemes(full));
+  check(
+    button("Create theme").disabled,
+    "Create remained enabled after the last slot was filled",
+  );
+  check(
+    document.querySelector('[role="alert"]') !== null,
+    "Missing theme-limit explanation",
+  );
+  click("Create theme");
+  check(
+    customThemes.length === MAX_CUSTOM_TERMINAL_THEMES,
+    "Save exceeded the theme limit",
+  );
+  check(
+    parseCustomTerminalThemes(serializeCustomTerminalThemes(customThemes))
+      .length === customThemes.length,
+    "Saving dropped a theme from storage",
+  );
+  if (document.querySelector(".terminal-theme-editor")) click("Cancel");
+  await settle();
+  check(
+    button("Duplicate Herdr Dark").disabled,
+    "Duplicate remained enabled at the theme limit",
+  );
+  check(
+    button("Duplicate Custom 0").disabled,
+    "Custom theme duplication bypassed the limit",
+  );
+  click("Edit Custom 0");
+  await settle();
+  check(
+    !button("Save theme").disabled,
+    "Editing an existing theme was blocked at the limit",
+  );
+  click("Save theme");
+  check(
+    customThemes.length === MAX_CUSTOM_TERMINAL_THEMES,
+    "Editing changed the theme count",
+  );
+  check(
+    selection.dark === "custom-0",
+    "Editing did not select the saved theme",
+  );
+  click("Delete Custom 0");
+  await settle();
+  const confirmation = document.querySelector(
+    '[role="dialog"][aria-label="Delete theme"]',
+  )!;
+  check(
+    confirmation.contains(document.activeElement),
+    "Delete confirmation lost focus",
+  );
+  flushSync(() =>
+    document.activeElement!.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    ),
+  );
+  await settle();
+  check(
+    customThemes.length === MAX_CUSTOM_TERMINAL_THEMES,
+    "Escape deleted a theme",
+  );
+  check(
+    document.activeElement?.getAttribute("aria-label") === "Terminal themes",
+    "Closing confirmation did not restore dialog focus",
+  );
+  click("Delete Custom 0");
+  await settle();
+  click("Delete");
+  check(
+    selection.dark === "herdr-dark",
+    "Deleting the selected theme did not restore the default",
+  );
+  check(
+    !button("Duplicate Herdr Dark").disabled,
+    "Deleting a theme did not free a slot",
+  );
+  click("Duplicate Herdr Dark");
+  await settle();
+  click("Create theme");
+  check(
+    customThemes.length === MAX_CUSTOM_TERMINAL_THEMES,
+    "The free slot could not be reused",
+  );
+  check(
+    parseCustomTerminalThemes(serializeCustomTerminalThemes(customThemes)).some(
+      (theme) => theme.id === selection.dark,
+    ),
+    "The newly selected theme was not persisted",
+  );
+  flushSync(() => root.unmount());
+  rootElement.remove();
+}
+
+run()
+  .catch((error: unknown) => failures.push(String(error)))
+  .finally(() =>
+    fetch("/result", { method: "POST", body: JSON.stringify(failures) }),
+  );

--- a/web/src/components/TerminalThemeDialog.browser.tsx
+++ b/web/src/components/TerminalThemeDialog.browser.tsx
@@ -2,7 +2,11 @@ import { useState } from "react";
 import { createRoot } from "react-dom/client";
 import { flushSync } from "react-dom";
 import { Terminal } from "@xterm/xterm";
+import "@xterm/xterm/css/xterm.css";
+import "../styles.css";
 import {
+  applyTerminalTheme,
+  terminalThemeFor,
   type CustomTerminalTheme,
   type TerminalThemeSelection,
   MAX_CUSTOM_TERMINAL_THEMES,
@@ -35,6 +39,7 @@ const click = (label: string) => flushSync(() => button(label).click());
 let customThemes: CustomTerminalTheme[] = [];
 let selection: TerminalThemeSelection;
 let replaceThemes: (themes: CustomTerminalTheme[]) => void;
+let replaceSelection: (selection: TerminalThemeSelection) => void;
 
 function Harness() {
   const [themes, setThemes] = useState<CustomTerminalTheme[]>([]);
@@ -45,6 +50,7 @@ function Harness() {
   customThemes = themes;
   selection = selected;
   replaceThemes = setThemes;
+  replaceSelection = setSelected;
   return (
     <TerminalThemeDialog
       open
@@ -89,7 +95,21 @@ async function run() {
     check(input.value === name, "Name input did not update");
   }
 
+  const modes = document.querySelectorAll(
+    ".terminal-theme-variant-field button",
+  );
+  check(
+    modes[0].getAttribute("aria-label") === "Dark mode",
+    "Dark mode button has no accessible name",
+  );
+  check(
+    modes[1].getAttribute("aria-label") === "Light mode",
+    "Light mode button has no accessible name",
+  );
+
   const termElement = document.createElement("div");
+  termElement.className = "terminal-view";
+  termElement.style.cssText = "position:relative;width:800px;height:240px";
   document.body.append(termElement);
   const term = new Terminal();
   term.open(termElement);
@@ -123,6 +143,45 @@ async function run() {
       `Duplicate changed default ANSI ${key}`,
     );
   }
+  const textarea = termElement.querySelector("textarea")!;
+  for (const { mode, theme } of [
+    { mode: "light", theme: { background: "#2b3245", foreground: "#ffffff" } },
+    { mode: "light", theme: terminalThemeFor("light") },
+    { mode: "dark", theme: terminalThemeFor("dark") },
+  ]) {
+    document.documentElement.dataset.theme = mode;
+    applyTerminalTheme(term, theme);
+    textarea.dispatchEvent(
+      new CompositionEvent("compositionstart", { bubbles: true }),
+    );
+    textarea.dispatchEvent(
+      new CompositionEvent("compositionupdate", {
+        data: "test",
+        bubbles: true,
+      }),
+    );
+    await settle();
+    const composition = termElement.querySelector(".composition-view")!;
+    const style = getComputedStyle(composition);
+    const expected = document.createElement("span");
+    expected.style.color = theme.foreground!;
+    check(
+      composition.classList.contains("active") && style.display !== "none",
+      "IME preedit was not activated",
+    );
+    check(
+      style.color === expected.style.color,
+      "IME preedit did not use the terminal foreground",
+    );
+    check(
+      style.color !== style.backgroundColor,
+      "IME preedit text is invisible against its background",
+    );
+    textarea.dispatchEvent(
+      new CompositionEvent("compositionend", { bubbles: true }),
+    );
+  }
+  delete document.documentElement.dataset.theme;
   term.dispose();
   termElement.remove();
 
@@ -248,6 +307,52 @@ async function run() {
       (theme) => theme.id === selection.dark,
     ),
     "The newly selected theme was not persisted",
+  );
+  const saved = customThemes.find((theme) => theme.id === selection.dark)!;
+  click(`Edit ${saved.name}`);
+  await settle();
+  const editedInput = document.querySelector<HTMLInputElement>(
+    ".terminal-theme-name-field input",
+  )!;
+  setValue.call(editedInput, "Unsaved edit");
+  flushSync(() =>
+    editedInput.dispatchEvent(new Event("input", { bubbles: true })),
+  );
+  // Deliver the state produced by deleting the selected theme in another tab.
+  flushSync(() => {
+    replaceThemes(customThemes.filter((theme) => theme.id !== saved.id));
+    replaceSelection({ ...selection, dark: "herdr-dark" });
+  });
+  const synchronized = JSON.stringify({ customThemes, selection });
+  check(
+    button("Save theme").disabled,
+    "Saving a deleted theme remained enabled",
+  );
+  click("Save theme");
+  check(
+    JSON.stringify({ customThemes, selection }) === synchronized,
+    "Saving a deleted theme changed synchronized state",
+  );
+  check(
+    editedInput.isConnected && editedInput.value === "Unsaved edit",
+    "Deleting the theme discarded its open draft",
+  );
+  check(
+    document
+      .querySelector('[role="alert"]')
+      ?.textContent?.includes("no longer exists") === true,
+    "Missing deleted-theme explanation",
+  );
+  flushSync(() => replaceThemes([...customThemes, saved]));
+  check(
+    !button("Save theme").disabled,
+    "Restoring the theme did not re-enable saving",
+  );
+  click("Save theme");
+  check(
+    customThemes.find((theme) => theme.id === saved.id)?.name ===
+      "Unsaved edit",
+    "The preserved draft could not be saved",
   );
   flushSync(() => root.unmount());
   rootElement.remove();

--- a/web/src/components/TerminalThemeDialog.test.ts
+++ b/web/src/components/TerminalThemeDialog.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import { existsSync } from "node:fs";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 const chrome =
   Bun.env.CHROME_BIN ||
@@ -16,6 +16,7 @@ test.skipIf(!chrome)(
   async () => {
     const dir = await mkdtemp(join(tmpdir(), "terminal-theme-test-"));
     const { promise, resolve } = Promise.withResolvers<unknown>();
+    const assets = new Map<string, Blob>();
     const server = Bun.serve({
       hostname: "127.0.0.1",
       port: 0,
@@ -25,15 +26,13 @@ test.skipIf(!chrome)(
           resolve(await request.json());
           return new Response("ok");
         }
-        if (path === "/test.js") {
-          return new Response(
-            Bun.file(join(dir, "TerminalThemeDialog.browser.js")),
-          );
-        }
+        const asset = assets.get(path);
+        if (asset) return new Response(asset);
         if (path === "/") {
-          return new Response('<body><script src="/test.js"></script></body>', {
-            headers: { "Content-Type": "text/html" },
-          });
+          return new Response(
+            '<head><link rel="stylesheet" href="/TerminalThemeDialog.browser.css"></head><body><script src="/TerminalThemeDialog.browser.js"></script></body>',
+            { headers: { "Content-Type": "text/html" } },
+          );
         }
         return new Response("Not found", { status: 404 });
       },
@@ -47,6 +46,8 @@ test.skipIf(!chrome)(
         target: "browser",
       });
       expect(build.success).toBe(true);
+      for (const asset of build.outputs)
+        assets.set(`/${basename(asset.path)}`, asset);
       const errorOutput = join(dir, "browser.log");
       child = Bun.spawn(
         [

--- a/web/src/components/TerminalThemeDialog.test.ts
+++ b/web/src/components/TerminalThemeDialog.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const chrome =
+  Bun.env.CHROME_BIN ||
+  (process.platform === "darwin" &&
+  existsSync("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome")
+    ? "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    : Bun.which("google-chrome") || Bun.which("chromium"));
+
+test.skipIf(!chrome)(
+  "terminal theme editor preserves focus, palette, and saved themes",
+  async () => {
+    const dir = await mkdtemp(join(tmpdir(), "terminal-theme-test-"));
+    const { promise, resolve } = Promise.withResolvers<unknown>();
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      async fetch(request) {
+        const path = new URL(request.url).pathname;
+        if (path === "/result" && request.method === "POST") {
+          resolve(await request.json());
+          return new Response("ok");
+        }
+        if (path === "/test.js") {
+          return new Response(
+            Bun.file(join(dir, "TerminalThemeDialog.browser.js")),
+          );
+        }
+        if (path === "/") {
+          return new Response('<body><script src="/test.js"></script></body>', {
+            headers: { "Content-Type": "text/html" },
+          });
+        }
+        return new Response("Not found", { status: 404 });
+      },
+    });
+    let child: ReturnType<typeof Bun.spawn> | undefined;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const build = await Bun.build({
+        entrypoints: [join(import.meta.dir, "TerminalThemeDialog.browser.tsx")],
+        outdir: dir,
+        target: "browser",
+      });
+      expect(build.success).toBe(true);
+      const errorOutput = join(dir, "browser.log");
+      child = Bun.spawn(
+        [
+          chrome!,
+          "--headless",
+          "--disable-gpu",
+          "--no-first-run",
+          "--no-default-browser-check",
+          `--user-data-dir=${join(dir, "profile")}`,
+          server.url.href,
+        ],
+        { stdout: "ignore", stderr: Bun.file(errorOutput) },
+      );
+      const failures = await Promise.race([
+        promise,
+        child.exited.then(async (code) => {
+          throw new Error(
+            `Browser exited (${code}): ${await readFile(errorOutput, "utf8")}`,
+          );
+        }),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () => reject(new Error("Browser regression checks timed out")),
+            15_000,
+          );
+        }),
+      ]);
+      expect(failures).toEqual([]);
+    } finally {
+      clearTimeout(timer);
+      if (child) {
+        child.kill();
+        await child.exited;
+      }
+      server.stop(true);
+      await rm(dir, { recursive: true, force: true });
+    }
+  },
+  25_000,
+);

--- a/web/src/components/TerminalThemeDialog.test.ts
+++ b/web/src/components/TerminalThemeDialog.test.ts
@@ -70,7 +70,7 @@ test.skipIf(!chrome)(
         new Promise<never>((_, reject) => {
           timer = setTimeout(
             () => reject(new Error("Browser regression checks timed out")),
-            15_000,
+            30_000,
           );
         }),
       ]);
@@ -85,5 +85,5 @@ test.skipIf(!chrome)(
       await rm(dir, { recursive: true, force: true });
     }
   },
-  25_000,
+  45_000,
 );

--- a/web/src/components/TerminalThemeDialog.tsx
+++ b/web/src/components/TerminalThemeDialog.tsx
@@ -1,0 +1,570 @@
+import { useEffect, useRef, useState } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+import type { ITheme } from "@xterm/xterm";
+import { Check, Copy, Moon, Pencil, Plus, Sun, Trash2 } from "lucide-react";
+import type { ResolvedTheme } from "../appearance";
+import {
+  type CustomTerminalTheme,
+  customTerminalThemeToITheme,
+  defaultTerminalThemeId,
+  MAX_CUSTOM_TERMINAL_THEMES,
+  MAX_TERMINAL_THEME_NAME_LENGTH,
+  resolveTerminalThemeDefinition,
+  TERMINAL_ANSI_COLOR_KEYS,
+  TERMINAL_BASE_COLOR_KEYS,
+  type TerminalThemeColorKey,
+  type TerminalThemeDefinition,
+  TERMINAL_THEME_PRESETS,
+  type TerminalThemeSelection,
+  terminalColorToHex,
+} from "../terminalThemes";
+import { CloseButton } from "./CloseButton";
+import { focusDialogElement } from "./dialogFocus";
+import { ConfirmDialog } from "./ModalDialogs";
+
+// Editor fallback palette for colors a source theme leaves unset (xterm
+// defaults, e.g. Herdr Dark's ANSI colors).
+const EDITOR_FALLBACK_COLORS: Record<TerminalThemeColorKey, string> = {
+  background: "#0b0d12",
+  foreground: "#c9cdd6",
+  cursor: "#c9cdd6",
+  cursorAccent: "#0b0d12",
+  selectionBackground: "#6ea8ff",
+  black: "#000000",
+  red: "#cd0000",
+  green: "#00cd00",
+  yellow: "#cdcd00",
+  blue: "#0000ee",
+  magenta: "#cd00cd",
+  cyan: "#00cdcd",
+  white: "#e5e5e5",
+  brightBlack: "#7f7f7f",
+  brightRed: "#ff0000",
+  brightGreen: "#00ff00",
+  brightYellow: "#ffff00",
+  brightBlue: "#5c5cff",
+  brightMagenta: "#ff00ff",
+  brightCyan: "#00ffff",
+  brightWhite: "#ffffff",
+};
+
+const COLOR_KEY_LABELS: Record<TerminalThemeColorKey, string> = {
+  background: "Background",
+  foreground: "Foreground",
+  cursor: "Cursor",
+  cursorAccent: "Cursor text",
+  selectionBackground: "Selection",
+  black: "Black",
+  red: "Red",
+  green: "Green",
+  yellow: "Yellow",
+  blue: "Blue",
+  magenta: "Magenta",
+  cyan: "Cyan",
+  white: "White",
+  brightBlack: "Bright black",
+  brightRed: "Bright red",
+  brightGreen: "Bright green",
+  brightYellow: "Bright yellow",
+  brightBlue: "Bright blue",
+  brightMagenta: "Bright magenta",
+  brightCyan: "Bright cyan",
+  brightWhite: "Bright white",
+};
+
+const ALL_COLOR_KEYS: readonly TerminalThemeColorKey[] = [
+  ...TERMINAL_BASE_COLOR_KEYS,
+  ...TERMINAL_ANSI_COLOR_KEYS,
+];
+
+const THEME_VARIANTS: readonly { value: ResolvedTheme; label: string }[] = [
+  { value: "dark", label: "Dark mode" },
+  { value: "light", label: "Light mode" },
+];
+
+let nextCustomThemeId = 1;
+
+function newCustomThemeId(): string {
+  return `custom-${Date.now()}-${nextCustomThemeId++}`;
+}
+
+type TerminalThemeDraft = {
+  id: string | null;
+  name: string;
+  variant: ResolvedTheme;
+  colors: Record<TerminalThemeColorKey, string>;
+};
+
+function draftColorsFromITheme(
+  theme: ITheme,
+): Record<TerminalThemeColorKey, string> {
+  const colors = {} as Record<TerminalThemeColorKey, string>;
+  for (const key of ALL_COLOR_KEYS) {
+    colors[key] = terminalColorToHex(theme[key]) || EDITOR_FALLBACK_COLORS[key];
+  }
+  return colors;
+}
+
+function draftFromDefinition(
+  definition: TerminalThemeDefinition,
+  name: string,
+): TerminalThemeDraft {
+  return {
+    id: null,
+    name,
+    variant: definition.variant,
+    colors: draftColorsFromITheme(definition.theme),
+  };
+}
+
+function draftFromCustom(custom: CustomTerminalTheme): TerminalThemeDraft {
+  const colors = {} as Record<TerminalThemeColorKey, string>;
+  for (const key of ALL_COLOR_KEYS) {
+    colors[key] = custom.colors[key]
+      ? terminalColorToHex(custom.colors[key])
+      : EDITOR_FALLBACK_COLORS[key];
+  }
+  return { id: custom.id, name: custom.name, variant: custom.variant, colors };
+}
+
+function TerminalThemePreview({
+  colors,
+}: {
+  colors: Record<TerminalThemeColorKey, string>;
+}) {
+  return (
+    <div
+      className="terminal-theme-preview"
+      style={{ background: colors.background }}
+      aria-hidden="true"
+    >
+      <div className="terminal-theme-preview-lines">
+        <span style={{ color: colors.foreground }}>$ herdr test</span>
+        <span>
+          <i style={{ color: colors.green }}>pass</i>
+          <i style={{ color: colors.red }}>fail</i>
+          <i style={{ color: colors.blue }}>src/main.ts</i>
+        </span>
+      </div>
+      <div className="terminal-theme-dots">
+        {TERMINAL_ANSI_COLOR_KEYS.map((key) => (
+          <span
+            key={key}
+            className="terminal-theme-dot"
+            style={{ background: colors[key] }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+type ThemeCardData = {
+  definition: TerminalThemeDefinition;
+  custom: CustomTerminalTheme | null;
+};
+
+export function TerminalThemeDialog({
+  open,
+  selection,
+  customThemes,
+  onSelectionChange,
+  onCustomThemesChange,
+  onClose,
+}: {
+  open: boolean;
+  selection: TerminalThemeSelection;
+  customThemes: CustomTerminalTheme[];
+  onSelectionChange: (selection: TerminalThemeSelection) => void;
+  onCustomThemesChange: (themes: CustomTerminalTheme[]) => void;
+  onClose: () => void;
+}) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const [draft, setDraft] = useState<TerminalThemeDraft | null>(null);
+  const [pendingDelete, setPendingDelete] =
+    useState<CustomTerminalTheme | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const cancelFocus = focusDialogElement(dialogRef.current);
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      // The delete confirmation handles its own Escape while open.
+      if (pendingDelete) return;
+      event.preventDefault();
+      event.stopPropagation();
+      if (draft) setDraft(null);
+      else onClose();
+    };
+    window.addEventListener("keydown", onKey, { capture: true });
+    return () => {
+      cancelFocus();
+      window.removeEventListener("keydown", onKey, { capture: true });
+    };
+  }, [open, draft, pendingDelete, onClose]);
+
+  useEffect(() => {
+    if (!open) {
+      setDraft(null);
+      setPendingDelete(null);
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  const cardsFor = (variant: ResolvedTheme): ThemeCardData[] => [
+    ...TERMINAL_THEME_PRESETS.filter(
+      (preset) => preset.variant === variant,
+    ).map((definition) => ({ definition, custom: null })),
+    ...customThemes
+      .filter((theme) => theme.variant === variant)
+      .map((custom) => ({
+        custom,
+        definition: {
+          id: custom.id,
+          name: custom.name,
+          variant: custom.variant,
+          builtin: false,
+          theme: customTerminalThemeToITheme(custom),
+        },
+      })),
+  ];
+
+  const selectTheme = (variant: ResolvedTheme, id: string) => {
+    onSelectionChange({ ...selection, [variant]: id });
+  };
+
+  const startNewTheme = (variant: ResolvedTheme) => {
+    const current = resolveTerminalThemeDefinition(
+      variant,
+      selection,
+      customThemes,
+    );
+    setDraft(draftFromDefinition(current, "Custom theme"));
+  };
+
+  const duplicateTheme = (card: ThemeCardData) => {
+    setDraft(
+      draftFromDefinition(card.definition, `${card.definition.name} copy`),
+    );
+  };
+
+  const saveDraft = () => {
+    if (!draft) return;
+    const theme: CustomTerminalTheme = {
+      id: draft.id ?? newCustomThemeId(),
+      name: draft.name.trim() || "Custom theme",
+      variant: draft.variant,
+      colors: { ...draft.colors },
+    };
+    onCustomThemesChange(
+      draft.id
+        ? customThemes.map((custom) =>
+            custom.id === draft.id ? theme : custom,
+          )
+        : [...customThemes, theme],
+    );
+    onSelectionChange({ ...selection, [theme.variant]: theme.id });
+    setDraft(null);
+  };
+
+  const deleteCustomTheme = (theme: CustomTerminalTheme) => {
+    onCustomThemesChange(
+      customThemes.filter((custom) => custom.id !== theme.id),
+    );
+    if (selection.dark === theme.id || selection.light === theme.id) {
+      onSelectionChange({
+        dark:
+          selection.dark === theme.id
+            ? defaultTerminalThemeId("dark")
+            : selection.dark,
+        light:
+          selection.light === theme.id
+            ? defaultTerminalThemeId("light")
+            : selection.light,
+      });
+    }
+  };
+
+  const onCardKeyDown = (
+    event: ReactKeyboardEvent<HTMLButtonElement>,
+    cards: ThemeCardData[],
+    index: number,
+    variant: ResolvedTheme,
+  ) => {
+    const direction =
+      event.key === "ArrowRight" || event.key === "ArrowDown"
+        ? 1
+        : event.key === "ArrowLeft" || event.key === "ArrowUp"
+          ? -1
+          : 0;
+    if (direction === 0) return;
+    event.preventDefault();
+    const nextIndex = (index + direction + cards.length) % cards.length;
+    selectTheme(variant, cards[nextIndex].definition.id);
+    const buttons = event.currentTarget
+      .closest('[role="radiogroup"]')
+      ?.querySelectorAll<HTMLButtonElement>('[role="radio"]');
+    buttons?.[nextIndex]?.focus();
+  };
+
+  const renderSection = (variant: ResolvedTheme, label: string) => {
+    const cards = cardsFor(variant);
+    const canCreate = customThemes.length < MAX_CUSTOM_TERMINAL_THEMES;
+    // A stale selection id (e.g. edited storage) marks no card active; keep
+    // the first card tabbable so the group stays keyboard-reachable.
+    const hasActive = cards.some(
+      (card) => selection[variant] === card.definition.id,
+    );
+    return (
+      <section className="terminal-theme-section" key={variant}>
+        <div className="terminal-theme-section-head">
+          <div>
+            <strong>
+              {variant === "dark" ? (
+                <Moon size={14} aria-hidden="true" />
+              ) : (
+                <Sun size={14} aria-hidden="true" />
+              )}
+              {label}
+            </strong>
+            <span>Used when the app is in {label.toLowerCase()}</span>
+          </div>
+          <button
+            type="button"
+            className="terminal-theme-new-button"
+            disabled={!canCreate}
+            title={
+              canCreate
+                ? `Create a custom theme for ${label.toLowerCase()}`
+                : `Custom theme limit reached (${MAX_CUSTOM_TERMINAL_THEMES})`
+            }
+            onClick={() => startNewTheme(variant)}
+          >
+            <Plus size={14} aria-hidden="true" />
+            New theme
+          </button>
+        </div>
+        <div
+          className="terminal-theme-grid"
+          role="radiogroup"
+          aria-label={`${label} terminal theme`}
+        >
+          {cards.map((card, index) => {
+            const active = selection[variant] === card.definition.id;
+            const custom = card.custom;
+            return (
+              <div
+                key={card.definition.id}
+                className={`terminal-theme-card ${active ? "is-active" : ""}`}
+              >
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={active}
+                  tabIndex={active || (!hasActive && index === 0) ? 0 : -1}
+                  className="terminal-theme-card-select"
+                  onClick={() => selectTheme(variant, card.definition.id)}
+                  onKeyDown={(event) =>
+                    onCardKeyDown(event, cards, index, variant)
+                  }
+                >
+                  <TerminalThemePreview
+                    colors={draftColorsFromITheme(card.definition.theme)}
+                  />
+                  <span className="terminal-theme-card-name">
+                    {active ? <Check size={13} aria-hidden="true" /> : null}
+                    {card.definition.name}
+                    {custom ? <span className="badge">Custom</span> : null}
+                  </span>
+                </button>
+                <span className="terminal-theme-card-actions">
+                  <button
+                    type="button"
+                    aria-label={`Duplicate ${card.definition.name}`}
+                    title="Duplicate as custom theme"
+                    onClick={() => duplicateTheme(card)}
+                  >
+                    <Copy size={13} aria-hidden="true" />
+                  </button>
+                  {custom ? (
+                    <>
+                      <button
+                        type="button"
+                        aria-label={`Edit ${card.definition.name}`}
+                        title="Edit theme"
+                        onClick={() => setDraft(draftFromCustom(custom))}
+                      >
+                        <Pencil size={13} aria-hidden="true" />
+                      </button>
+                      <button
+                        type="button"
+                        aria-label={`Delete ${card.definition.name}`}
+                        title="Delete theme"
+                        onClick={() => setPendingDelete(custom)}
+                      >
+                        <Trash2 size={13} aria-hidden="true" />
+                      </button>
+                    </>
+                  ) : null}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+    );
+  };
+
+  const renderEditor = (current: TerminalThemeDraft) => {
+    const setColor = (key: TerminalThemeColorKey, value: string) => {
+      setDraft({ ...current, colors: { ...current.colors, [key]: value } });
+    };
+    const colorField = (key: TerminalThemeColorKey) => (
+      <label className="terminal-theme-color-field" key={key}>
+        <input
+          type="color"
+          value={current.colors[key]}
+          onChange={(event) => setColor(key, event.target.value)}
+        />
+        <span>{COLOR_KEY_LABELS[key]}</span>
+        <code>{current.colors[key]}</code>
+      </label>
+    );
+    return (
+      <>
+        <div className="modal-head">
+          <div>
+            <h2>{current.id ? "Edit theme" : "New theme"}</h2>
+            <p>Pick colors; the preview updates as you go.</p>
+          </div>
+          <CloseButton onClick={onClose} />
+        </div>
+
+        <div className="terminal-theme-editor">
+          <div className="terminal-theme-editor-top">
+            <label className="form-field terminal-theme-name-field">
+              <span>Theme name</span>
+              <input
+                value={current.name}
+                maxLength={MAX_TERMINAL_THEME_NAME_LENGTH}
+                onChange={(event) =>
+                  setDraft({ ...current, name: event.target.value })
+                }
+              />
+            </label>
+            <div className="terminal-theme-variant-field">
+              <span>Suggested for</span>
+              <div
+                className="config-theme-control"
+                aria-label="Suggested appearance"
+              >
+                {THEME_VARIANTS.map((variant) => (
+                  <button
+                    key={variant.value}
+                    type="button"
+                    aria-pressed={current.variant === variant.value}
+                    className={
+                      current.variant === variant.value ? "is-active" : ""
+                    }
+                    onClick={() =>
+                      setDraft({ ...current, variant: variant.value })
+                    }
+                  >
+                    {variant.value === "dark" ? (
+                      <Moon size={14} />
+                    ) : (
+                      <Sun size={14} />
+                    )}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <TerminalThemePreview colors={current.colors} />
+
+          <div className="terminal-theme-color-group">
+            <strong>Base colors</strong>
+            <div className="terminal-theme-color-grid">
+              {TERMINAL_BASE_COLOR_KEYS.map(colorField)}
+            </div>
+          </div>
+          <div className="terminal-theme-color-group">
+            <strong>ANSI colors</strong>
+            <div className="terminal-theme-color-grid">
+              {TERMINAL_ANSI_COLOR_KEYS.map(colorField)}
+            </div>
+          </div>
+        </div>
+
+        <div className="modal-actions">
+          <button
+            type="button"
+            className="ghost"
+            onClick={() => setDraft(null)}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={!current.name.trim()}
+            onClick={saveDraft}
+          >
+            {current.id ? "Save theme" : "Create theme"}
+          </button>
+        </div>
+      </>
+    );
+  };
+
+  return (
+    <>
+      <div
+        className="modal-backdrop"
+        onMouseDown={() => (draft ? setDraft(null) : onClose())}
+      >
+        <div
+          ref={dialogRef}
+          className="modal terminal-themes-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Terminal themes"
+          tabIndex={-1}
+          onMouseDown={(event) => event.stopPropagation()}
+        >
+          {draft ? (
+            renderEditor(draft)
+          ) : (
+            <>
+              <div className="modal-head">
+                <div>
+                  <h2>Terminal Themes</h2>
+                  <p>
+                    Choose a theme per appearance mode, or create your own from
+                    any preset.
+                  </p>
+                </div>
+                <CloseButton onClick={onClose} />
+              </div>
+              {THEME_VARIANTS.map((variant) =>
+                renderSection(variant.value, variant.label),
+              )}
+            </>
+          )}
+        </div>
+      </div>
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title="Delete theme"
+        message={`Delete "${pendingDelete?.name ?? ""}"? This cannot be undone.`}
+        confirmLabel="Delete"
+        danger
+        onConfirm={() => {
+          if (pendingDelete) deleteCustomTheme(pendingDelete);
+        }}
+        onClose={() => setPendingDelete(null)}
+      />
+    </>
+  );
+}

--- a/web/src/components/TerminalThemeDialog.tsx
+++ b/web/src/components/TerminalThemeDialog.tsx
@@ -30,22 +30,22 @@ const EDITOR_FALLBACK_COLORS: Record<TerminalThemeColorKey, string> = {
   cursor: "#c9cdd6",
   cursorAccent: "#0b0d12",
   selectionBackground: "#6ea8ff",
-  black: "#000000",
-  red: "#cd0000",
-  green: "#00cd00",
-  yellow: "#cdcd00",
-  blue: "#0000ee",
-  magenta: "#cd00cd",
-  cyan: "#00cdcd",
-  white: "#e5e5e5",
-  brightBlack: "#7f7f7f",
-  brightRed: "#ff0000",
-  brightGreen: "#00ff00",
-  brightYellow: "#ffff00",
-  brightBlue: "#5c5cff",
-  brightMagenta: "#ff00ff",
-  brightCyan: "#00ffff",
-  brightWhite: "#ffffff",
+  black: "#2e3436",
+  red: "#cc0000",
+  green: "#4e9a06",
+  yellow: "#c4a000",
+  blue: "#3465a4",
+  magenta: "#75507b",
+  cyan: "#06989a",
+  white: "#d3d7cf",
+  brightBlack: "#555753",
+  brightRed: "#ef2929",
+  brightGreen: "#8ae234",
+  brightYellow: "#fce94f",
+  brightBlue: "#729fcf",
+  brightMagenta: "#ad7fa8",
+  brightCyan: "#34e2e2",
+  brightWhite: "#eeeeec",
 };
 
 const COLOR_KEY_LABELS: Record<TerminalThemeColorKey, string> = {
@@ -184,9 +184,18 @@ export function TerminalThemeDialog({
   const [pendingDelete, setPendingDelete] =
     useState<CustomTerminalTheme | null>(null);
 
+  const editing = draft !== null;
+  const confirmingDelete = pendingDelete !== null;
+  const canCreate = customThemes.length < MAX_CUSTOM_TERMINAL_THEMES;
+
+  useEffect(() => {
+    if (open && !confirmingDelete) {
+      return focusDialogElement(dialogRef.current);
+    }
+  }, [open, editing, confirmingDelete]);
+
   useEffect(() => {
     if (!open) return;
-    const cancelFocus = focusDialogElement(dialogRef.current);
     const onKey = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
       // The delete confirmation handles its own Escape while open.
@@ -198,7 +207,6 @@ export function TerminalThemeDialog({
     };
     window.addEventListener("keydown", onKey, { capture: true });
     return () => {
-      cancelFocus();
       window.removeEventListener("keydown", onKey, { capture: true });
     };
   }, [open, draft, pendingDelete, onClose]);
@@ -250,7 +258,7 @@ export function TerminalThemeDialog({
   };
 
   const saveDraft = () => {
-    if (!draft) return;
+    if (!draft || (!draft.id && !canCreate)) return;
     const theme: CustomTerminalTheme = {
       id: draft.id ?? newCustomThemeId(),
       name: draft.name.trim() || "Custom theme",
@@ -310,7 +318,6 @@ export function TerminalThemeDialog({
 
   const renderSection = (variant: ResolvedTheme, label: string) => {
     const cards = cardsFor(variant);
-    const canCreate = customThemes.length < MAX_CUSTOM_TERMINAL_THEMES;
     // A stale selection id (e.g. edited storage) marks no card active; keep
     // the first card tabbable so the group stays keyboard-reachable.
     const hasActive = cards.some(
@@ -382,7 +389,12 @@ export function TerminalThemeDialog({
                   <button
                     type="button"
                     aria-label={`Duplicate ${card.definition.name}`}
-                    title="Duplicate as custom theme"
+                    title={
+                      canCreate
+                        ? "Duplicate as custom theme"
+                        : `Custom theme limit reached (${MAX_CUSTOM_TERMINAL_THEMES})`
+                    }
+                    disabled={!canCreate}
                     onClick={() => duplicateTheme(card)}
                   >
                     <Copy size={13} aria-hidden="true" />
@@ -498,6 +510,12 @@ export function TerminalThemeDialog({
           </div>
         </div>
 
+        {!current.id && !canCreate ? (
+          <p role="alert">
+            Custom theme limit reached ({MAX_CUSTOM_TERMINAL_THEMES}). Delete a
+            theme before creating another.
+          </p>
+        ) : null}
         <div className="modal-actions">
           <button
             type="button"
@@ -508,7 +526,7 @@ export function TerminalThemeDialog({
           </button>
           <button
             type="button"
-            disabled={!current.name.trim()}
+            disabled={!current.name.trim() || (!current.id && !canCreate)}
             onClick={saveDraft}
           >
             {current.id ? "Save theme" : "Create theme"}

--- a/web/src/components/TerminalThemeDialog.tsx
+++ b/web/src/components/TerminalThemeDialog.tsx
@@ -187,6 +187,8 @@ export function TerminalThemeDialog({
   const editing = draft !== null;
   const confirmingDelete = pendingDelete !== null;
   const canCreate = customThemes.length < MAX_CUSTOM_TERMINAL_THEMES;
+  const missingDraft =
+    draft?.id != null && !customThemes.some((theme) => theme.id === draft.id);
 
   useEffect(() => {
     if (open && !confirmingDelete) {
@@ -258,7 +260,7 @@ export function TerminalThemeDialog({
   };
 
   const saveDraft = () => {
-    if (!draft || (!draft.id && !canCreate)) return;
+    if (!draft || missingDraft || (!draft.id && !canCreate)) return;
     const theme: CustomTerminalTheme = {
       id: draft.id ?? newCustomThemeId(),
       name: draft.name.trim() || "Custom theme",
@@ -475,6 +477,7 @@ export function TerminalThemeDialog({
                   <button
                     key={variant.value}
                     type="button"
+                    aria-label={variant.label}
                     aria-pressed={current.variant === variant.value}
                     className={
                       current.variant === variant.value ? "is-active" : ""
@@ -510,6 +513,12 @@ export function TerminalThemeDialog({
           </div>
         </div>
 
+        {missingDraft ? (
+          <p role="alert">
+            This theme no longer exists. Your unsaved edits are kept here until
+            you close the editor.
+          </p>
+        ) : null}
         {!current.id && !canCreate ? (
           <p role="alert">
             Custom theme limit reached ({MAX_CUSTOM_TERMINAL_THEMES}). Delete a
@@ -526,7 +535,11 @@ export function TerminalThemeDialog({
           </button>
           <button
             type="button"
-            disabled={!current.name.trim() || (!current.id && !canCreate)}
+            disabled={
+              !current.name.trim() ||
+              missingDraft ||
+              (!current.id && !canCreate)
+            }
             onClick={saveDraft}
           >
             {current.id ? "Save theme" : "Create theme"}

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -4,7 +4,7 @@ import {
 } from "@xterm/addon-clipboard";
 import { FitAddon } from "@xterm/addon-fit";
 import { UnicodeGraphemesAddon } from "@xterm/addon-unicode-graphemes";
-import type { IBufferLine, ILink } from "@xterm/xterm";
+import type { IBufferLine, ILink, ITheme } from "@xterm/xterm";
 import { Terminal } from "@xterm/xterm";
 import { Columns2, Keyboard, Maximize2, Rows2, X } from "lucide-react";
 import {
@@ -18,7 +18,6 @@ import {
 } from "react";
 import "@xterm/xterm/css/xterm.css";
 import { bridge, type ConnectionClient } from "../api";
-import type { ResolvedTheme } from "../appearance";
 import { mobileTerminalShortcutExecution } from "../mobileTerminalShortcutAction";
 import {
   defaultMobileTerminalShortcutRows,
@@ -103,7 +102,7 @@ import {
 } from "../terminalResize";
 import { terminalPageScroll, terminalWheelScroll } from "../terminalScroll";
 import { TerminalSelectionDragGuard } from "../terminalSelectionGuard";
-import { applyTerminalTheme, terminalThemeFor } from "../terminalThemes";
+import { applyTerminalTheme } from "../terminalThemes";
 import { paneHasAgentHistory } from "./agentSession";
 import { ConfirmDialog, MessageDialog } from "./ModalDialogs";
 import { TerminalComposer } from "./TerminalComposer";
@@ -414,7 +413,7 @@ export type TerminalWorkspaceFileRequest = {
 
 export function TerminalView({
   paneId,
-  resolvedTheme,
+  terminalTheme,
   showMobileKeys = true,
   mobileShortcuts = defaultMobileTerminalShortcutRows(),
   mobileSideShortcuts = defaultMobileTerminalSideShortcuts(),
@@ -425,7 +424,7 @@ export function TerminalView({
   onOpenWorkspaceFile,
 }: {
   paneId?: string;
-  resolvedTheme: ResolvedTheme;
+  terminalTheme: ITheme;
   showMobileKeys?: boolean;
   mobileShortcuts?: MobileTerminalShortcutRows;
   mobileSideShortcuts?: MobileTerminalSideShortcuts;
@@ -515,7 +514,7 @@ export function TerminalView({
   // fire again, leaving the recreated terminal detached and blank.
   const [termInstance, setTermInstance] = useState<Terminal | null>(null);
   // Theme changes update xterm in place without recreating the terminal.
-  const resolvedThemeRef = useRef(resolvedTheme);
+  const terminalThemeRef = useRef(terminalTheme);
   const fitRef = useRef<FitAddon | null>(null);
   const attachedRef = useRef<string | null>(null);
   const attachingRef = useRef<string | null>(null);
@@ -783,7 +782,7 @@ export function TerminalView({
       disableStdin: composerOpenRef.current,
       fontFamily: FONT_FAMILY,
       ...terminalDensity(),
-      theme: terminalThemeFor(resolvedThemeRef.current),
+      theme: terminalThemeRef.current,
       allowProposedApi: true,
       linkHandler: {
         activate(event, text) {
@@ -2229,9 +2228,9 @@ export function TerminalView({
   ]);
 
   useEffect(() => {
-    resolvedThemeRef.current = resolvedTheme;
-    if (termInstance) applyTerminalTheme(termInstance, resolvedTheme);
-  }, [resolvedTheme, termInstance]);
+    terminalThemeRef.current = terminalTheme;
+    if (termInstance) applyTerminalTheme(termInstance, terminalTheme);
+  }, [terminalTheme, termInstance]);
 
   // Mobile browsers freeze the page while hidden: the socket can die
   // silently, rendering pauses, and composited content may come back blank.

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3721,6 +3721,243 @@ textarea:focus {
   display: block;
   flex: 0 0 auto;
 }
+
+/* ===== terminal theme picker ===== */
+.terminal-themes-modal {
+  width: min(760px, 100%);
+  max-height: min(760px, calc(100dvh - 36px));
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+.terminal-themes-modal .modal-head {
+  align-items: flex-start;
+  margin: 0;
+}
+.terminal-themes-modal .modal-head p {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+.terminal-theme-section {
+  display: grid;
+  gap: 8px;
+}
+.terminal-theme-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.terminal-theme-section-head > div {
+  display: grid;
+  gap: 2px;
+}
+.terminal-theme-section-head strong {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+}
+.terminal-theme-section-head span {
+  font-size: 12px;
+  color: var(--muted);
+}
+.terminal-theme-new-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 30px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel-2);
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 600;
+}
+.terminal-theme-new-button:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--accent) 58%, var(--border));
+  background: var(--accent-soft);
+}
+.terminal-theme-new-button:disabled {
+  opacity: 0.5;
+}
+.terminal-theme-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(158px, 1fr));
+  gap: 10px;
+}
+.terminal-theme-card {
+  position: relative;
+  min-width: 0;
+}
+.terminal-theme-card-select {
+  display: grid;
+  gap: 8px;
+  width: 100%;
+  padding: 8px;
+  border: 1px solid var(--border-soft);
+  border-radius: 12px;
+  background: var(--panel-2);
+  color: var(--text);
+  text-align: left;
+}
+.terminal-theme-card-select:hover {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+}
+.terminal-theme-card-select:focus-visible {
+  outline: none;
+  border-color: color-mix(in srgb, var(--accent) 72%, var(--border));
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.terminal-theme-card.is-active .terminal-theme-card-select {
+  border-color: color-mix(in srgb, var(--accent) 58%, var(--border));
+  background: var(--accent-soft);
+}
+.terminal-theme-preview {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  border-radius: 8px;
+  font-family: monospace;
+}
+.terminal-theme-preview-lines {
+  display: grid;
+  gap: 2px;
+  font-size: 11px;
+  line-height: 1.5;
+  white-space: nowrap;
+  overflow: hidden;
+}
+.terminal-theme-preview-lines > span {
+  display: flex;
+  gap: 10px;
+}
+.terminal-theme-preview-lines i {
+  font-style: normal;
+}
+.terminal-theme-dots {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.terminal-theme-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+.terminal-theme-card-name {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  font-size: 12px;
+  font-weight: 600;
+}
+.terminal-theme-card-name > svg {
+  color: var(--accent);
+  flex: 0 0 auto;
+}
+.terminal-theme-card-actions {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: flex;
+  gap: 4px;
+  opacity: 0;
+  transition: opacity 120ms ease-out;
+}
+.terminal-theme-card:hover .terminal-theme-card-actions,
+.terminal-theme-card:focus-within .terminal-theme-card-actions {
+  opacity: 1;
+}
+@media (hover: none) {
+  .terminal-theme-card-actions {
+    opacity: 1;
+  }
+}
+.terminal-theme-card-actions > button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--panel) 88%, transparent);
+  color: var(--text);
+}
+.terminal-theme-card-actions > button:hover {
+  border-color: color-mix(in srgb, var(--accent) 58%, var(--border));
+  background: var(--panel);
+}
+.terminal-theme-editor {
+  display: grid;
+  gap: 12px;
+}
+.terminal-theme-editor-top {
+  display: flex;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+.terminal-theme-name-field {
+  flex: 1 1 220px;
+}
+.terminal-theme-variant-field {
+  display: grid;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.terminal-theme-color-group {
+  display: grid;
+  gap: 8px;
+}
+.terminal-theme-color-group > strong {
+  font-size: 12px;
+}
+.terminal-theme-color-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 6px;
+}
+.terminal-theme-color-field {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 4px 8px 4px 4px;
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  background: var(--panel-2);
+  font-size: 12px;
+}
+.terminal-theme-color-field input[type="color"] {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: none;
+  cursor: pointer;
+}
+.terminal-theme-color-field code {
+  color: var(--muted);
+  font-size: 11px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .terminal-theme-card-actions {
+    transition: none;
+  }
+}
 .file-explorer-modal {
   width: min(900px, 100%);
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -7612,7 +7612,7 @@ textarea:focus {
 }
 .terminal-view .xterm .composition-view {
   background-color: var(--terminal-canvas-background, var(--terminal-bg));
-  color: var(--terminal-fg);
+  color: var(--terminal-canvas-foreground, var(--terminal-fg));
 }
 .terminal-pane-toolbar {
   position: absolute;

--- a/web/src/terminalThemes.test.ts
+++ b/web/src/terminalThemes.test.ts
@@ -1,6 +1,25 @@
 import { describe, expect, test } from "bun:test";
 import { Terminal } from "@xterm/xterm";
-import { applyTerminalTheme, terminalThemeFor } from "./terminalThemes";
+import {
+  CUSTOM_TERMINAL_THEME_SELECTION_ALPHA,
+  MAX_CUSTOM_TERMINAL_THEMES,
+  TERMINAL_THEME_PRESETS,
+  applyTerminalTheme,
+  customTerminalThemeToITheme,
+  defaultTerminalThemeId,
+  hexToRgba,
+  normalizeCustomTerminalThemes,
+  normalizeTerminalColor,
+  normalizeTerminalThemeSelection,
+  parseCustomTerminalThemes,
+  parseTerminalThemeSelection,
+  resolveTerminalTheme,
+  resolveTerminalThemeDefinition,
+  serializeCustomTerminalThemes,
+  serializeTerminalThemeSelection,
+  terminalColorToHex,
+  terminalThemeFor,
+} from "./terminalThemes";
 
 describe("terminal themes", () => {
   test("changes defaults and the ANSI palette without changing dark defaults", () => {
@@ -19,7 +38,7 @@ describe("terminal themes", () => {
         "\x1b[0;38;2;255;255;255;48;2;80;0;0m X";
       await new Promise<void>((resolve) => term.write(frame, resolve));
       for (const theme of ["light", "dark"] as const) {
-        applyTerminalTheme(term, theme);
+        applyTerminalTheme(term, terminalThemeFor(theme));
         const line = term.buffer.active.getLine(0)!;
         expect(line.getCell(100)?.getBgColor()).toBe(0x282c34);
         expect(line.getCell(101)?.getBgColor()).toBe(0x500000);
@@ -37,7 +56,7 @@ describe("terminal themes", () => {
     const term = new Terminal({ allowProposedApi: true });
     try {
       for (const theme of ["light", "dark"] as const) {
-        applyTerminalTheme(term, theme);
+        applyTerminalTheme(term, terminalThemeFor(theme));
         await new Promise<void>((resolve) =>
           term.write(
             "\x1b[H\x1b[0;38;2;48;2;200;48;2;40;44;52mX" +
@@ -54,5 +73,240 @@ describe("terminal themes", () => {
     } finally {
       term.dispose();
     }
+  });
+});
+
+describe("terminal theme presets", () => {
+  test("have unique ids and valid colors", () => {
+    const ids = new Set<string>();
+    for (const preset of TERMINAL_THEME_PRESETS) {
+      expect(ids.has(preset.id)).toBe(false);
+      ids.add(preset.id);
+      expect(preset.name.length).toBeGreaterThan(0);
+      expect(preset.builtin).toBe(true);
+      expect(preset.theme.background).toMatch(/^#/);
+      expect(preset.theme.foreground).toMatch(/^#/);
+    }
+  });
+
+  test("keep Herdr Dark and Herdr Light as the per-mode defaults", () => {
+    expect(defaultTerminalThemeId("dark")).toBe("herdr-dark");
+    expect(defaultTerminalThemeId("light")).toBe("herdr-light");
+    const dark = TERMINAL_THEME_PRESETS.find(
+      (preset) => preset.id === "herdr-dark",
+    );
+    expect(dark?.theme.red).toBeUndefined();
+    expect(dark?.theme.background).toBe("#0b0d12");
+    const light = TERMINAL_THEME_PRESETS.find(
+      (preset) => preset.id === "herdr-light",
+    );
+    expect(light?.theme.red).toBe("#cf222e");
+  });
+
+  test("include both dark and light variants beyond the defaults", () => {
+    const dark = TERMINAL_THEME_PRESETS.filter(
+      (preset) => preset.variant === "dark",
+    );
+    const light = TERMINAL_THEME_PRESETS.filter(
+      (preset) => preset.variant === "light",
+    );
+    expect(dark.length).toBeGreaterThan(1);
+    expect(light.length).toBeGreaterThan(1);
+  });
+});
+
+describe("custom terminal themes", () => {
+  test("round-trip through serialize and parse", () => {
+    const themes = [
+      {
+        id: "custom-1",
+        name: "My Theme",
+        variant: "dark" as const,
+        colors: {
+          background: "#101010",
+          foreground: "#eeeeee",
+          red: "#ff0000",
+        },
+      },
+    ];
+    expect(
+      parseCustomTerminalThemes(serializeCustomTerminalThemes(themes)),
+    ).toEqual(themes);
+  });
+
+  test("drops invalid entries, normalizes colors, and dedupes ids", () => {
+    const themes = normalizeCustomTerminalThemes([
+      null,
+      {
+        id: "ok",
+        name: "Ok",
+        variant: "dark",
+        colors: { background: "#ABC", foreground: "#EEEEEE" },
+      },
+      {
+        id: "ok",
+        name: "Dupe",
+        variant: "dark",
+        colors: { background: "#111111", foreground: "#222222" },
+      },
+      {
+        id: "herdr-dark",
+        name: "Preset clash",
+        variant: "dark",
+        colors: { background: "#111111", foreground: "#222222" },
+      },
+      {
+        id: "no-fg",
+        name: "Missing fg",
+        variant: "dark",
+        colors: { background: "#111111" },
+      },
+      {
+        id: "mixed",
+        name: "Mixed",
+        variant: "light",
+        colors: {
+          background: "#fafafa",
+          foreground: "#333333",
+          red: "red",
+          cursor: "#ABCDEF99",
+          bogus: "#123456",
+        },
+      },
+    ]);
+    expect(themes.map((theme) => theme.id)).toEqual([
+      "ok",
+      "ok-2",
+      "herdr-dark-2",
+      "mixed",
+    ]);
+    expect(themes[0].colors.background).toBe("#aabbcc");
+    expect(themes[3].colors.red).toBeUndefined();
+    expect(themes[3].colors.cursor).toBe("#abcdef99");
+    expect(themes[3].variant).toBe("light");
+  });
+
+  test("caps the number of custom themes", () => {
+    const many = Array.from(
+      { length: MAX_CUSTOM_TERMINAL_THEMES + 5 },
+      (_, index) => ({
+        id: `theme-${index}`,
+        name: `Theme ${index}`,
+        variant: "dark",
+        colors: { background: "#111111", foreground: "#eeeeee" },
+      }),
+    );
+    expect(normalizeCustomTerminalThemes(many)).toHaveLength(
+      MAX_CUSTOM_TERMINAL_THEMES,
+    );
+  });
+
+  test("parses corrupt storage safely", () => {
+    expect(parseCustomTerminalThemes(null)).toEqual([]);
+    expect(parseCustomTerminalThemes("{oops")).toEqual([]);
+    expect(parseCustomTerminalThemes('{"not":"an array"}')).toEqual([]);
+  });
+
+  test("renders selection with translucency", () => {
+    const theme = customTerminalThemeToITheme({
+      id: "custom-1",
+      name: "Mine",
+      variant: "dark",
+      colors: {
+        background: "#101010",
+        foreground: "#eeeeee",
+        selectionBackground: "#3388ff",
+      },
+    });
+    expect(theme.selectionBackground).toBe(
+      `rgba(51,136,255,${CUSTOM_TERMINAL_THEME_SELECTION_ALPHA})`,
+    );
+    expect(theme.background).toBe("#101010");
+  });
+});
+
+describe("terminal theme selection", () => {
+  test("falls back to per-mode defaults for missing or invalid values", () => {
+    expect(parseTerminalThemeSelection(null)).toEqual({
+      dark: "herdr-dark",
+      light: "herdr-light",
+    });
+    expect(parseTerminalThemeSelection("{oops")).toEqual({
+      dark: "herdr-dark",
+      light: "herdr-light",
+    });
+    expect(
+      normalizeTerminalThemeSelection({ dark: 42, light: "dracula" }),
+    ).toEqual({
+      dark: "herdr-dark",
+      light: "dracula",
+    });
+  });
+
+  test("round-trips through serialize and parse", () => {
+    const selection = { dark: "nord", light: "solarized-light" };
+    expect(
+      parseTerminalThemeSelection(serializeTerminalThemeSelection(selection)),
+    ).toEqual(selection);
+  });
+
+  test("resolves presets and custom themes per mode with default fallback", () => {
+    const custom = normalizeCustomTerminalThemes([
+      {
+        id: "custom-1",
+        name: "Mine",
+        variant: "dark",
+        colors: { background: "#101010", foreground: "#eeeeee" },
+      },
+    ]);
+    expect(
+      resolveTerminalTheme(
+        "dark",
+        { dark: "dracula", light: "github-light" },
+        [],
+      ).background,
+    ).toBe("#282a36");
+    expect(
+      resolveTerminalTheme(
+        "dark",
+        { dark: "custom-1", light: "herdr-light" },
+        custom,
+      ).background,
+    ).toBe("#101010");
+    // Unknown id (e.g. a deleted custom theme) falls back to the mode default.
+    expect(
+      resolveTerminalTheme("light", { dark: "custom-1", light: "gone" }, custom)
+        .background,
+    ).toBe("#f6f7f9");
+    expect(
+      resolveTerminalThemeDefinition(
+        "light",
+        { dark: "custom-1", light: "gone" },
+        custom,
+      ).id,
+    ).toBe("herdr-light");
+  });
+});
+
+describe("terminal color helpers", () => {
+  test("normalizeTerminalColor accepts hex and expands shorthand", () => {
+    expect(normalizeTerminalColor("#ABC")).toBe("#aabbcc");
+    expect(normalizeTerminalColor(" #12AB34 ")).toBe("#12ab34");
+    expect(normalizeTerminalColor("#12ab34cd")).toBe("#12ab34cd");
+    expect(normalizeTerminalColor("red")).toBeNull();
+    expect(normalizeTerminalColor("rgba(1,2,3,0.5)")).toBeNull();
+    expect(normalizeTerminalColor(42)).toBeNull();
+  });
+
+  test("hexToRgba converts hex channels", () => {
+    expect(hexToRgba("#3388ff", 0.3)).toBe("rgba(51,136,255,0.3)");
+    expect(hexToRgba("#38f", 0.5)).toBe("rgba(51,136,255,0.5)");
+  });
+
+  test("terminalColorToHex extracts hex from presets and rgba", () => {
+    expect(terminalColorToHex("#ABCDEF")).toBe("#abcdef");
+    expect(terminalColorToHex("rgba(110,168,255,0.3)")).toBe("#6ea8ff");
+    expect(terminalColorToHex(undefined)).toBe("");
+    expect(terminalColorToHex("not-a-color")).toBe("");
   });
 });

--- a/web/src/terminalThemes.ts
+++ b/web/src/terminalThemes.ts
@@ -1,6 +1,12 @@
 import type { ITheme, Terminal } from "@xterm/xterm";
 import type { ResolvedTheme } from "./appearance";
 
+export const TERMINAL_THEME_SELECTION_STORAGE_KEY = "terminalThemeSelection.v1";
+export const CUSTOM_TERMINAL_THEMES_STORAGE_KEY = "customTerminalThemes.v1";
+export const MAX_CUSTOM_TERMINAL_THEMES = 24;
+export const MAX_TERMINAL_THEME_NAME_LENGTH = 40;
+export const CUSTOM_TERMINAL_THEME_SELECTION_ALPHA = 0.3;
+
 // Dark keeps the historical palette exactly: only background, foreground,
 // cursor, and selection are overridden; ANSI colors stay at xterm defaults.
 const DARK_TERMINAL_THEME: ITheme = {
@@ -37,18 +43,614 @@ const LIGHT_TERMINAL_THEME: ITheme = {
   brightWhite: "#8c959f",
 };
 
+export type TerminalThemeDefinition = {
+  id: string;
+  name: string;
+  variant: ResolvedTheme;
+  builtin: boolean;
+  theme: ITheme;
+};
+
+export type TerminalThemeSelection = {
+  dark: string;
+  light: string;
+};
+
+const NO_RULER_BORDER = "rgba(0,0,0,0)";
+
+export const TERMINAL_THEME_PRESETS: readonly TerminalThemeDefinition[] = [
+  {
+    id: "herdr-dark",
+    name: "Herdr Dark",
+    variant: "dark",
+    builtin: true,
+    theme: DARK_TERMINAL_THEME,
+  },
+  {
+    id: "herdr-light",
+    name: "Herdr Light",
+    variant: "light",
+    builtin: true,
+    theme: LIGHT_TERMINAL_THEME,
+  },
+  {
+    id: "solarized-dark",
+    name: "Solarized Dark",
+    variant: "dark",
+    builtin: true,
+    theme: {
+      background: "#002b36",
+      foreground: "#839496",
+      cursor: "#839496",
+      cursorAccent: "#002b36",
+      overviewRulerBorder: NO_RULER_BORDER,
+      selectionBackground: "rgba(88,110,117,0.35)",
+      black: "#073642",
+      red: "#dc322f",
+      green: "#859900",
+      yellow: "#b58900",
+      blue: "#268bd2",
+      magenta: "#d33682",
+      cyan: "#2aa198",
+      white: "#eee8d5",
+      brightBlack: "#002b36",
+      brightRed: "#cb4b16",
+      brightGreen: "#586e75",
+      brightYellow: "#657b83",
+      brightBlue: "#839496",
+      brightMagenta: "#6c71c4",
+      brightCyan: "#93a1a1",
+      brightWhite: "#fdf6e3",
+    },
+  },
+  {
+    id: "dracula",
+    name: "Dracula",
+    variant: "dark",
+    builtin: true,
+    theme: {
+      background: "#282a36",
+      foreground: "#f8f8f2",
+      cursor: "#f8f8f2",
+      cursorAccent: "#282a36",
+      overviewRulerBorder: NO_RULER_BORDER,
+      selectionBackground: "rgba(68,71,90,0.6)",
+      black: "#21222c",
+      red: "#ff5555",
+      green: "#50fa7b",
+      yellow: "#f1fa8c",
+      blue: "#bd93f9",
+      magenta: "#ff79c6",
+      cyan: "#8be9fd",
+      white: "#f8f8f2",
+      brightBlack: "#6272a4",
+      brightRed: "#ff6e6e",
+      brightGreen: "#69ff94",
+      brightYellow: "#ffffa5",
+      brightBlue: "#d6acff",
+      brightMagenta: "#ff92df",
+      brightCyan: "#a4ffff",
+      brightWhite: "#ffffff",
+    },
+  },
+  {
+    id: "one-dark",
+    name: "One Dark",
+    variant: "dark",
+    builtin: true,
+    theme: {
+      background: "#282c34",
+      foreground: "#abb2bf",
+      cursor: "#528bff",
+      cursorAccent: "#282c34",
+      overviewRulerBorder: NO_RULER_BORDER,
+      selectionBackground: "rgba(62,68,81,0.9)",
+      black: "#3f4451",
+      red: "#e06c75",
+      green: "#98c379",
+      yellow: "#d19a66",
+      blue: "#61afef",
+      magenta: "#c678dd",
+      cyan: "#56b6c2",
+      white: "#abb2bf",
+      brightBlack: "#5c6370",
+      brightRed: "#e06c75",
+      brightGreen: "#98c379",
+      brightYellow: "#d19a66",
+      brightBlue: "#61afef",
+      brightMagenta: "#c678dd",
+      brightCyan: "#56b6c2",
+      brightWhite: "#ffffff",
+    },
+  },
+  {
+    id: "nord",
+    name: "Nord",
+    variant: "dark",
+    builtin: true,
+    theme: {
+      background: "#2e3440",
+      foreground: "#d8dee9",
+      cursor: "#d8dee9",
+      cursorAccent: "#2e3440",
+      overviewRulerBorder: NO_RULER_BORDER,
+      selectionBackground: "rgba(67,76,94,0.7)",
+      black: "#3b4252",
+      red: "#bf616a",
+      green: "#a3be8c",
+      yellow: "#ebcb8b",
+      blue: "#81a1c1",
+      magenta: "#b48ead",
+      cyan: "#88c0d0",
+      white: "#e5e9f0",
+      brightBlack: "#4c566a",
+      brightRed: "#bf616a",
+      brightGreen: "#a3be8c",
+      brightYellow: "#ebcb8b",
+      brightBlue: "#81a1c1",
+      brightMagenta: "#b48ead",
+      brightCyan: "#8fbcbb",
+      brightWhite: "#eceff4",
+    },
+  },
+  {
+    id: "tokyo-night",
+    name: "Tokyo Night",
+    variant: "dark",
+    builtin: true,
+    theme: {
+      background: "#1a1b26",
+      foreground: "#c0caf5",
+      cursor: "#c0caf5",
+      cursorAccent: "#1a1b26",
+      overviewRulerBorder: NO_RULER_BORDER,
+      selectionBackground: "rgba(51,70,124,0.6)",
+      black: "#15161e",
+      red: "#f7768e",
+      green: "#9ece6a",
+      yellow: "#e0af68",
+      blue: "#7aa2f7",
+      magenta: "#bb9af7",
+      cyan: "#7dcfff",
+      white: "#a9b1d6",
+      brightBlack: "#414868",
+      brightRed: "#f7768e",
+      brightGreen: "#9ece6a",
+      brightYellow: "#e0af68",
+      brightBlue: "#7aa2f7",
+      brightMagenta: "#bb9af7",
+      brightCyan: "#7dcfff",
+      brightWhite: "#c0caf5",
+    },
+  },
+  {
+    id: "catppuccin-mocha",
+    name: "Catppuccin Mocha",
+    variant: "dark",
+    builtin: true,
+    theme: {
+      background: "#1e1e2e",
+      foreground: "#cdd6f4",
+      cursor: "#f5e0dc",
+      cursorAccent: "#1e1e2e",
+      overviewRulerBorder: NO_RULER_BORDER,
+      selectionBackground: "rgba(88,91,112,0.5)",
+      black: "#45475a",
+      red: "#f38ba8",
+      green: "#a6e3a1",
+      yellow: "#f9e2af",
+      blue: "#89b4fa",
+      magenta: "#f5c2e7",
+      cyan: "#94e2d5",
+      white: "#bac2de",
+      brightBlack: "#585b70",
+      brightRed: "#f38ba8",
+      brightGreen: "#a6e3a1",
+      brightYellow: "#f9e2af",
+      brightBlue: "#89b4fa",
+      brightMagenta: "#f5c2e7",
+      brightCyan: "#94e2d5",
+      brightWhite: "#a6adc8",
+    },
+  },
+  {
+    id: "github-dark",
+    name: "GitHub Dark",
+    variant: "dark",
+    builtin: true,
+    theme: {
+      background: "#0d1117",
+      foreground: "#e6edf3",
+      cursor: "#e6edf3",
+      cursorAccent: "#0d1117",
+      overviewRulerBorder: NO_RULER_BORDER,
+      selectionBackground: "rgba(56,139,253,0.4)",
+      black: "#484f58",
+      red: "#ff7b72",
+      green: "#3fb950",
+      yellow: "#d29922",
+      blue: "#58a6ff",
+      magenta: "#bc8cff",
+      cyan: "#39c5cf",
+      white: "#b1bac4",
+      brightBlack: "#6e7681",
+      brightRed: "#ffa198",
+      brightGreen: "#56d364",
+      brightYellow: "#e3b341",
+      brightBlue: "#79c0ff",
+      brightMagenta: "#d2a8ff",
+      brightCyan: "#56d4dd",
+      brightWhite: "#f0f6fc",
+    },
+  },
+  {
+    id: "solarized-light",
+    name: "Solarized Light",
+    variant: "light",
+    builtin: true,
+    theme: {
+      background: "#fdf6e3",
+      foreground: "#657b83",
+      cursor: "#657b83",
+      cursorAccent: "#fdf6e3",
+      overviewRulerBorder: NO_RULER_BORDER,
+      selectionBackground: "rgba(238,232,213,0.9)",
+      black: "#073642",
+      red: "#dc322f",
+      green: "#859900",
+      yellow: "#b58900",
+      blue: "#268bd2",
+      magenta: "#d33682",
+      cyan: "#2aa198",
+      white: "#eee8d5",
+      brightBlack: "#002b36",
+      brightRed: "#cb4b16",
+      brightGreen: "#93a1a1",
+      brightYellow: "#839496",
+      brightBlue: "#657b83",
+      brightMagenta: "#6c71c4",
+      brightCyan: "#586e75",
+      brightWhite: "#fdf6e3",
+    },
+  },
+  {
+    id: "github-light",
+    name: "GitHub Light",
+    variant: "light",
+    builtin: true,
+    theme: {
+      background: "#ffffff",
+      foreground: "#1f2328",
+      cursor: "#1f2328",
+      cursorAccent: "#ffffff",
+      overviewRulerBorder: NO_RULER_BORDER,
+      selectionBackground: "rgba(9,105,218,0.2)",
+      black: "#24292f",
+      red: "#cf222e",
+      green: "#116329",
+      yellow: "#4d2d00",
+      blue: "#0969da",
+      magenta: "#8250df",
+      cyan: "#1b7c83",
+      white: "#6e7781",
+      brightBlack: "#57606a",
+      brightRed: "#a40e26",
+      brightGreen: "#1a7f37",
+      brightYellow: "#9a6700",
+      brightBlue: "#218bff",
+      brightMagenta: "#a475f9",
+      brightCyan: "#3192aa",
+      brightWhite: "#8c959f",
+    },
+  },
+  {
+    id: "one-light",
+    name: "One Light",
+    variant: "light",
+    builtin: true,
+    theme: {
+      background: "#fafafa",
+      foreground: "#383a42",
+      cursor: "#526eff",
+      cursorAccent: "#fafafa",
+      overviewRulerBorder: NO_RULER_BORDER,
+      selectionBackground: "rgba(56,58,66,0.12)",
+      black: "#383a42",
+      red: "#e45649",
+      green: "#50a14f",
+      yellow: "#c18401",
+      blue: "#0184bc",
+      magenta: "#a626a4",
+      cyan: "#0997b3",
+      white: "#a0a1a7",
+      brightBlack: "#696c77",
+      brightRed: "#e45649",
+      brightGreen: "#50a14f",
+      brightYellow: "#c18401",
+      brightBlue: "#0184bc",
+      brightMagenta: "#a626a4",
+      brightCyan: "#0997b3",
+      brightWhite: "#d3d3d3",
+    },
+  },
+];
+
+export const TERMINAL_ANSI_COLOR_KEYS = [
+  "black",
+  "red",
+  "green",
+  "yellow",
+  "blue",
+  "magenta",
+  "cyan",
+  "white",
+  "brightBlack",
+  "brightRed",
+  "brightGreen",
+  "brightYellow",
+  "brightBlue",
+  "brightMagenta",
+  "brightCyan",
+  "brightWhite",
+] as const;
+
+export const TERMINAL_BASE_COLOR_KEYS = [
+  "background",
+  "foreground",
+  "cursor",
+  "cursorAccent",
+  "selectionBackground",
+] as const;
+
+export type TerminalThemeColorKey =
+  | (typeof TERMINAL_BASE_COLOR_KEYS)[number]
+  | (typeof TERMINAL_ANSI_COLOR_KEYS)[number];
+
+const TERMINAL_THEME_COLOR_KEYS: readonly TerminalThemeColorKey[] = [
+  ...TERMINAL_BASE_COLOR_KEYS,
+  ...TERMINAL_ANSI_COLOR_KEYS,
+];
+
+export type CustomTerminalTheme = {
+  id: string;
+  name: string;
+  variant: ResolvedTheme;
+  colors: Partial<Record<TerminalThemeColorKey, string>>;
+};
+
+const presetById = new Map(
+  TERMINAL_THEME_PRESETS.map((preset) => [preset.id, preset]),
+);
+
+export function defaultTerminalThemeId(variant: ResolvedTheme): string {
+  return variant === "light" ? "herdr-light" : "herdr-dark";
+}
+
 export function terminalThemeFor(resolvedTheme: ResolvedTheme): ITheme {
   return resolvedTheme === "light" ? LIGHT_TERMINAL_THEME : DARK_TERMINAL_THEME;
 }
 
-export function applyTerminalTheme(
-  term: Terminal,
+export function normalizeTerminalColor(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim().toLowerCase();
+  if (/^#[0-9a-f]{3}$/.test(trimmed)) {
+    return `#${trimmed[1]}${trimmed[1]}${trimmed[2]}${trimmed[2]}${trimmed[3]}${trimmed[3]}`;
+  }
+  if (/^#[0-9a-f]{6}([0-9a-f]{2})?$/.test(trimmed)) return trimmed;
+  return null;
+}
+
+export function hexToRgba(hex: string, alpha: number): string {
+  const normalized = normalizeTerminalColor(hex);
+  if (!normalized) return hex;
+  const red = Number.parseInt(normalized.slice(1, 3), 16);
+  const green = Number.parseInt(normalized.slice(3, 5), 16);
+  const blue = Number.parseInt(normalized.slice(5, 7), 16);
+  return `rgba(${red},${green},${blue},${alpha})`;
+}
+
+// Native color inputs and most palette sources work in hex; rgba() presets keep
+// only their RGB channels when a user duplicates them into a custom theme.
+export function terminalColorToHex(value: string | undefined): string {
+  if (!value) return "";
+  const hex = normalizeTerminalColor(value);
+  if (hex) return hex.slice(0, 7);
+  const rgba = /^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})/.exec(
+    value.trim(),
+  );
+  if (!rgba) return "";
+  const channel = (raw: string) =>
+    Math.min(255, Number.parseInt(raw, 10)).toString(16).padStart(2, "0");
+  return `#${channel(rgba[1])}${channel(rgba[2])}${channel(rgba[3])}`;
+}
+
+export function customTerminalThemeToITheme(
+  custom: CustomTerminalTheme,
+): ITheme {
+  const theme: ITheme = { overviewRulerBorder: NO_RULER_BORDER };
+  for (const key of TERMINAL_THEME_COLOR_KEYS) {
+    const value = custom.colors[key];
+    if (!value) continue;
+    theme[key] =
+      key === "selectionBackground"
+        ? hexToRgba(value, CUSTOM_TERMINAL_THEME_SELECTION_ALPHA)
+        : value;
+  }
+  return theme;
+}
+
+function normalizeThemeName(value: unknown): string {
+  if (typeof value !== "string") return "Custom theme";
+  const clipped = Array.from(value.trim())
+    .slice(0, MAX_TERMINAL_THEME_NAME_LENGTH)
+    .join("");
+  return clipped || "Custom theme";
+}
+
+function normalizeCustomThemeId(
+  value: unknown,
+  index: number,
+  usedIds: Set<string>,
+): string {
+  const requested =
+    typeof value === "string" && /^[A-Za-z0-9_-]{1,64}$/.test(value)
+      ? value
+      : `custom-theme-${index + 1}`;
+  let id = requested;
+  let suffix = 2;
+  while (usedIds.has(id) || presetById.has(id)) {
+    id = `${requested}-${suffix}`;
+    suffix += 1;
+  }
+  usedIds.add(id);
+  return id;
+}
+
+export function normalizeCustomTerminalTheme(
+  value: unknown,
+  index: number,
+  usedIds: Set<string>,
+): CustomTerminalTheme | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  const rawColors =
+    raw.colors && typeof raw.colors === "object"
+      ? (raw.colors as Record<string, unknown>)
+      : null;
+  if (!rawColors) return null;
+  const colors: Partial<Record<TerminalThemeColorKey, string>> = {};
+  for (const key of TERMINAL_THEME_COLOR_KEYS) {
+    const color = normalizeTerminalColor(rawColors[key]);
+    if (color) colors[key] = color;
+  }
+  // A theme without background and foreground cannot render legibly.
+  if (!colors.background || !colors.foreground) return null;
+  return {
+    id: normalizeCustomThemeId(raw.id, index, usedIds),
+    name: normalizeThemeName(raw.name),
+    variant: raw.variant === "light" ? "light" : "dark",
+    colors,
+  };
+}
+
+export function normalizeCustomTerminalThemes(
+  value: unknown,
+): CustomTerminalTheme[] {
+  if (!Array.isArray(value)) return [];
+  const usedIds = new Set<string>();
+  const themes: CustomTerminalTheme[] = [];
+  for (
+    let index = 0;
+    index < Math.min(value.length, MAX_CUSTOM_TERMINAL_THEMES);
+    index += 1
+  ) {
+    const theme = normalizeCustomTerminalTheme(value[index], index, usedIds);
+    if (theme) themes.push(theme);
+  }
+  return themes;
+}
+
+export function parseCustomTerminalThemes(
+  raw: string | null,
+): CustomTerminalTheme[] {
+  if (!raw) return [];
+  try {
+    return normalizeCustomTerminalThemes(JSON.parse(raw));
+  } catch {
+    return [];
+  }
+}
+
+export function serializeCustomTerminalThemes(
+  themes: CustomTerminalTheme[],
+): string {
+  return JSON.stringify(normalizeCustomTerminalThemes(themes));
+}
+
+export function normalizeTerminalThemeSelection(
+  value: unknown,
+): TerminalThemeSelection {
+  const raw =
+    value && typeof value === "object"
+      ? (value as Record<string, unknown>)
+      : {};
+  return {
+    dark:
+      typeof raw.dark === "string" && raw.dark
+        ? raw.dark
+        : defaultTerminalThemeId("dark"),
+    light:
+      typeof raw.light === "string" && raw.light
+        ? raw.light
+        : defaultTerminalThemeId("light"),
+  };
+}
+
+export function parseTerminalThemeSelection(
+  raw: string | null,
+): TerminalThemeSelection {
+  if (!raw) return normalizeTerminalThemeSelection(null);
+  try {
+    return normalizeTerminalThemeSelection(JSON.parse(raw));
+  } catch {
+    return normalizeTerminalThemeSelection(null);
+  }
+}
+
+export function serializeTerminalThemeSelection(
+  selection: TerminalThemeSelection,
+): string {
+  return JSON.stringify(normalizeTerminalThemeSelection(selection));
+}
+
+export function terminalThemeById(
+  id: string,
+  customThemes: CustomTerminalTheme[],
+): TerminalThemeDefinition | null {
+  const preset = presetById.get(id);
+  if (preset) return preset;
+  const custom = customThemes.find((theme) => theme.id === id);
+  if (!custom) return null;
+  return {
+    id: custom.id,
+    name: custom.name,
+    variant: custom.variant,
+    builtin: false,
+    theme: customTerminalThemeToITheme(custom),
+  };
+}
+
+export function resolveTerminalThemeDefinition(
   resolvedTheme: ResolvedTheme,
-) {
+  selection: TerminalThemeSelection,
+  customThemes: CustomTerminalTheme[],
+): TerminalThemeDefinition {
+  const selected = terminalThemeById(selection[resolvedTheme], customThemes);
+  if (selected) return selected;
+  const fallback = presetById.get(defaultTerminalThemeId(resolvedTheme));
+  if (fallback) return fallback;
+  return {
+    id: defaultTerminalThemeId(resolvedTheme),
+    name: resolvedTheme === "light" ? "Herdr Light" : "Herdr Dark",
+    variant: resolvedTheme,
+    builtin: true,
+    theme: terminalThemeFor(resolvedTheme),
+  };
+}
+
+export function resolveTerminalTheme(
+  resolvedTheme: ResolvedTheme,
+  selection: TerminalThemeSelection,
+  customThemes: CustomTerminalTheme[],
+): ITheme {
+  return resolveTerminalThemeDefinition(resolvedTheme, selection, customThemes)
+    .theme;
+}
+
+export function applyTerminalTheme(term: Terminal, theme: ITheme) {
   // The ANSI stream does not distinguish Herdr's resolved default background
   // from an application's explicit RGB background. Preserve both; only xterm
   // defaults and its ANSI palette follow the app theme. No repaint/reset is needed.
-  const theme = terminalThemeFor(resolvedTheme);
   term.options.theme = theme;
   if (theme.background) {
     term.element?.style.setProperty(

--- a/web/src/terminalThemes.ts
+++ b/web/src/terminalThemes.ts
@@ -652,6 +652,10 @@ export function applyTerminalTheme(term: Terminal, theme: ITheme) {
   // from an application's explicit RGB background. Preserve both; only xterm
   // defaults and its ANSI palette follow the app theme. No repaint/reset is needed.
   term.options.theme = theme;
+  term.element?.style.setProperty(
+    "--terminal-canvas-foreground",
+    theme.foreground ?? "",
+  );
   if (theme.background) {
     term.element?.style.setProperty(
       "--terminal-canvas-background",


### PR DESCRIPTION
## Summary

- Add terminal color themes to the Studio frontend: per-mode (dark/light) theme selection that follows the app appearance, via Menu → Appearance → Terminal theme.
- 11 built-in presets with live mini-previews: the existing Herdr Dark/Light defaults (unchanged, still the defaults), Solarized Dark/Light, Dracula, One Dark/Light, Nord, Tokyo Night, Catppuccin Mocha, and GitHub Dark/Light.
- Custom themes: create from the current selection or duplicate any preset, then edit name, suggested mode, and all 21 colors (base + 16 ANSI) with native color pickers and a live preview. Customs can be edited and deleted (with confirmation); deleting a selected theme falls back to the Herdr default. Capped at 24 customs.
- Themes apply live to every open terminal without recreation, persist in localStorage (`terminalThemeSelection.v1`, `customTerminalThemes.v1`), and sync across browser tabs via storage events.

## Implementation notes

- `web/src/terminalThemes.ts` gains the preset registry, strict parse/serialize/normalize for custom themes (hex validation, id dedupe, background/foreground required), and per-mode resolution with default fallback; `applyTerminalTheme` now takes a resolved `ITheme`.
- `TerminalView`'s `resolvedTheme` prop becomes `terminalTheme: ITheme`; App owns selection/custom state and memoizes the resolved theme.
- Theme cards use radiogroup/roving-tabindex semantics with arrow-key navigation; touch devices always show card actions.

## Verification

- `bun run precommit` (format, lint, typecheck, 1235 unit tests incl. 17 terminal-theme tests) and `bun run build:web` pass.
- Browser smoke test against the dev server: dialog rendering, preset selection, custom theme create/save, persistence across reload, and delete-with-fallback all exercised via DOM automation.