### PR TITLE
Toggle mobile Workspaces panel and document version selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,10 @@ Herdr must already be installed and running. Install the latest standalone
 Herdr Studio binary with:
 
 ```bash
+# Leave empty for latest; set HERDR_GUI_VERSION=X.Y.Z for a specific version (no v prefix).
 curl -fsSL \
   https://github.com/powerfooI/herdr-studio/releases/latest/download/install-herdr-gui.sh \
-  | sh
+  | HERDR_GUI_VERSION= sh
 ```
 
 Make sure `~/.local/bin` is in `PATH`, then start the application:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2699,12 +2699,16 @@ export default function App() {
           mobileView === "workspaces" ? "is-active" : ""
         }`}
         title="Workspaces"
-        aria-label="Show workspaces"
+        aria-label={
+          mobileView === "workspaces" ? "Hide workspaces" : "Show workspaces"
+        }
         aria-pressed={mobileView === "workspaces"}
         aria-hidden={mobileControlsCollapsed}
         tabIndex={mobileControlsCollapsed ? -1 : 0}
         onPointerDown={blurActiveInput}
-        onClick={openWorkspaces}
+        onClick={
+          mobileView === "workspaces" ? activateTerminalSurface : openWorkspaces
+        }
       >
         <PanelTop size={17} />
       </button>


### PR DESCRIPTION
## Summary
- Let the mobile Workspaces button close the panel and return to Session when pressed again; keep keyboard open behavior unchanged.
- Update the accessible label to reflect the open/close action.
- Show HERDR_GUI_VERSION in the README installer command with latest and pinned-version guidance.

## Verification
- `bun run precommit` passed.
- `bun run build:web` passed, including asset budgets.
- Mobile interaction has not been manually verified; no screenshot attached (behavior-only change).

## Manual check
- On mobile, tap Workspaces to open it, then tap it again to close it and return to Session.