### PR TITLE
Center README logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Roamgate
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="./site/assets/roamgate-lockup-on-charcoal.png" />
-  <img src="./site/assets/roamgate-lockup-charcoal.png" alt="Roamgate logo" width="400" />
-</picture>
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="./site/assets/roamgate-lockup-on-charcoal.png" />
+    <img src="./site/assets/roamgate-lockup-charcoal.png" alt="Roamgate logo" width="400" />
+  </picture>
+</p>
 
 An independent, community-built **web and PWA client** for
 [Herdr](https://herdr.dev). Access terminals, inspect agent sessions, and review


### PR DESCRIPTION
## Summary

- Center the README logo with a GitHub-compatible `<p align="center">` wrapper.
- Preserve the existing 400px image width, alternative text, and light/dark artwork selection.
- Change only `README.md`; no application previewer, artwork, installer, or release changes.

## Verification

- `bun run precommit` passed (formatting, lint, type checks, and unit tests).
- `git diff --check -- README.md` passed.
- GitHub's Markdown API retained the centered wrapper, `<picture>`, dark-mode `<source>`, and image attributes.
- Local Chromium rendering at a 1200px viewport confirmed horizontal centering and successful loading of the correct artwork under both light and dark color schemes.
