### PR TITLE
Defer Inspector and file preview loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   or create custom themes with your own colors (Menu → Terminal theme).
 - Stabilize split-pane sizing and terminal rendering during navigation and resizing.
 - Show loading and retryable errors while terminal layouts are fetched.
+- Load the Inspector and file preview on demand to reduce initial JavaScript downloads.
 
 ## 0.6.1 - 2026-09-11
 

--- a/scripts/check-web-assets.mjs
+++ b/scripts/check-web-assets.mjs
@@ -1,10 +1,33 @@
-import { readdir, stat } from "node:fs/promises";
+import { readFile, readdir, stat } from "node:fs/promises";
+import { gzipSync } from "node:zlib";
 import process from "node:process";
 import { fileURLToPath, URL } from "node:url";
 
 const publicRoot = fileURLToPath(new URL("../server/public/", import.meta.url));
 const maxFileCount = 160;
 const maxTotalBytes = 12 * 1024 * 1024;
+const maxInitialJsBytes = 650 * 1024;
+const maxInitialJsGzipBytes = 200 * 1024;
+const maxInitialCssBytes = 192 * 1024;
+
+/** Follow eager imports only; dynamic imports belong to feature budgets. */
+export function initialAssetFiles(manifest) {
+  const entries = Object.keys(manifest).filter((key) => manifest[key].isEntry);
+  if (!entries.length) throw new Error("Vite manifest has no entry points");
+  const visited = new Set();
+  const files = new Set();
+  function visit(key) {
+    if (visited.has(key)) return;
+    const chunk = manifest[key];
+    if (!chunk) throw new Error(`Missing Vite manifest chunk: ${key}`);
+    visited.add(key);
+    files.add(chunk.file);
+    for (const css of chunk.css ?? []) files.add(css);
+    for (const dependency of chunk.imports ?? []) visit(dependency);
+  }
+  for (const entry of entries) visit(entry);
+  return [...files];
+}
 
 async function collectAssetStats(root) {
   const directories = [root];
@@ -29,13 +52,44 @@ async function collectAssetStats(root) {
   return { fileCount, totalBytes };
 }
 
-const { fileCount, totalBytes } = await collectAssetStats(publicRoot);
-const totalMiB = (totalBytes / 1024 / 1024).toFixed(1);
-const message = `web asset budget: ${fileCount}/${maxFileCount} files, ${totalMiB}/${maxTotalBytes / 1024 / 1024} MiB`;
-
-if (fileCount > maxFileCount || totalBytes > maxTotalBytes) {
-  process.stderr.write(`${message.replace("budget:", "budget exceeded:")}\n`);
-  process.exitCode = 1;
-} else {
-  process.stdout.write(`${message}\n`);
+async function checkAssets() {
+  const { fileCount, totalBytes } = await collectAssetStats(publicRoot);
+  let manifest;
+  try {
+    manifest = JSON.parse(
+      await readFile(`${publicRoot}/.vite/manifest.json`, "utf8"),
+    );
+  } catch (cause) {
+    throw new Error(
+      "Cannot read the Vite manifest; run the frontend build first",
+      { cause },
+    );
+  }
+  let jsBytes = 0;
+  let jsGzipBytes = 0;
+  let cssBytes = 0;
+  for (const file of initialAssetFiles(manifest)) {
+    const content = await readFile(`${publicRoot}/${file}`);
+    if (file.endsWith(".js")) {
+      jsBytes += content.length;
+      jsGzipBytes += gzipSync(content).length;
+    } else if (file.endsWith(".css")) {
+      cssBytes += content.length;
+    }
+  }
+  const checks = [
+    ["files", fileCount, maxFileCount, 1, "files"],
+    ["total", totalBytes, maxTotalBytes, 1024 * 1024, "MiB"],
+    ["initial JS", jsBytes, maxInitialJsBytes, 1024, "KiB"],
+    ["initial JS gzip", jsGzipBytes, maxInitialJsGzipBytes, 1024, "KiB"],
+    ["initial CSS", cssBytes, maxInitialCssBytes, 1024, "KiB"],
+  ];
+  for (const [name, actual, max, unit, suffix] of checks) {
+    const exceeded = actual > max;
+    const message = `web asset ${name}: ${(actual / unit).toFixed(1)}/${max / unit} ${suffix}${exceeded ? " (budget exceeded)" : ""}\n`;
+    (exceeded ? process.stderr : process.stdout).write(message);
+    if (exceeded) process.exitCode = 1;
+  }
 }
+
+if (import.meta.main) await checkAssets();

--- a/scripts/check-web-assets.test.js
+++ b/scripts/check-web-assets.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { initialAssetFiles } from "./check-web-assets.mjs";
+
+describe("initial web asset budget", () => {
+  test("counts transitive eager JS/CSS once, without charging lazy features", () => {
+    expect(
+      initialAssetFiles({
+        "index.html": {
+          isEntry: true,
+          file: "app.js",
+          imports: ["shared", "other"],
+          css: ["app.css"],
+          dynamicImports: ["preview"],
+        },
+        shared: { file: "shared.js", imports: ["other"], css: ["shared.css"] },
+        other: { file: "other.js", imports: ["shared"], css: ["shared.css"] },
+        preview: {
+          isDynamicEntry: true,
+          file: "preview.js",
+          css: ["preview.css"],
+        },
+      }).sort(),
+    ).toEqual(["app.css", "app.js", "other.js", "shared.css", "shared.js"]);
+  });
+
+  test("fails closed on missing entry points or missing eager chunks", () => {
+    expect(() => initialAssetFiles({})).toThrow("no entry points");
+    expect(() =>
+      initialAssetFiles({
+        app: { isEntry: true, file: "app.js", imports: ["missing"] },
+      }),
+    ).toThrow("Missing Vite manifest chunk");
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -59,7 +59,6 @@ import { GlobalTooltip } from "./components/GlobalTooltip";
 import { MobileTabSheet } from "./components/MobileTabSheet";
 import { requestClosePane, requestCloseTab, TabBar } from "./components/TabBar";
 import type { TerminalWorkspaceFileRequest } from "./components/TerminalView";
-import { WorkspaceInspectorHost } from "./components/WorkspaceInspectorHost";
 import { WorkspaceTree } from "./components/WorkspaceTree";
 import { isIosDevice } from "./downloadFile";
 import { lazyWithReload } from "./lazyWithReload";
@@ -145,6 +144,12 @@ import {
   writeInspectorPreferences,
   writeResourceFileSelection,
 } from "./workspaceResource";
+
+const WorkspaceInspectorHost = lazyWithReload("workspace-inspector", () =>
+  import("./components/WorkspaceInspectorHost").then((module) => ({
+    default: module.WorkspaceInspectorHost,
+  })),
+);
 
 const MIN_SIDEBAR = 180;
 const MAX_SIDEBAR = 560;
@@ -2952,34 +2957,38 @@ export default function App() {
                       : { height: inspectorState.size }
                 }
               >
-                <WorkspaceInspectorHost
-                  key={`${resourceUiKey}:${resourceOwnerKey(inspectorState.scope)}`}
-                  state={inspectorState}
-                  visible={!mobile || mobileView !== "workspaces"}
-                  workspace={inspectorWorkspace}
-                  historyPane={inspectorHistoryPane}
-                  fileSelection={activeFilePreview}
-                  diffSelection={activeDiff}
-                  connectionClient={connectionClient}
-                  onFileSelectionChange={(selection) =>
-                    handleFilePreviewChange(
-                      resourceStateKey(inspectorState.scope),
-                      selection,
-                    )
-                  }
-                  onDiffSelectionChange={(selection) =>
-                    handleDiffSelectionChange(
-                      resourceStateKey(inspectorState.scope),
-                      selection,
-                    )
-                  }
-                  onOpenDiffFile={openDiffFileInExplorer}
-                  onViewChange={setInspectorView}
-                  onDockChange={setInspectorDock}
-                  onExpandedChange={setInspectorExpanded}
-                  onClose={closeInspector}
-                  onBack={clearInspectorDetail}
-                />
+                <Suspense
+                  fallback={<div role="status">Loading Inspector...</div>}
+                >
+                  <WorkspaceInspectorHost
+                    key={`${resourceUiKey}:${resourceOwnerKey(inspectorState.scope)}`}
+                    state={inspectorState}
+                    visible={!mobile || mobileView !== "workspaces"}
+                    workspace={inspectorWorkspace}
+                    historyPane={inspectorHistoryPane}
+                    fileSelection={activeFilePreview}
+                    diffSelection={activeDiff}
+                    connectionClient={connectionClient}
+                    onFileSelectionChange={(selection) =>
+                      handleFilePreviewChange(
+                        resourceStateKey(inspectorState.scope),
+                        selection,
+                      )
+                    }
+                    onDiffSelectionChange={(selection) =>
+                      handleDiffSelectionChange(
+                        resourceStateKey(inspectorState.scope),
+                        selection,
+                      )
+                    }
+                    onOpenDiffFile={openDiffFileInExplorer}
+                    onViewChange={setInspectorView}
+                    onDockChange={setInspectorDock}
+                    onExpandedChange={setInspectorExpanded}
+                    onClose={closeInspector}
+                    onBack={clearInspectorDetail}
+                  />
+                </Suspense>
               </div>
             ) : null}
           </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -40,6 +40,7 @@ import {
 import { AgentIcon } from "./components/AgentIcon";
 import { paneHasAgentHistory } from "./components/agentSession";
 import { CloseButton } from "./components/CloseButton";
+import { focusIfUnchanged } from "./components/dialogFocus";
 import { CommandCombobox } from "./components/CommandCombobox";
 import { CONFIG_MENU_ID, ConfigMenu } from "./components/ConfigMenu";
 import { ConnectionSwitcher } from "./components/ConnectionSwitcher";
@@ -1130,6 +1131,24 @@ export default function App() {
   const [inspectorState, setInspectorState] =
     useState<WorkspaceInspectorState | null>(null);
   const inspectorStateRef = useRef<WorkspaceInspectorState | null>(null);
+  const inspectorFocusRequestRef = useRef<{
+    state: WorkspaceInspectorState;
+    source: Element | null;
+  } | null>(null);
+  const finishInspectorFocus = useCallback(() => {
+    const request = inspectorFocusRequestRef.current;
+    if (!request) return;
+    if (inspectorStateRef.current !== request.state || !request.state.open) {
+      inspectorFocusRequestRef.current = null;
+      return;
+    }
+    const target = document.querySelector<HTMLElement>(
+      '.workspace-inspector-tabs [role="tab"][aria-selected="true"]',
+    );
+    if (focusIfUnchanged(target, request.source)) {
+      inspectorFocusRequestRef.current = null;
+    }
+  }, []);
   const inspectorReturnFocusRef = useRef<HTMLElement | null>(null);
   const pendingInspectorRequestRef = useRef<WorkspaceInspectorRequest | null>(
     null,
@@ -1414,19 +1433,14 @@ export default function App() {
         setActiveDiff(emptyActiveDiffSelection());
         setActiveFilePreview(emptyActiveFilePreviewSelection());
       }
+      inspectorFocusRequestRef.current = focusInspector
+        ? { state: nextState, source: document.activeElement }
+        : null;
       commitInspectorState(nextState);
       writeInspectorPreferences(localStorage, nextState);
       setSidebarHidden(false);
       if (mobile) setMobileView(view);
-      if (focusInspector) {
-        requestAnimationFrame(() => {
-          document
-            .querySelector<HTMLElement>(
-              '.workspace-inspector-tabs [role="tab"][aria-selected="true"]',
-            )
-            ?.focus();
-        });
-      }
+      if (focusInspector) requestAnimationFrame(finishInspectorFocus);
 
       const selectedPath =
         options.path ??
@@ -1454,6 +1468,7 @@ export default function App() {
     [
       commitInspectorState,
       connectionClient.connectionId,
+      finishInspectorFocus,
       loadInspectorFilePreview,
       mobile,
     ],
@@ -2963,6 +2978,7 @@ export default function App() {
                   <WorkspaceInspectorHost
                     key={`${resourceUiKey}:${resourceOwnerKey(inspectorState.scope)}`}
                     state={inspectorState}
+                    onReady={finishInspectorFocus}
                     visible={!mobile || mobileView !== "workspaces"}
                     workspace={inspectorWorkspace}
                     historyPane={inspectorHistoryPane}

--- a/web/src/components/FileExplorerDialog.tsx
+++ b/web/src/components/FileExplorerDialog.tsx
@@ -2,6 +2,7 @@ import {
   type DragEvent,
   type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
+  Suspense,
   useEffect,
   useMemo,
   useRef,
@@ -24,6 +25,7 @@ import { connectionHttpPath } from "../connectionHttp";
 import { connectionStorageKey } from "../connectionStorage";
 import { downloadFileFromUrl } from "../downloadFile";
 import { gitDiffCode, type GitDiffCode } from "../gitDiffStatus";
+import { lazyWithReload } from "../lazyWithReload";
 import {
   refreshGitDiffSummary,
   retireGitDiffSummaryResource,
@@ -54,11 +56,16 @@ import {
   keyboardContextMenuPoint,
   treeKeyboardAction,
 } from "./treeKeyboard";
-import {
-  FilePreviewContent,
-  type ActiveFilePreviewSelection,
-  type FilePreviewSelectionMeta,
+import type {
+  ActiveFilePreviewSelection,
+  FilePreviewSelectionMeta,
 } from "./FilePreviewContent";
+
+const FilePreviewContent = lazyWithReload("file-preview", () =>
+  import("./FilePreviewContent").then((module) => ({
+    default: module.FilePreviewContent,
+  })),
+);
 
 const LONG_PRESS_MS = 550;
 const LONG_PRESS_MOVE_PX = 10;
@@ -2331,12 +2338,14 @@ function FileExplorerContent({
           </div>
         </div>
         {previewPlacement === "inline" ? (
-          <FilePreviewContent
-            entry={previewEntry}
-            preview={preview}
-            loading={previewLoading}
-            error={previewError}
-          />
+          <Suspense fallback={<div role="status">Loading preview...</div>}>
+            <FilePreviewContent
+              entry={previewEntry}
+              preview={preview}
+              loading={previewLoading}
+              error={previewError}
+            />
+          </Suspense>
         ) : null}
       </div>
       <FileExplorerEntryMenu

--- a/web/src/components/WorkspaceInspectorHost.tsx
+++ b/web/src/components/WorkspaceInspectorHost.tsx
@@ -203,6 +203,7 @@ function InspectorSplitResizer({
 
 export function WorkspaceInspectorHost({
   state,
+  onReady,
   visible,
   workspace,
   historyPane,
@@ -219,6 +220,7 @@ export function WorkspaceInspectorHost({
   onBack,
 }: {
   state: WorkspaceInspectorState;
+  onReady?: () => void;
   visible: boolean;
   workspace?: Workspace;
   historyPane?: Pane;
@@ -237,6 +239,9 @@ export function WorkspaceInspectorHost({
   onBack: () => void;
 }) {
   const hostRef = useRef<HTMLElement | null>(null);
+  useLayoutEffect(() => {
+    onReady?.();
+  }, [onReady]);
   const filesTabRef = useRef<HTMLButtonElement | null>(null);
   const changesTabRef = useRef<HTMLButtonElement | null>(null);
   const historyTabRef = useRef<HTMLButtonElement | null>(null);

--- a/web/src/components/dialogFocus.test.ts
+++ b/web/src/components/dialogFocus.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { focusIfUnchanged } from "./dialogFocus";
+
+function fixture() {
+  const source = { isConnected: true } as Element;
+  const body = {} as HTMLElement;
+  const document = { activeElement: source, body };
+  let focused = 0;
+  const target = {
+    ownerDocument: document,
+    focus: () => {
+      focused += 1;
+      document.activeElement = target;
+    },
+  } as unknown as HTMLElement;
+  return { source, body, document, target, count: () => focused };
+}
+
+describe("deferred Inspector focus", () => {
+  test("waits for the lazy target, then focuses it without repeating", () => {
+    const f = fixture();
+    expect(focusIfUnchanged(null, f.source)).toBe(false);
+    expect(f.count()).toBe(0);
+    expect(focusIfUnchanged(f.target, f.source)).toBe(true);
+    expect(f.document.activeElement).toBe(f.target);
+    expect(focusIfUnchanged(f.target, f.source)).toBe(true);
+    expect(f.count()).toBe(1);
+  });
+
+  test("consumes the request without stealing focus from another control", () => {
+    const f = fixture();
+    f.document.activeElement = {} as Element;
+    expect(focusIfUnchanged(f.target, f.source)).toBe(true);
+    expect(f.count()).toBe(0);
+  });
+
+  test("allows a removed menu opener to fall back to body, but not a user-focused control", () => {
+    const f = fixture();
+    const removed = { isConnected: false } as Element;
+    f.document.activeElement = {} as Element;
+    expect(focusIfUnchanged(f.target, removed)).toBe(true);
+    expect(f.count()).toBe(0);
+    f.document.activeElement = f.body;
+    expect(focusIfUnchanged(f.target, removed)).toBe(true);
+    expect(f.count()).toBe(1);
+  });
+});

--- a/web/src/components/dialogFocus.ts
+++ b/web/src/components/dialogFocus.ts
@@ -1,3 +1,19 @@
+/** Returns false while the target is unmounted; otherwise consumes the request. */
+export function focusIfUnchanged(
+  target: HTMLElement | null,
+  source: Element | null,
+): boolean {
+  if (!target) return false;
+  const document = target.ownerDocument;
+  if (
+    document.activeElement === source ||
+    (source && !source.isConnected && document.activeElement === document.body)
+  ) {
+    target.focus({ preventScroll: true });
+  }
+  return true;
+}
+
 export function focusDialogElement(
   element: HTMLElement | null,
   options: { select?: boolean } = {},

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -18,6 +18,8 @@ export default defineConfig({
     format: "es",
   },
   build: {
+    // The asset check follows static imports from the entry, excluding lazy features.
+    manifest: true,
     // Build straight into the server's static dir so the backend can serve it.
     outDir: "../server/public",
     emptyOutDir: true,


### PR DESCRIPTION
## Summary
- Load the Workspace Inspector and inline file preview on demand, using the existing stale-chunk reload recovery.
- Add manifest-based static-entry JS, gzip and CSS budgets alongside the existing total asset budgets.
- Restore requested Inspector focus after its first lazy mount without stealing focus from another control or a closed Inspector.

This is a bounded first pass for #113, not the complete issue scope. No dependencies or preview features were removed.

## Measurements
Compared with current main (`7a82b46`), the entry bundle drops from approximately 793 KB to 657 KB (about 17%). This defers downloads rather than shrinking the overall asset set; no latency improvement is claimed. The budget covers static entry dependencies, not dynamically loaded terminal code.

## Verification
- `bun run precommit`: 1,275 passed, 1 skipped, 0 failed.
- `bun run build:web`: passed, including asset budgets (initial JS 641.2/650 KiB, gzip 194.9/200 KiB, CSS 178.3/192 KiB).
- `git diff --check`: passed.
- Browser smoke checks covered terminal, Inspector, Markdown/code, Mermaid, working-tree Diff and mobile preview; History was also confirmed by the user before rebasing.
- Final-build browser regression checks passed cold Files, cold/warm Changes, focus moved while loading, close before loading completes, and the explicit no-focus-request path, with no page errors.
- Installed PWA has not been manually tested.

The UI appearance is unchanged; the visible loading fallback and first-mount focus behavior are the intended interaction changes.
