### PR TITLE
Fix missing cursors when switching terminal panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- Keep terminal cursors updating across incremental endpoint repaints and split-pane
-  activity, including cursor hide/show transitions.
+- Keep the cursor on the selected terminal pane when switching splits, and preserve
+  cursor updates and hide/show transitions across incremental repaints.
 
 ## 0.6.2 - 2026-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Keep terminal cursors updating across incremental endpoint repaints and split-pane
+  activity, including cursor hide/show transitions.
+
 ## 0.6.2 - 2026-09-11
 
 - Reload open tabs once when an update removes their cached code chunks, instead

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,6 +90,14 @@ cannot replace newer browser selections. This is independent workspace/tab
 navigation, not independent native same-tab pane focus. Legacy navigation,
 topology mutations, and terminal dimensions remain shared.
 
+Active terminal selection and terminal clicks send `terminal.focus` through the
+attached shell's `pane.focus` endpoint so the tab surface supplies that pane's
+cursor. The browser restores its selection after split attachments become ready,
+but does not refocus on streaming frames or routine snapshots. Focus requests are
+serialized per browser across endpoint lanes, superseded queued selections are
+discarded, and attachment ownership and connection leases are rechecked before
+dispatch. Same-tab cursor ownership remains shared with other Herdr clients.
+
 Creation uses explicit context and `focus: false`, adopting returned IDs only
 while the initiating selection and connection lease remain current. Studio-only
 `browser_source` identifies the source terminal, pane, tab, and workspace. The

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,6 +39,11 @@ capabilities. Attachment waits for the initial snapshot. Each terminal crops its
 pane from the server-rendered tab surface and sends semantic input to that pane;
 panes retain their shared layout dimensions.
 
+Incremental surface patches update only the named panes; other pane metadata
+remains available for cropping and cursor delivery. Each patch replaces the
+complete cursor state, including `null` to clear it. Pane topology changes
+require a full surface; patches naming unknown panes are discarded.
+
 `terminal.attach` carries pane content dimensions in `cols`/`rows`. When layout
 is available, the browser also supplies `surface_cols`/`surface_rows` for the
 complete tab, including pane borders but excluding app sidebar/tab-bar insets.

--- a/server/src/bridge/endpoint-client.test.ts
+++ b/server/src/bridge/endpoint-client.test.ts
@@ -97,9 +97,16 @@ function writePane(
   w.varint(0); // pixel_height
 }
 
+type TestPane = {
+  paneId: string;
+  focused?: boolean;
+  mouseReporting?: boolean;
+};
+
 function surfaceFrame(payload: {
   surfaceRevision: number;
   frame: FrameData;
+  panes?: TestPane[];
 }): Buffer {
   const w = new BinWriter();
   w.variant(13); // PaneSurface
@@ -107,8 +114,10 @@ function surfaceFrame(payload: {
   w.varint(1); // projection_revision
   w.varint(payload.surfaceRevision);
   writeFrame(w, payload.frame);
-  w.varint(1); // one pane
-  writePane(w, "w1:p1");
+  const panes = payload.panes ?? [{ paneId: "w1:p1" }];
+  w.varint(panes.length);
+  for (const pane of panes)
+    writePane(w, pane.paneId, pane.focused, pane.mouseReporting);
   w.varint(0); // splits
   w.bool(false); // popup
   // SurfaceGraphicsScene tail: the client stops reading before it.
@@ -119,7 +128,8 @@ function patchFrame(payload: {
   baseSurfaceRevision: number;
   surfaceRevision: number;
   rows: Array<{ x: number; y: number; cells: CellData[] }>;
-  cursor?: { x: number; y: number; visible: boolean; shape: number };
+  cursor?: FrameData["cursor"];
+  panes?: TestPane[];
   mouseReporting?: boolean;
 }): Buffer {
   const w = new BinWriter();
@@ -135,8 +145,12 @@ function patchFrame(payload: {
     w.varint(row.cells.length);
     for (const c of row.cells) writeCell(w, c);
   }
-  w.varint(1);
-  writePane(w, "w1:p1", true, payload.mouseReporting);
+  const panes = payload.panes ?? [
+    { paneId: "w1:p1", mouseReporting: payload.mouseReporting },
+  ];
+  w.varint(panes.length);
+  for (const pane of panes)
+    writePane(w, pane.paneId, pane.focused, pane.mouseReporting);
   w.option(payload.cursor, (cur) => {
     w.varint(cur.x);
     w.varint(cur.y);
@@ -488,6 +502,193 @@ describe("EndpointClient (endpoint generation 1)", () => {
       shape: 1,
     });
     client.close();
+  });
+
+  test("keeps pane metadata through cursor-only hide, clear, and show patches", async () => {
+    const visible = { x: 4, y: 1, visible: true, shape: 5 };
+    const cursors = [
+      visible,
+      { ...visible, visible: false },
+      null,
+      { ...visible, x: 6 },
+    ];
+    const socketPath = await startEndpointServer((_hello, socket) => {
+      socket.write(
+        encodeFrame(
+          surfaceFrame({
+            surfaceRevision: 1,
+            frame: {
+              cells: Array.from({ length: 50 }, () => cell(" ")),
+              width: 10,
+              height: 5,
+              cursor: visible,
+              hyperlinks: [],
+            },
+            panes: [{ paneId: "w1:p1" }, { paneId: "w1:p2", focused: false }],
+          }),
+        ),
+      );
+      for (let i = 1; i < cursors.length; i++) {
+        socket.write(
+          encodeFrame(
+            patchFrame({
+              baseSurfaceRevision: i,
+              surfaceRevision: i + 1,
+              rows: [],
+              panes: [],
+              cursor: cursors[i],
+            }),
+          ),
+        );
+      }
+    });
+    const client = new EndpointClient(socketPath);
+    const surfaces: EndpointSurface[] = [];
+    client.on("surface", (surface) => surfaces.push(surface));
+    try {
+      await client.connect(10, 5);
+      await Bun.sleep(50);
+      expect(surfaces).toHaveLength(cursors.length);
+      for (let i = 0; i < cursors.length; i++) {
+        expect(surfaces[i].frame.cursor).toEqual(cursors[i]);
+        expect(surfaces[i].panes).toEqual(surfaces[0].panes);
+        expect(surfaces[i].panes.map((pane) => pane.paneId)).toEqual([
+          "w1:p1",
+          "w1:p2",
+        ]);
+        expect(surfaces[i].frame.cells).toEqual(surfaces[0].frame.cells);
+      }
+    } finally {
+      client.close();
+    }
+  });
+
+  test("merges partial pane updates without losing other panes or mutating earlier surfaces", async () => {
+    const socketPath = await startEndpointServer((_hello, socket) => {
+      socket.write(
+        encodeFrame(
+          surfaceFrame({
+            surfaceRevision: 1,
+            frame: {
+              cells: Array.from({ length: 50 }, () => cell(" ")),
+              width: 10,
+              height: 5,
+              cursor: null,
+              hyperlinks: [],
+            },
+            panes: [{ paneId: "w1:p1" }, { paneId: "w1:p2", focused: false }],
+          }),
+        ),
+      );
+      socket.write(
+        encodeFrame(
+          patchFrame({
+            baseSurfaceRevision: 1,
+            surfaceRevision: 2,
+            rows: [{ x: 1, y: 0, cells: [cell("a")] }],
+            panes: [{ paneId: "w1:p2", focused: false, mouseReporting: true }],
+            cursor: { x: 4, y: 1, visible: true, shape: 5 },
+          }),
+        ),
+      );
+      socket.write(
+        encodeFrame(
+          patchFrame({
+            baseSurfaceRevision: 2,
+            surfaceRevision: 3,
+            rows: [],
+            panes: [{ paneId: "w1:p1", mouseReporting: true }],
+            cursor: null,
+          }),
+        ),
+      );
+    });
+    const client = new EndpointClient(socketPath);
+    const surfaces: EndpointSurface[] = [];
+    client.on("surface", (surface) => surfaces.push(surface));
+    try {
+      await client.connect(10, 5);
+      await Bun.sleep(50);
+      expect(surfaces).toHaveLength(3);
+      expect(
+        surfaces.map((surface) =>
+          surface.panes.map((pane) => [pane.paneId, pane.mouseReporting]),
+        ),
+      ).toEqual([
+        [
+          ["w1:p1", false],
+          ["w1:p2", false],
+        ],
+        [
+          ["w1:p1", false],
+          ["w1:p2", true],
+        ],
+        [
+          ["w1:p1", true],
+          ["w1:p2", true],
+        ],
+      ]);
+      expect(surfaces[0].frame.cells[1].symbol).toBe(" ");
+      expect(surfaces[1].frame.cells[1].symbol).toBe("a");
+      expect(surfaces[1].frame.cursor?.visible).toBe(true);
+      expect(surfaces[2].frame.cursor).toBeNull();
+    } finally {
+      client.close();
+    }
+  });
+
+  test("rejects unknown-pane patches without changing the retained surface", async () => {
+    const base: FrameData = {
+      cells: Array.from({ length: 50 }, () => cell(" ")),
+      width: 10,
+      height: 5,
+      cursor: null,
+      hyperlinks: [],
+    };
+    const socketPath = await startEndpointServer((_hello, socket) => {
+      socket.write(
+        encodeFrame(surfaceFrame({ surfaceRevision: 1, frame: base })),
+      );
+      socket.write(
+        encodeFrame(
+          patchFrame({
+            baseSurfaceRevision: 1,
+            surfaceRevision: 2,
+            rows: [{ x: 0, y: 0, cells: [cell("X")] }],
+            panes: [{ paneId: "unknown" }],
+            cursor: { x: 4, y: 1, visible: true, shape: 5 },
+          }),
+        ),
+      );
+      socket.write(
+        encodeFrame(
+          patchFrame({
+            baseSurfaceRevision: 1,
+            surfaceRevision: 3,
+            rows: [{ x: 1, y: 0, cells: [cell("Y")] }],
+            panes: [],
+            cursor: null,
+          }),
+        ),
+      );
+    });
+    const client = new EndpointClient(socketPath);
+    const surfaces: EndpointSurface[] = [];
+    client.on("surface", (surface) => surfaces.push(surface));
+    try {
+      await client.connect(10, 5);
+      await Bun.sleep(50);
+      expect(surfaces.map((surface) => surface.surfaceRevision)).toEqual([
+        1, 3,
+      ]);
+      expect(surfaces[0].frame).toEqual(base);
+      expect(surfaces[1].frame.cells[0].symbol).toBe(" ");
+      expect(surfaces[1].frame.cells[1].symbol).toBe("Y");
+      expect(surfaces[1].frame.cursor).toBeNull();
+      expect(surfaces[1].panes).toEqual(surfaces[0].panes);
+    } finally {
+      client.close();
+    }
   });
 
   test("encodes resize and answers health pings with a pong", async () => {

--- a/server/src/bridge/endpoint-client.ts
+++ b/server/src/bridge/endpoint-client.ts
@@ -495,10 +495,20 @@ export class EndpointClient extends EventEmitter {
       // ponytail: no resend request; the server repaints on focus/resize.
       return;
     }
+    // Patches carry only changed pane metadata, not the complete pane list.
+    // Keep the other panes so cursor-only updates still reach their sessions.
+    const nextPanes = current.panes.slice();
+    for (const pane of panes) {
+      const index = nextPanes.findIndex((p) => p.paneId === pane.paneId);
+      // Topology changes require a full surface; do not apply a partial one.
+      if (index < 0) return;
+      nextPanes[index] = pane;
+    }
     const { frame } = current;
     // Copy before patching: consumers may retain earlier emitted frames.
     const cells = frame.cells.slice();
-    const nextFrame: FrameData = { ...frame, cells };
+    // The cursor is the final state, including null when it is cleared.
+    const nextFrame: FrameData = { ...frame, cells, cursor };
     for (const { x, y, cells: rowCells } of rows) {
       if (y >= frame.height) continue;
       const offset = y * frame.width + x;
@@ -506,8 +516,7 @@ export class EndpointClient extends EventEmitter {
         cells[offset + j] = rowCells[j];
       }
     }
-    if (cursor) nextFrame.cursor = cursor;
-    this.surface = { frame: nextFrame, surfaceRevision, panes };
+    this.surface = { frame: nextFrame, surfaceRevision, panes: nextPanes };
     this.emit("surface", this.surface);
   }
 }

--- a/server/src/bridge/endpoint-terminal-session.test.ts
+++ b/server/src/bridge/endpoint-terminal-session.test.ts
@@ -162,6 +162,9 @@ async function startSessionServer(handlers: {
   onPaneInput?: (paneId: string, reader: BinReader) => void;
   panes?: TestPane[];
   onConnection?: (sendSurface: (panes: TestPane[]) => void) => void;
+  onPatchConnection?: (
+    send: (cursor: FrameData["cursor"], panes: TestPane[]) => void,
+  ) => void;
   onClipboardConnection?: (send: (data: string) => void) => void;
   onDisconnectConnection?: (disconnect: () => void) => void;
   initialSurface?: { frame: FrameData; panes: TestPane[] };
@@ -208,6 +211,33 @@ async function startSessionServer(handlers: {
     handlers.onConnection?.((panes) =>
       socket.write(encodeFrame(surfaceFrame(++revision, frame, panes))),
     );
+    handlers.onPatchConnection?.((cursor, panes) => {
+      const w = new BinWriter();
+      w.variant(19); // PaneSurfacePatch
+      w.string("boot-1");
+      w.varint(1); // projection_revision
+      w.varint(revision);
+      w.varint(++revision);
+      w.varint(0); // cursor/metadata-only patch: no changed rows
+      w.varint(panes.length);
+      for (const pane of panes)
+        writePane(
+          w,
+          pane.paneId,
+          pane.x,
+          0,
+          pane.mouseReporting,
+          pane.rect,
+          pane.innerRect,
+        );
+      w.option(cursor, (cur) => {
+        w.varint(cur.x);
+        w.varint(cur.y);
+        w.bool(cur.visible);
+        w.u8(cur.shape);
+      });
+      socket.write(encodeFrame(w.toBuffer()));
+    });
     socket.on("data", (chunk) => {
       input = Buffer.concat([
         input,
@@ -310,6 +340,68 @@ async function startSessionServer(handlers: {
   });
   return socketPath;
 }
+
+test.each(["cursor only", "other split pane"])(
+  "restores a hidden cursor when a patch updates %s",
+  async (update) => {
+    const initial: FrameData = {
+      cells: Array.from({ length: 100 }, () => cell(" ")),
+      width: 20,
+      height: 5,
+      cursor: null,
+      hyperlinks: [],
+    };
+    const panes = [
+      { paneId: "w1:p1", x: 0, mouseReporting: false },
+      { paneId: "w1:p2", x: 10, mouseReporting: true },
+    ];
+    let sendPatch!: (cursor: FrameData["cursor"], panes: TestPane[]) => void;
+    const socketPath = await startSessionServer({
+      initialSurface: { frame: initial, panes },
+      onPatchConnection: (send) => {
+        sendPatch = send;
+      },
+    });
+    const session = new EndpointTerminalSession(
+      socketPath,
+      "terminal",
+      async () => "w1:p1",
+    );
+    const frames: Array<{
+      frame: FrameData;
+      bytes: Buffer;
+      mouseReporting: boolean;
+    }> = [];
+    session.on("terminal", (frame) => frames.push(frame));
+    try {
+      await session.connect(8, 3, { cols: 20, rows: 5 });
+      expect(frames.at(-1)?.bytes.toString()).toEndWith("\x1b[?25l");
+      const changedPanes = update === "cursor only" ? [] : [panes[1]];
+      const visible = { x: 2, y: 2, visible: true, shape: 5 };
+      for (const cursor of [
+        visible,
+        null,
+        { ...visible, visible: false },
+        { ...visible, x: 3 },
+      ]) {
+        const count = frames.length;
+        sendPatch(cursor, changedPanes);
+        await Bun.sleep(50);
+        expect(frames).toHaveLength(count + 1);
+        const result = frames.at(-1)!;
+        expect(result.frame.cursor).toEqual(
+          cursor ? { ...cursor, x: cursor.x - 1, y: cursor.y - 1 } : null,
+        );
+        expect(result.mouseReporting).toBe(false);
+        expect(result.bytes.toString()).toEndWith(
+          cursor?.visible ? "\x1b[5 q\x1b[?25h" : "\x1b[?25l",
+        );
+      }
+    } finally {
+      session.close();
+    }
+  },
+);
 
 function splitSurface(cols: number, rows: number, count = 2) {
   const frame: FrameData = {

--- a/server/src/bridge/endpoint-terminal-session.test.ts
+++ b/server/src/bridge/endpoint-terminal-session.test.ts
@@ -2451,3 +2451,160 @@ test("reconnect replaces advertisements while other connection runtimes retain t
     b.bridge.dispose();
   }
 });
+
+describe("attached endpoint cursor focus", () => {
+  test("focuses an owned attachment without input and rejects other viewers", async () => {
+    const requests: Array<{ method: string; params: any }> = [];
+    const inputs: string[] = [];
+    const socketPath = await startSessionServer({
+      onRequest: (method, params) => {
+        requests.push({ method, params });
+      },
+      onPaneInput: (paneId) => inputs.push(paneId),
+    });
+    const { bridge, ws, replies, attach } = creationBridge(socketPath);
+    try {
+      await attach();
+      requests.length = 0;
+      await bridge.handleTerminalRpc(ws, "focus", "terminal.focus", {
+        terminal_id: "term1",
+      });
+      expect(requests).toEqual([
+        { method: "pane.focus", params: { pane_id: "w1:p1" } },
+      ]);
+      expect(replies.find((r) => r.id === "focus")?.result).toEqual({
+        ok: true,
+      });
+      await bridge.handleTerminalRpc(
+        {} as ServerWebSocket<unknown>,
+        "other",
+        "terminal.focus",
+        { terminal_id: "term1" },
+      );
+      await bridge.handleTerminalRpc(ws, "unknown", "terminal.focus", {
+        terminal_id: "missing",
+      });
+      expect(replies.find((r) => r.id === "other")?.error).toBeDefined();
+      expect(replies.find((r) => r.id === "unknown")?.error).toBeDefined();
+      expect(requests).toHaveLength(1);
+      expect(inputs).toEqual([]);
+    } finally {
+      bridge.dispose();
+    }
+  });
+
+  for (const invalidation of [
+    "none",
+    "detach",
+    "replace",
+    "lease",
+    "disconnect",
+    "dispose",
+  ] as const) {
+    test(`waits for attachment readiness and handles ${invalidation}`, async () => {
+      const lookup = deferred<string>();
+      let lookupCount = 0;
+      let current = true;
+      const requests: string[] = [];
+      const socketPath = await startSessionServer({
+        onRequest: (method) => {
+          requests.push(method);
+        },
+      });
+      const { bridge, ws, replies, attach } = creationBridge(socketPath, {
+        lookup: async () => (++lookupCount === 1 ? lookup.promise : "w1:p1"),
+      });
+      try {
+        const attaching = attach();
+        await settleUntil(() => lookupCount === 1);
+        const focusing = bridge.handleTerminalRpc(
+          ws,
+          "focus",
+          "terminal.focus",
+          { terminal_id: "term1" },
+          () => current,
+        );
+        await Bun.sleep(10);
+        expect(requests).toEqual([]);
+        expect(replies.find((r) => r.id === "focus")).toBeUndefined();
+        if (invalidation === "lease") current = false;
+        else if (invalidation === "dispose") bridge.dispose();
+        else if (invalidation === "disconnect") bridge.cleanupWs(ws);
+        else if (invalidation !== "none") {
+          await bridge.handleTerminalRpc(ws, "detach", "terminal.detach", {
+            terminal_id: "term1",
+          });
+          if (invalidation === "replace") await attach("replacement");
+        }
+        lookup.resolve("w1:p1");
+        await Promise.all([attaching, focusing]);
+        const response = replies.find((r) => r.id === "focus");
+        if (invalidation === "none") {
+          expect(response?.result).toEqual({ ok: true });
+          expect(requests).toEqual(["pane.focus", "pane.focus"]);
+        } else {
+          expect(response?.error).toBeDefined();
+          expect(requests).toHaveLength(
+            invalidation === "lease" || invalidation === "replace" ? 1 : 0,
+          );
+        }
+      } finally {
+        bridge.dispose();
+      }
+    });
+  }
+
+  for (const supersede of [false, true]) {
+    test(`orders focus across endpoint lanes${supersede ? " and drops superseded selections" : ""}`, async () => {
+      const hold = deferred<void>();
+      const requests: string[] = [];
+      let block = false;
+      const socketPath = await startSessionServer({
+        panes: [
+          { paneId: "w1:p1", x: 0, mouseReporting: false },
+          { paneId: "w1:p2", x: 10, mouseReporting: false },
+        ],
+        onRequest: async (method, params) => {
+          if (method !== "pane.focus") return;
+          requests.push(params.pane_id);
+          if (block && requests.length === 1) await hold.promise;
+        },
+      });
+      const { bridge, ws, replies, attach } = creationBridge(socketPath, {
+        lookup: async (id) => (id === "term1" ? "w1:p1" : "w1:p2"),
+      });
+      try {
+        await attach();
+        await bridge.handleTerminalRpc(ws, "attach2", "terminal.attach", {
+          terminal_id: "term2",
+          cols: 8,
+          rows: 3,
+          relay_active: false,
+        });
+        requests.length = 0;
+        block = true;
+        const focus = (id: string, terminalId: string) =>
+          bridge.handleTerminalRpc(ws, id, "terminal.focus", {
+            terminal_id: terminalId,
+          });
+        const first = focus("first", "term1");
+        await settleUntil(() => requests.length === 1);
+        const second = focus("second", "term2");
+        const third = supersede ? focus("third", "term1") : Promise.resolve();
+        await Bun.sleep(20);
+        expect(requests).toEqual(["w1:p1"]);
+        hold.resolve();
+        await Promise.all([first, second, third]);
+        expect(requests).toEqual(["w1:p1", supersede ? "w1:p1" : "w1:p2"]);
+        expect(
+          replies
+            .filter((r) => ["first", "second", "third"].includes(r.id))
+            .every((r) => r.result?.ok),
+        ).toBe(true);
+      } finally {
+        hold.resolve();
+        bridge.dispose();
+      }
+    });
+  }
+});

--- a/server/src/bridge/endpoint-terminal-session.ts
+++ b/server/src/bridge/endpoint-terminal-session.ts
@@ -104,7 +104,8 @@ export class EndpointTerminalSession extends EventEmitter {
       }
       this.paneId = paneId;
       // Focus scopes this shell's surface to the pane's tab; per-client
-      // focus in Herdr 0.9.0 keeps this from moving other clients.
+      // tab navigation leaves other clients on their own tabs. Same-tab
+      // pane focus remains shared and determines which pane has a cursor.
       await this.enqueueCommand(() =>
         this.client.callEndpoint("pane.focus", { pane_id: paneId }),
       );
@@ -156,6 +157,15 @@ export class EndpointTerminalSession extends EventEmitter {
     const task = this.commandChain.then(bounded, bounded);
     this.commandChain = task.catch(() => undefined);
     return task;
+  }
+
+  /** Select the cursor owner using this shell's scoped endpoint lane. */
+  focus(isCurrent: () => boolean): Promise<void> {
+    return this.enqueueCommand(async () => {
+      if (!isCurrent()) return;
+      if (!this.paneId) throw new Error("Endpoint terminal is not ready");
+      await this.client.callEndpoint("pane.focus", { pane_id: this.paneId });
+    });
   }
 
   /** Reuse the attached shell/clipboard lane; never refocus it for creation. */

--- a/server/src/bridge/terminal-bridge.ts
+++ b/server/src/bridge/terminal-bridge.ts
@@ -95,6 +95,10 @@ export function createTerminalBridge(args: {
     ServerWebSocket<unknown>,
     Map<string, object>
   >();
+  // Different panes have different endpoint lanes. Preserve each browser's
+  // selection order across them, and discard superseded queued selections.
+  const focusIntents = new Map<ServerWebSocket<unknown>, object>();
+  const focusChains = new Map<ServerWebSocket<unknown>, Promise<void>>();
   let clipboardRelay: ThinClient | null = null;
   let clipboardRelayConnecting: Promise<void> | null = null;
   let clipboardTarget: ClipboardTarget | null = null;
@@ -994,6 +998,42 @@ export function createTerminalBridge(args: {
         });
         return reply({ ok: true });
       }
+      if (method === "terminal.focus") {
+        if (!thin || thin.isClosed || !shared || !requestedTerminalId) {
+          return fail(NO_TERMINAL_ATTACHED_MESSAGE);
+        }
+        // Legacy streams already have their own per-terminal cursor.
+        if (!(thin instanceof EndpointTerminalSession))
+          return reply({ ok: true });
+        const intent = {};
+        const token = attachmentTokens.get(ws)?.get(requestedTerminalId);
+        focusIntents.set(ws, intent);
+        const run = async () => {
+          if (focusIntents.get(ws) !== intent) return;
+          const validateAttachment = await waitForOwnedTerminal(
+            ws,
+            requestedTerminalId,
+            shared,
+            () =>
+              requestIsCurrent() &&
+              attachmentTokens.get(ws)?.get(requestedTerminalId) === token,
+          );
+          await thin.focus(() => {
+            validateAttachment();
+            return focusIntents.get(ws) === intent;
+          });
+        };
+        const previous = focusChains.get(ws) ?? Promise.resolve();
+        const task = previous.then(run, run);
+        focusChains.set(ws, task);
+        try {
+          await task;
+        } finally {
+          if (focusChains.get(ws) === task) focusChains.delete(ws);
+          if (focusIntents.get(ws) === intent) focusIntents.delete(ws);
+        }
+        return reply({ ok: true });
+      }
       if (method === "terminal.input") {
         if (!thin || thin.isClosed || !shared || !requestedTerminalId) {
           return fail(NO_TERMINAL_ATTACHED_MESSAGE);
@@ -1067,6 +1107,8 @@ export function createTerminalBridge(args: {
   }
 
   function cleanupWs(ws: ServerWebSocket<unknown>) {
+    focusIntents.delete(ws);
+    focusChains.delete(ws);
     detachTerminalViewer(ws);
   }
 
@@ -1101,6 +1143,8 @@ export function createTerminalBridge(args: {
     sharedTerminals.clear();
     terminalViewers.clear();
     attachmentTokens.clear();
+    focusIntents.clear();
+    focusChains.clear();
     terminals.clear();
   }
 

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -27,7 +27,7 @@ import {
   type MobileTerminalSideShortcuts,
   mobileTerminalShortcutOption,
 } from "../mobileTerminalShortcuts";
-import { paneCanClose } from "../paneJump";
+import { activePaneIdForSnapshot, paneCanClose } from "../paneJump";
 import {
   shallowEqual,
   store,
@@ -112,6 +112,23 @@ import { applyTerminalTheme } from "../terminalThemes";
 import { paneHasAgentHistory } from "./agentSession";
 import { ConfirmDialog, MessageDialog } from "./ModalDialogs";
 import { TerminalComposer } from "./TerminalComposer";
+
+function focusTerminalEndpoint(
+  client: ConnectionClient,
+  terminalId: string | undefined,
+) {
+  if (
+    !terminalId ||
+    !client.isCurrent() ||
+    !store
+      .get()
+      .endpointAvailability[terminalId]?.methods.includes("pane.focus")
+  )
+    return;
+  void client
+    .call("terminal.focus", { terminal_id: terminalId })
+    .catch(() => null);
+}
 
 const SYSTEM_CLIPBOARD = "c" as ClipboardSelectionType;
 
@@ -612,7 +629,12 @@ export function TerminalView({
     if (shouldAvoidVirtualKeyboard()) return;
     requestAnimationFrame(() => {
       window.setTimeout(() => {
-        if (!connectionClient.isCurrent() || composerOpenRef.current) return;
+        if (
+          !connectionClient.isCurrent() ||
+          !isActivePaneRef.current ||
+          composerOpenRef.current
+        )
+          return;
         const term = termRef.current;
         const active = document.activeElement;
         const activeElement = active instanceof HTMLElement ? active : null;
@@ -626,6 +648,19 @@ export function TerminalView({
       }, 0);
     });
   }, [connectionClient]);
+  const focusEndpoint = useCallback(() => {
+    focusTerminalEndpoint(connectionClient, paneTerminalIdRef.current);
+  }, [connectionClient]);
+  useEffect(() => {
+    if (isActivePane) focusEndpoint();
+  }, [focusEndpoint, isActivePane, pane?.terminal_id]);
+  useEffect(() => {
+    if (!container) return;
+    // Clicking the already-selected pane must also reclaim its cursor after
+    // another client has changed the shared same-tab focus.
+    container.addEventListener("pointerdown", focusEndpoint);
+    return () => container.removeEventListener("pointerdown", focusEndpoint);
+  }, [container, focusEndpoint]);
   // Fits the xterm to its container, unless the container is hidden or
   // unmounted (e.g. the diff/files view covers it with display:none). Fitting
   // a hidden container would collapse the terminal to a 2x1 minimum and leak a
@@ -2177,6 +2212,16 @@ export function TerminalView({
           if (attachingRef.current === terminalId) attachingRef.current = null;
           if (desiredTerminalRef.current === terminalId) {
             attachedRef.current = terminalId;
+            // Attaching a split focuses it in Herdr, even in the background.
+            // Restore the current selection after each completed attach; use
+            // current state so a late response cannot revive an old selection.
+            const current = store.get();
+            const selectedPaneId = activePaneIdForSnapshot(current);
+            focusTerminalEndpoint(
+              connectionClient,
+              current.panes.find((p) => p.pane_id === selectedPaneId)
+                ?.terminal_id,
+            );
             focusTerminalSoon();
             // Resizes observed while the attach was in flight are dropped by
             // the sync's send guard; push the settled size now (deduped).


### PR DESCRIPTION
With Herdr 0.9.0 split terminals, selecting pane 1 can focus its browser input and accept typing while the cursor remains assigned to pane 2. Incremental surface patches can also discard unchanged pane metadata or leave a stale cursor after a hide transition. This fixes both paths so the selected terminal receives the cursor and subsequent repaints preserve its state.

### Changes

- Send terminal selection and terminal clicks through the attached shell's `pane.focus` endpoint. Restore the current selection after each split finishes attaching, including delayed background attachments.
- Serialize focus requests across a browser's endpoint sessions, discard superseded queued selections, and recheck attachment ownership and connection validity before dispatch.
- Merge changed pane metadata into the existing surface, preserve unchanged panes, and apply every cursor update, including `null`. Reject patches referring to unknown panes until a complete surface arrives.
- Recheck the selected pane before delayed browser input focus, preventing an old callback from focusing an inactive split.

Same-tab native pane focus remains shared with other Herdr clients. Explicit selection or clicking an already-selected terminal reclaims its cursor; routine snapshots and streaming frames do not repeatedly claim focus. Application-requested cursor hiding is preserved.

### Reproduction and verification

1. Open a tab with two terminal panes using Herdr 0.9.0 endpoints.
2. Click pane 1, pane 2, then pane 1 again. Before the fix, pane 1 accepts input without a cursor while pane 2 retains the cursor.
3. After the fix, the selected pane owns the native cursor and displays a blinking cursor while typing.

Verified against a separate real Herdr 0.9.0 instance with Chromium, including visible blink animation, keyboard pane navigation, typing, rapid switching, reloads, reconnects, and clicking the already-selected pane after another client changes focus. Idle snapshots produced no additional focus requests.

- `bun run precommit`: **1,289 passed**, one optional live OpenSSH test skipped; formatting, lint, type checks, and the production frontend build passed.
- Regression coverage includes cursor-only patches, patches for another split, explicit cursor hiding, attachment ownership, stale connections, and delayed or superseded focus requests.
- The integrated fork also passed its full suite: **1,312 passed**, one optional live OpenSSH test skipped.
