### PR TITLE
Release 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.7.1 - 2026-09-13
+
 - Use Roamgate service, plugin and data names while keeping existing managed
   services controllable after a 0.7.0 update. Stop/uninstall the previous service
   and unlink `herdr.studio` before switching identities; missing data and browser

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "roamgate"
 name = "Roamgate"
-version = "0.7.0"
+version = "0.7.1"
 min_herdr_version = "0.7.2"
 description = "Web and PWA client for Herdr: workspaces, tabs, panes, agent status, session inspection, diffs, and review annotations"
 platforms = ["linux", "macos", "windows"]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roamgate",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Roamgate: an independent community Web and PWA client for Herdr.",
   "license": "MIT",
   "author": "Arthur",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roamgate-server",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roamgate-web",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepare v0.7.1 by updating the three package versions and plugin manifest, and finalizing the CHANGELOG section.

This PR resumes Prepare Release run 34749519057 using its existing commit 64e9ed6d67591f55944351e027c53d7ec4069d91. Release-file validation passed; the first attempt pushed the branch but GitHub failed to create the PR. No branch history was rewritten.

## Verification and publication

- Prepare Release validation passed; CI is being explicitly dispatched on release/v0.7.1.
- Review and merge this PR after CI passes, then run Publish Release for 0.7.1 separately.
- This recovery does not merge, tag, or publish a release.