### PR TITLE
Reload stale tabs once when lazy chunks 404 after an update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Reload open tabs once when an update removes their cached code chunks, instead
+  of crashing when Changes or a terminal is opened.
+
 - Stabilize split-pane sizing and terminal rendering during navigation and resizing.
 - Show loading and retryable errors while terminal layouts are fetched.
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,7 +16,6 @@ import {
   X,
 } from "lucide-react";
 import {
-  lazy,
   Suspense,
   useCallback,
   useEffect,
@@ -62,6 +61,7 @@ import type { TerminalWorkspaceFileRequest } from "./components/TerminalView";
 import { WorkspaceInspectorHost } from "./components/WorkspaceInspectorHost";
 import { WorkspaceTree } from "./components/WorkspaceTree";
 import { isIosDevice } from "./downloadFile";
+import { lazyWithReload } from "./lazyWithReload";
 import {
   LEGACY_MOBILE_TERMINAL_SHORTCUTS_STORAGE_KEY,
   MOBILE_TERMINAL_SHORTCUTS_STORAGE_KEY,
@@ -140,7 +140,7 @@ const DEFAULT_SIDEBAR = 284;
 const THEME_KEY = "theme";
 const ACCENT_COLOR_KEY = "accentColor";
 const UI_SCALE_KEY = "uiScale";
-const LazyTerminalView = lazy(() =>
+const LazyTerminalView = lazyWithReload(() =>
   import("./components/TerminalView").then((module) => ({
     default: module.TerminalView,
   })),

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -152,7 +152,7 @@ const DEFAULT_SIDEBAR = 284;
 const THEME_KEY = "theme";
 const ACCENT_COLOR_KEY = "accentColor";
 const UI_SCALE_KEY = "uiScale";
-const LazyTerminalView = lazyWithReload(() =>
+const LazyTerminalView = lazyWithReload("terminal-view", () =>
   import("./components/TerminalView").then((module) => ({
     default: module.TerminalView,
   })),

--- a/web/src/components/WorkspaceInspectorHost.tsx
+++ b/web/src/components/WorkspaceInspectorHost.tsx
@@ -71,7 +71,7 @@ import {
 } from "./FilePreviewContent";
 import { workspaceInspectorLayout } from "./workspaceInspectorLayout";
 
-const DiffContentView = lazyWithReload(() =>
+const DiffContentView = lazyWithReload("diff-content-view", () =>
   import("./DiffContentView").then((module) => ({
     default: module.DiffContentView,
   })),

--- a/web/src/components/WorkspaceInspectorHost.tsx
+++ b/web/src/components/WorkspaceInspectorHost.tsx
@@ -12,7 +12,6 @@ import {
   X,
 } from "lucide-react";
 import {
-  lazy,
   Suspense,
   useCallback,
   useEffect,
@@ -39,6 +38,7 @@ import {
   type NewReviewAnnotation,
   type ReviewAnnotation,
 } from "../annotations";
+import { lazyWithReload } from "../lazyWithReload";
 import { store, useStoreSelector } from "../store";
 import { copyTextFromUserGesture } from "../terminalClipboard";
 import { terminalPasteRequest } from "../terminalPaste";
@@ -71,7 +71,7 @@ import {
 } from "./FilePreviewContent";
 import { workspaceInspectorLayout } from "./workspaceInspectorLayout";
 
-const DiffContentView = lazy(() =>
+const DiffContentView = lazyWithReload(() =>
   import("./DiffContentView").then((module) => ({
     default: module.DiffContentView,
   })),

--- a/web/src/lazyWithReload.test.ts
+++ b/web/src/lazyWithReload.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+import { importWithReload } from "./lazyWithReload";
+
+const RELOAD_ATTEMPTED_KEY = "herdr:lazy-chunk-reload";
+
+let storage: Map<string, string>;
+let reloadCount = 0;
+
+beforeEach(() => {
+  storage = new Map();
+  reloadCount = 0;
+  Object.defineProperty(globalThis, "sessionStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => void storage.set(key, value),
+      removeItem: (key: string) => void storage.delete(key),
+    },
+  });
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { location: { reload: mock(() => void (reloadCount += 1)) } },
+  });
+});
+
+afterEach(() => {
+  delete (globalThis as { sessionStorage?: unknown }).sessionStorage;
+  delete (globalThis as { window?: unknown }).window;
+});
+
+test("returns the module and clears the reload marker on success", async () => {
+  storage.set(RELOAD_ATTEMPTED_KEY, "1");
+  const module = await importWithReload(() => Promise.resolve({ ok: true }));
+  expect(module).toEqual({ ok: true });
+  expect(storage.has(RELOAD_ATTEMPTED_KEY)).toBe(false);
+  expect(reloadCount).toBe(0);
+});
+
+test("reloads once when the import fails, then throws on a retry", async () => {
+  const failure = () => Promise.reject(new Error("chunk 404"));
+  const pending = importWithReload(failure);
+  await Promise.resolve();
+  expect(reloadCount).toBe(1);
+  // The first attempt stays pending forever while the page unloads.
+  await expect(
+    Promise.race([pending, Promise.resolve("settled")]),
+  ).resolves.toBe("settled");
+  await expect(importWithReload(failure)).rejects.toThrow("chunk 404");
+  expect(reloadCount).toBe(1);
+});

--- a/web/src/lazyWithReload.test.ts
+++ b/web/src/lazyWithReload.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, expect, mock, test } from "bun:test";
 import { importWithReload } from "./lazyWithReload";
 
-const RELOAD_ATTEMPTED_KEY = "herdr:lazy-chunk-reload";
+const COMPONENT_KEY = "diff-content-view";
+const RELOAD_ATTEMPTED_KEY = `herdr:lazy-chunk-reload:${COMPONENT_KEY}`;
 
 let storage: Map<string, string>;
 let reloadCount = 0;
@@ -30,21 +31,59 @@ afterEach(() => {
 
 test("returns the module and clears the reload marker on success", async () => {
   storage.set(RELOAD_ATTEMPTED_KEY, "1");
-  const module = await importWithReload(() => Promise.resolve({ ok: true }));
+  storage.set("herdr:lazy-chunk-reload:terminal-view", "1");
+  const module = await importWithReload(COMPONENT_KEY, () =>
+    Promise.resolve({ ok: true }),
+  );
   expect(module).toEqual({ ok: true });
   expect(storage.has(RELOAD_ATTEMPTED_KEY)).toBe(false);
+  expect(storage.get("herdr:lazy-chunk-reload:terminal-view")).toBe("1");
   expect(reloadCount).toBe(0);
 });
 
 test("reloads once when the import fails, then throws on a retry", async () => {
   const failure = () => Promise.reject(new Error("chunk 404"));
-  const pending = importWithReload(failure);
+  const pending = importWithReload(COMPONENT_KEY, failure);
   await Promise.resolve();
   expect(reloadCount).toBe(1);
   // The first attempt stays pending forever while the page unloads.
   await expect(
     Promise.race([pending, Promise.resolve("settled")]),
   ).resolves.toBe("settled");
-  await expect(importWithReload(failure)).rejects.toThrow("chunk 404");
+  await expect(importWithReload(COMPONENT_KEY, failure)).rejects.toThrow(
+    "chunk 404",
+  );
   expect(reloadCount).toBe(1);
+});
+
+test("a successful terminal import does not reset a failing diff's reload guard", async () => {
+  const error = new Error("diff chunk 404");
+  const failure = () => Promise.reject(error);
+  void importWithReload(COMPONENT_KEY, failure);
+  await Promise.resolve();
+  expect(reloadCount).toBe(1);
+
+  // TerminalView loads first after a reload; Changes is then opened again.
+  for (let retry = 0; retry < 2; retry++) {
+    await importWithReload("terminal-view", () =>
+      Promise.resolve({ ok: true }),
+    );
+    expect(storage.get(RELOAD_ATTEMPTED_KEY)).toBe("1");
+    await expect(importWithReload(COMPONENT_KEY, failure)).rejects.toBe(error);
+  }
+  expect(reloadCount).toBe(1);
+});
+
+test("each lazy component has its own reload attempt", async () => {
+  const error = new Error("chunk 404");
+  const failure = () => Promise.reject(error);
+  for (const key of [COMPONENT_KEY, "terminal-view"]) {
+    void importWithReload(key, failure);
+    await Promise.resolve();
+  }
+  expect(reloadCount).toBe(2);
+  for (const key of [COMPONENT_KEY, "terminal-view"]) {
+    await expect(importWithReload(key, failure)).rejects.toBe(error);
+  }
+  expect(reloadCount).toBe(2);
 });

--- a/web/src/lazyWithReload.ts
+++ b/web/src/lazyWithReload.ts
@@ -1,21 +1,21 @@
 import { type ComponentType, lazy } from "react";
 
-const RELOAD_ATTEMPTED_KEY = "herdr:lazy-chunk-reload";
-
 // After an in-app update, the restarted server only embeds the new build's
 // hashed chunks, so a lazy import from an older open tab 404s and crashes the
-// root error boundary. Reload once to fetch the fresh index.html; a repeated
-// failure throws the original error instead of looping.
+// root error boundary. Reload each lazy component once to fetch fresh assets;
+// other components loading successfully must not reset its retry guard.
 export async function importWithReload<T>(
+  componentKey: string,
   factory: () => Promise<T>,
 ): Promise<T> {
+  const reloadKey = `herdr:lazy-chunk-reload:${componentKey}`;
   try {
     const module = await factory();
-    sessionStorage.removeItem(RELOAD_ATTEMPTED_KEY);
+    sessionStorage.removeItem(reloadKey);
     return module;
   } catch (error) {
-    if (sessionStorage.getItem(RELOAD_ATTEMPTED_KEY)) throw error;
-    sessionStorage.setItem(RELOAD_ATTEMPTED_KEY, "1");
+    if (sessionStorage.getItem(reloadKey)) throw error;
+    sessionStorage.setItem(reloadKey, "1");
     window.location.reload();
     // Keep the lazy boundary suspended while the page unloads.
     return new Promise<T>(() => {});
@@ -23,7 +23,8 @@ export async function importWithReload<T>(
 }
 
 export function lazyWithReload<C extends ComponentType<any>>(
+  componentKey: string,
   factory: () => Promise<{ default: C }>,
 ) {
-  return lazy(() => importWithReload(factory));
+  return lazy(() => importWithReload(componentKey, factory));
 }

--- a/web/src/lazyWithReload.ts
+++ b/web/src/lazyWithReload.ts
@@ -1,0 +1,29 @@
+import { type ComponentType, lazy } from "react";
+
+const RELOAD_ATTEMPTED_KEY = "herdr:lazy-chunk-reload";
+
+// After an in-app update, the restarted server only embeds the new build's
+// hashed chunks, so a lazy import from an older open tab 404s and crashes the
+// root error boundary. Reload once to fetch the fresh index.html; a repeated
+// failure throws the original error instead of looping.
+export async function importWithReload<T>(
+  factory: () => Promise<T>,
+): Promise<T> {
+  try {
+    const module = await factory();
+    sessionStorage.removeItem(RELOAD_ATTEMPTED_KEY);
+    return module;
+  } catch (error) {
+    if (sessionStorage.getItem(RELOAD_ATTEMPTED_KEY)) throw error;
+    sessionStorage.setItem(RELOAD_ATTEMPTED_KEY, "1");
+    window.location.reload();
+    // Keep the lazy boundary suspended while the page unloads.
+    return new Promise<T>(() => {});
+  }
+}
+
+export function lazyWithReload<C extends ComponentType<any>>(
+  factory: () => Promise<{ default: C }>,
+) {
+  return lazy(() => importWithReload(factory));
+}


### PR DESCRIPTION
## Summary

After an in-app update, the restarted server only embeds the new build's hashed JS chunks. An old open tab still referencing the previous hashes got a 404 on the next lazily loaded chunk (opening Changes or a terminal), and the rejected dynamic import reached the root error boundary as a full-screen crash (`Failed to fetch dynamically imported module` / Safari's `Importing a module script failed`).

This wraps both `React.lazy` sites in a `lazyWithReload` helper: on chunk-import failure it reloads the page once (index.html is served no-cache, so the reload picks up fresh asset URLs), guarded by a sessionStorage marker so a persistent failure surfaces the original error instead of looping.

## Changes

- `web/src/lazyWithReload.ts`: `importWithReload` core + `lazyWithReload` wrapper
- Wire into `LazyTerminalView` (App.tsx) and `DiffContentView` (WorkspaceInspectorHost.tsx)
- Unit tests for success-clears-marker, reload-once, rethrow-after-reload, and pending-while-unloading
- CHANGELOG entry under Unreleased

## Verification

- `bun run test` — 1253 pass, 0 fail
- `bun run typecheck` — clean
- `bun run build:web` — clean, asset budget 118/160 files, 9.5/12 MiB
- eslint clean on changed files (repo-wide lint fails on main already, unrelated)