### PR TITLE
Render Mobile Layout menu item as a compact row

### DIFF
--- a/web/src/components/ConfigMenu.tsx
+++ b/web/src/components/ConfigMenu.tsx
@@ -385,6 +385,7 @@ export function ConfigMenu({
               <ConfigMenuItem
                 icon={<Smartphone size={15} />}
                 label="Mobile Layout"
+                className="config-menu-item-row"
                 description="Display mode, breakpoint, and sidebar order"
                 onClick={() => {
                   setOpen(false);


### PR DESCRIPTION
## Summary

The **Mobile Layout** item in Menu → Appearance rendered as a full-width tile while the sibling **Terminal theme** item uses the compact row style. Add the missing `config-menu-item-row` class so both match.

## Verification

- `bun run typecheck` — pass
- `bun run test` — 1465 pass, 0 fail
- `bun run lint` — fails on main too: stale `.delta/worktrees` copies break ts-eslint `tsconfigRootDir` resolution; unrelated to this change